### PR TITLE
Taxonomy API - Add GET /api/taxonomy endpoint and client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A ⚠️☠️🚨 **vibe-coded**, authored by Claude, and minimally reviewed �
 - **Barcode Scanner Integration**: Keyboard wedge barcode scanner support across all workflows
 - **Advanced Search & Filtering**: Range queries, compound filters, CSV export, and URL bookmarking
 - **Item History API**: RESTful endpoints for accessing complete item modification history
-- **REST API for Item Creation and Autocomplete**: JSON endpoints for creating items and querying autocomplete suggestions for free-form fields (thread size, purchase location, vendor, location, sub-location), plus a standalone Python client (`app/api_client.py`) with only `requests` as a dependency
+- **REST API for Item Creation and Autocomplete**: JSON endpoints for creating items, querying autocomplete suggestions for free-form fields (thread size, purchase location, vendor, location, sub-location), and retrieving the hierarchical materials taxonomy, plus a standalone Python client (`app/api_client.py`) with only `requests` as a dependency
 - **Thread System Management**: Standardized thread formats with semantic validation
 - **Professional UI/UX**: Bootstrap 5.3.2 responsive interface with 15+ keyboard shortcuts
 - **Performance Optimization**: Caching, batch operations, and monitoring capabilities

--- a/app/api_client.py
+++ b/app/api_client.py
@@ -24,6 +24,7 @@ __all__ = [
     'CreateItemResult',
     'FieldSuggestionsResult',
     'SUGGESTABLE_FIELDS',
+    'TaxonomyResult',
     'UploadPhotoResult',
     'WorkshopInventoryClient',
 ]
@@ -64,6 +65,17 @@ class FieldSuggestionsResult:
     success: bool
     field: str
     suggestions: list[str]
+    errors: list[dict[str, Any]]
+    http_status: int
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TaxonomyResult:
+    """Outcome of a ``get_taxonomy`` call."""
+
+    success: bool
+    taxonomy: list[dict[str, Any]]
     errors: list[dict[str, Any]]
     http_status: int
     raw: dict[str, Any]
@@ -328,6 +340,84 @@ class WorkshopInventoryClient:
             success=success,
             field=str(body.get('field') or field),
             suggestions=suggestions,
+            errors=errors,
+            http_status=response.status_code,
+            raw=body,
+        )
+
+    def get_taxonomy(
+        self,
+        *,
+        include_inactive: bool = False,
+    ) -> TaxonomyResult:
+        """Fetch the full hierarchical materials taxonomy.
+
+        Calls ``GET /api/taxonomy`` and returns the nested taxonomy
+        tree: a list of category nodes, each with a ``children`` list of
+        family nodes, each with a ``children`` list of material nodes.
+
+        **Arguments**
+
+        - ``include_inactive`` (bool, default ``False``): when ``True``,
+          inactive taxonomy entries are included in the tree.
+
+        **Returned ``TaxonomyResult``**
+
+        - ``success`` (bool): ``True`` only on a 2xx response with
+          ``"success": true`` in the body. Any HTTP 4xx/5xx forces
+          ``False`` regardless of body content.
+        - ``taxonomy`` (list[dict]): the nested taxonomy tree. Each node
+          carries ``id``, ``name``, ``level`` (1=Category, 2=Family,
+          3=Material), ``active``, ``notes``, and ``sort_order``.
+          Family and material nodes also carry ``parent``; material
+          nodes also carry ``aliases``. Category and family nodes carry
+          a ``children`` list. Empty list on failure.
+        - ``errors`` (list[dict]): single-entry list on failure of the
+          shape ``{"index": 0, "ja_id": None, "message": "..."}``.
+          Empty on success.
+        - ``http_status`` (int): the raw HTTP status code.
+        - ``raw`` (dict): the parsed JSON response body.
+
+        **Network errors**
+
+        Network failures (connection refused, DNS, TLS, timeout)
+        propagate as ``requests.RequestException`` subclasses. HTTP
+        errors land as ``success=False`` rather than raising.
+        """
+        params: dict[str, Any] = {}
+        if include_inactive:
+            params['include_inactive'] = 'true'
+
+        response = self.session.get(
+            f'{self.base_url}/api/taxonomy',
+            params=params,
+            timeout=self.timeout,
+        )
+        body = self._safe_json(response)
+
+        if response.status_code >= 400:
+            success = False
+        else:
+            success = bool(body.get('success', False))
+
+        taxonomy: list[dict[str, Any]] = []
+        if success:
+            raw_taxonomy = body.get('taxonomy') or []
+            if isinstance(raw_taxonomy, list):
+                taxonomy = [node for node in raw_taxonomy if isinstance(node, dict)]
+
+        errors: list[dict[str, Any]] = []
+        if not success:
+            err_msg = (
+                body.get('error')
+                or body.get('message')
+                or f'HTTP {response.status_code}'
+            )
+            errors = [{'index': 0, 'ja_id': None, 'message': err_msg}]
+
+        return TaxonomyResult(
+            success=success,
+            taxonomy=taxonomy,
             errors=errors,
             http_status=response.status_code,
             raw=body,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1197,7 +1197,7 @@ def inventory_field_suggestions(field):
     })
 
 
-def _normalize_taxonomy_aliases(nodes):
+def _normalize_taxonomy_aliases(nodes: list[dict[str, Any]]) -> None:
     """Recursively convert each node's ``aliases`` into a list.
 
     ``get_taxonomy_overview`` passes the raw ``MaterialTaxonomy.aliases``
@@ -1209,7 +1209,9 @@ def _normalize_taxonomy_aliases(nodes):
         aliases = node.get('aliases')
         if isinstance(aliases, str):
             node['aliases'] = [a.strip() for a in aliases.split(',') if a.strip()]
-        _normalize_taxonomy_aliases(node.get('children', []))
+        children = node.get('children')
+        if isinstance(children, list):
+            _normalize_taxonomy_aliases(children)
 
 
 @bp.route('/api/taxonomy')
@@ -1248,7 +1250,9 @@ def api_taxonomy():
         })
 
     except Exception as e:
-        current_app.logger.error(f'Error getting materials taxonomy: {e}')
+        current_app.logger.error(
+            f'Error getting materials taxonomy: {e}\n{traceback.format_exc()}'
+        )
         return jsonify({
             'success': False,
             'error': 'Failed to get materials taxonomy'

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1197,9 +1197,73 @@ def inventory_field_suggestions(field):
     })
 
 
+def _normalize_taxonomy_aliases(nodes):
+    """Recursively convert each node's ``aliases`` into a list.
+
+    ``get_taxonomy_overview`` passes the raw ``MaterialTaxonomy.aliases``
+    column through, which is a comma-separated string (or an empty list
+    when null). Mutates ``nodes`` in place so the public API returns
+    consistently list-typed aliases.
+    """
+    for node in nodes:
+        aliases = node.get('aliases')
+        if isinstance(aliases, str):
+            node['aliases'] = [a.strip() for a in aliases.split(',') if a.strip()]
+        _normalize_taxonomy_aliases(node.get('children', []))
+
+
+@bp.route('/api/taxonomy')
+def api_taxonomy():
+    """Return the full hierarchical materials taxonomy.
+
+    Reuses the canonical tree builder
+    (``MariaDBMaterialsAdminService.get_taxonomy_overview``) that powers
+    the admin interface, so callers get the same nested structure:
+    categories -> ``children`` (families) -> ``children`` (materials),
+    each node carrying ``id``, ``name``, ``level``, ``active``,
+    ``notes``, ``sort_order`` (plus ``parent`` on families/materials and
+    ``aliases`` on materials).
+
+    Query parameters:
+      * ``include_inactive`` (``true``/``false``, default ``false``):
+        when true, inactive taxonomy entries are included.
+    """
+    try:
+        from app.mariadb_materials_admin_service import MariaDBMaterialsAdminService
+
+        include_inactive = request.args.get('include_inactive', 'false').lower() == 'true'
+
+        admin_service = MariaDBMaterialsAdminService(_get_storage_backend())
+        taxonomy = admin_service.get_taxonomy_overview(include_inactive=include_inactive)
+
+        # Normalize `aliases` into a proper list. The admin service
+        # passes the raw MaterialTaxonomy.aliases column through, which
+        # is a comma-separated string (or an empty list when null); for
+        # this public API we want consistent list-typed aliases.
+        _normalize_taxonomy_aliases(taxonomy)
+
+        return jsonify({
+            'success': True,
+            'taxonomy': taxonomy,
+        })
+
+    except Exception as e:
+        current_app.logger.error(f'Error getting materials taxonomy: {e}')
+        return jsonify({
+            'success': False,
+            'error': 'Failed to get materials taxonomy'
+        }), 500
+
+
 @bp.route('/api/materials/hierarchy')
 def materials_hierarchy():
-    """Get hierarchical materials taxonomy (for testing)"""
+    """Get hierarchical materials taxonomy.
+
+    Powers the material-selector autocomplete UI
+    (``app/static/js/material-selector.js``); its response shape is
+    tailored to that frontend. Programmatic clients should prefer the
+    general-purpose ``GET /api/taxonomy`` endpoint instead.
+    """
     try:
         from app.database import MaterialTaxonomy
         from app.mariadb_storage import MariaDBStorage

--- a/docs/development-testing-guide.md
+++ b/docs/development-testing-guide.md
@@ -432,10 +432,10 @@ constraint in mind:
 - Do not import anything from the rest of the `app` package or from
   the application's models. Stay on stdlib + `requests`.
 - Public surface (`WorkshopInventoryClient`, `CreateItemResult`,
-  `UploadPhotoResult`, `FieldSuggestionsResult`, `SUGGESTABLE_FIELDS`)
-  is exported via `__all__`. Treat it as the contract — adding fields
-  to the result dataclasses is fine, but renaming or removing them is
-  a breaking change for any vendored copy.
+  `UploadPhotoResult`, `FieldSuggestionsResult`, `TaxonomyResult`,
+  `SUGGESTABLE_FIELDS`) is exported via `__all__`. Treat it as the
+  contract — adding fields to the result dataclasses is fine, but
+  renaming or removing them is a breaking change for any vendored copy.
 - Unit tests live in `tests/unit/test_api_client.py` and mock
   `requests.Session` directly so they run offline. End-to-end tests
   in `tests/e2e/test_api_client.py` exercise the client against the

--- a/docs/features/complete/taxonomy_api.md
+++ b/docs/features/complete/taxonomy_api.md
@@ -45,7 +45,7 @@ An API endpoint should be added, if not already present, to return the hierarchi
 
 ### Progress
 
-**Status: Implementation complete; all tests passing.** (Milestone `Taxonomy API - 1`)
+**Status: Complete and human-verified.** (Milestone `Taxonomy API - 1`)
 
 - ✅ Task 1 — Added `GET /api/taxonomy` (`app/main/routes.py`) reusing `MariaDBMaterialsAdminService.get_taxonomy_overview()`, with optional `include_inactive` query param and a `_normalize_taxonomy_aliases()` pass that converts the raw comma-separated `aliases` column into a proper list. Corrected the stale `(for testing)` docstring on `materials_hierarchy()`.
 - ✅ Task 2 — Added `TaxonomyResult` dataclass and `WorkshopInventoryClient.get_taxonomy(include_inactive=False)` to `app/api_client.py`; exported `TaxonomyResult` in `__all__`.

--- a/docs/features/taxonomy_api.md
+++ b/docs/features/taxonomy_api.md
@@ -5,3 +5,59 @@
 ## Requirements
 
 An API endpoint should be added, if not already present, to return the hierarchical materials taxonomy. Then add support for retrieving this taxonomy in `app/api_client.py` and document the API endpoint in the "REST API" section of the user guide. Add/update tests as applicable.
+
+## Implementation Plan
+
+### Background / findings
+
+- The hierarchical materials taxonomy is stored in the `material_taxonomy` table, modeled by `MaterialTaxonomy` (`app/database.py:615`). It is a single self-referential table with a 3-level scheme: `level` 1 = Category, 2 = Family, 3 = Material; `parent` holds the parent row's `name` (categories have `parent = NULL`).
+- The canonical tree builder is `MariaDBMaterialsAdminService.get_taxonomy_overview(include_inactive=False)` (`app/mariadb_materials_admin_service.py:52`), which the admin UI uses. It returns a nested list of category → `children` (families) → `children` (materials), each node carrying `id, name, level, active, notes, sort_order` (plus `parent` on families/materials and `aliases` on materials).
+- An existing endpoint `GET /api/materials/hierarchy` (`app/main/routes.py:1200`) also returns a tree, but: (a) its docstring says "(for testing)" which is **inaccurate** — it is production code consumed by the material-selector autocomplete (`app/static/js/material-selector.js:96`); (b) it reimplements tree-building inline; (c) its shape is frontend-tailored (`hierarchy`/`families`/`materials` + a `summary` block) and omits `id`/`active`/`aliases`/`parent`/`sort_order`; (d) it has **no test coverage**.
+- Decision (approved): add a clean, general-purpose public endpoint rather than blessing the frontend-tailored shape. Leave `/api/materials/hierarchy` behavior untouched (the frontend depends on it) but correct its misleading docstring.
+
+### Scope (single Milestone — prefix `Taxonomy API`)
+
+**Task 1 — New endpoint `GET /api/taxonomy`** (`app/main/routes.py`)
+- Add `@bp.route('/api/taxonomy')` returning the canonical tree via `MariaDBMaterialsAdminService(_get_storage_backend()).get_taxonomy_overview(...)` (same service/storage pattern as `app/admin/routes.py`).
+- Optional query param `include_inactive` (`true`/`false`, default `false`), matching the service's capability.
+- Response envelope follows the established convention: `{"success": true, "taxonomy": [...]}` on success; `{"success": false, "error": "..."}` with HTTP 500 on failure.
+- Fix the stale `"""...(for testing)"""` docstring on the existing `materials_hierarchy()` route to accurately state it powers the material-selector UI.
+
+**Task 2 — Client support** (`app/api_client.py`)
+- Add a frozen `TaxonomyResult` dataclass (`success`, `taxonomy: list`, `errors`, `http_status`, `raw`) mirroring the existing result dataclasses.
+- Add `WorkshopInventoryClient.get_taxonomy(*, include_inactive=False) -> TaxonomyResult`, calling `GET /api/taxonomy`, following the existing HTTP-error-never-raises / network-error-raises contract and error-shaping used by the other methods.
+- Export `TaxonomyResult` in `__all__`.
+
+**Task 3 — Documentation** (`docs/user-manual.md`)
+- Add a `GET /api/taxonomy` subsection under "REST API" documenting the query param, response shape (with a nested example), node fields, and status codes.
+- Update the "Python client" subsection to mention `get_taxonomy(...)` / `TaxonomyResult`.
+
+**Task 4 — Tests**
+- Unit tests in `tests/unit/test_api_client.py`: success, `include_inactive` param propagation, HTTP-error → `success=False`, non-JSON/non-dict handling (mirroring existing patterns).
+- E2E tests in `tests/e2e/test_api_client.py` (and/or a route test): hit the live endpoint, assert the nested structure and envelope, and exercise the client's `get_taxonomy()` against the running server.
+
+### Completion steps (per features README)
+
+1. Run the full unit suite and the full e2e suite via `nox` (e2e with a ≥15-minute Bash timeout) and ensure **all** tests pass.
+2. Update any other affected docs (`README.md`, deployment/testing/troubleshooting guides) if applicable.
+3. Update this feature document with progress.
+4. Commit on a feature branch with the `Taxonomy API - 1.x` prefix; open a PR when complete.
+
+### Progress
+
+**Status: Implementation complete; all tests passing.** (Milestone `Taxonomy API - 1`)
+
+- ✅ Task 1 — Added `GET /api/taxonomy` (`app/main/routes.py`) reusing `MariaDBMaterialsAdminService.get_taxonomy_overview()`, with optional `include_inactive` query param and a `_normalize_taxonomy_aliases()` pass that converts the raw comma-separated `aliases` column into a proper list. Corrected the stale `(for testing)` docstring on `materials_hierarchy()`.
+- ✅ Task 2 — Added `TaxonomyResult` dataclass and `WorkshopInventoryClient.get_taxonomy(include_inactive=False)` to `app/api_client.py`; exported `TaxonomyResult` in `__all__`.
+- ✅ Task 3 — Documented `GET /api/taxonomy` in `docs/user-manual.md` (REST API section + Python client example/summary). Also updated `README.md` feature blurb and `docs/development-testing-guide.md` public-surface list.
+- ✅ Task 4 — Added unit tests (`TestGetTaxonomy` in `tests/unit/test_api_client.py`) and e2e tests (`TestApiClientTaxonomy` in `tests/e2e/test_api_client.py`).
+- ✅ Full unit suite: 350 passed.
+- ✅ Full e2e suite: 304 passed, 1 skipped (ran to completion in ~19 min).
+
+### Implementation note
+
+`aliases` normalization: `get_taxonomy_overview()` (shared with the admin UI) emits the raw `MaterialTaxonomy.aliases` string. Rather than change that shared method (and risk the admin UI), the new endpoint normalizes aliases to a list locally, so the public API contract is consistently list-typed.
+
+### Open questions
+
+None currently.

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1180,12 +1180,90 @@ Returns sub-locations currently recorded under Location "Shelf A":
 }
 ```
 
+### `GET /api/taxonomy`
+
+Return the full hierarchical materials taxonomy as a nested tree. This
+is the general-purpose endpoint for programmatic clients that need the
+materials taxonomy (the material names and aliases accepted by the
+`material` field on `POST /api/inventory/items`).
+
+The taxonomy has three levels: **Category** (level 1) → **Family**
+(level 2) → **Material** (level 3). Each level's nodes are returned
+under the `children` key of their parent.
+
+#### Query parameters
+
+| Parameter          | Type    | Description |
+|--------------------|---------|-------------|
+| `include_inactive` | boolean | When `true`, inactive taxonomy entries are included. Defaults to `false` (active entries only). |
+
+#### Response
+
+```json
+{
+  "success": true,
+  "taxonomy": [
+    {
+      "id": 1,
+      "name": "Steel",
+      "level": 1,
+      "active": true,
+      "notes": "",
+      "sort_order": 0,
+      "children": [
+        {
+          "id": 5,
+          "name": "Alloy Steel",
+          "level": 2,
+          "parent": "Steel",
+          "active": true,
+          "notes": "",
+          "sort_order": 0,
+          "children": [
+            {
+              "id": 9,
+              "name": "4140",
+              "level": 3,
+              "parent": "Alloy Steel",
+              "active": true,
+              "aliases": ["41400"],
+              "notes": "",
+              "sort_order": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Node fields:
+
+| Field        | Levels        | Description |
+|--------------|---------------|-------------|
+| `id`         | all           | Database id of the taxonomy entry. |
+| `name`       | all           | The taxonomy name (used as the parent reference of child nodes). |
+| `level`      | all           | `1` = Category, `2` = Family, `3` = Material. |
+| `active`     | all           | Whether the entry is active. |
+| `notes`      | all           | Free-form notes (empty string if none). |
+| `sort_order` | all           | Ordering hint within the parent. |
+| `children`   | 1, 2          | List of child nodes (families under a category, materials under a family). |
+| `parent`     | 2, 3          | `name` of the parent node. |
+| `aliases`    | 3             | List of alias names for the material. |
+
+#### Status codes
+
+- `200 OK` — taxonomy returned (possibly an empty list when the
+  taxonomy is unconfigured).
+- `500 Internal Server Error` — unexpected backend failure.
+
 ### Python client
 
 A standalone Python client lives at `app/api_client.py`. It depends
 only on the `requests` library and exposes a `WorkshopInventoryClient`
-class with `create_item(...)`, `upload_photo(...)`, and
-`get_field_suggestions(...)` methods. The client can be copied or
+class with `create_item(...)`, `upload_photo(...)`,
+`get_field_suggestions(...)`, and `get_taxonomy(...)` methods. The client can be copied or
 vendored into other projects without pulling in any of the
 application's runtime dependencies.
 
@@ -1217,12 +1295,18 @@ subs = client.get_field_suggestions(
     "sub_location", location="Shelf A", limit=20
 )
 print(subs.suggestions)
+
+# Full materials taxonomy tree:
+taxonomy = client.get_taxonomy()
+for category in taxonomy.taxonomy:
+    print(category["name"], "->", [f["name"] for f in category["children"]])
 ```
 
-`create_item`, `upload_photo`, and `get_field_suggestions` return
-frozen dataclasses (`CreateItemResult`, `UploadPhotoResult`,
-`FieldSuggestionsResult`) carrying the parsed response. Network errors
-raise `requests.RequestException`; HTTP errors (4xx/5xx) populate the
+`create_item`, `upload_photo`, `get_field_suggestions`, and
+`get_taxonomy` return frozen dataclasses (`CreateItemResult`,
+`UploadPhotoResult`, `FieldSuggestionsResult`, `TaxonomyResult`)
+carrying the parsed response. Network errors raise
+`requests.RequestException`; HTTP errors (4xx/5xx) populate the
 result's `errors` list and set `success=False` rather than raising.
 
 The constant `SUGGESTABLE_FIELDS` (a tuple of the five whitelisted

--- a/tests/e2e/test_api_client.py
+++ b/tests/e2e/test_api_client.py
@@ -214,14 +214,16 @@ class TestApiClientFieldSuggestions:
         assert any('material' in err.get('message', '') for err in result.errors)
 
 
-def _find_node(nodes, name):
+def _find_node(nodes: list[dict], name: str) -> dict | None:
     """Depth-first search for a node with the given name in a tree."""
     for node in nodes:
         if node.get('name') == name:
             return node
-        found = _find_node(node.get('children', []), name)
-        if found is not None:
-            return found
+        children = node.get('children')
+        if isinstance(children, list):
+            found = _find_node(children, name)
+            if found is not None:
+                return found
     return None
 
 

--- a/tests/e2e/test_api_client.py
+++ b/tests/e2e/test_api_client.py
@@ -214,6 +214,64 @@ class TestApiClientFieldSuggestions:
         assert any('material' in err.get('message', '') for err in result.errors)
 
 
+def _find_node(nodes, name):
+    """Depth-first search for a node with the given name in a tree."""
+    for node in nodes:
+        if node.get('name') == name:
+            return node
+        found = _find_node(node.get('children', []), name)
+        if found is not None:
+            return found
+    return None
+
+
+@pytest.mark.e2e
+class TestApiClientTaxonomy:
+    def test_get_taxonomy_round_trip(self, client, live_server):
+        result = client.get_taxonomy()
+
+        assert result.success is True, result.errors
+        assert result.http_status == 200
+        assert isinstance(result.taxonomy, list)
+        assert len(result.taxonomy) > 0
+
+        # The test server seeds Carbon Steel -> Medium Carbon Steel -> 4140.
+        category = _find_node(result.taxonomy, 'Carbon Steel')
+        assert category is not None, 'Carbon Steel category not found'
+        assert category['level'] == 1
+        assert 'children' in category
+
+        family = _find_node([category], 'Medium Carbon Steel')
+        assert family is not None
+        assert family['level'] == 2
+        assert family['parent'] == 'Carbon Steel'
+
+        material = _find_node([family], '4140')
+        assert material is not None
+        assert material['level'] == 3
+        assert material['parent'] == 'Medium Carbon Steel'
+        # Aliases are normalized to a proper list by the endpoint.
+        assert isinstance(material['aliases'], list)
+
+    def test_get_taxonomy_aliases_are_lists(self, client):
+        # '304' is seeded with aliases '304 Stainless,SS304'.
+        result = client.get_taxonomy()
+        assert result.success is True, result.errors
+
+        material = _find_node(result.taxonomy, '304')
+        assert material is not None
+        assert isinstance(material['aliases'], list)
+        assert 'SS304' in material['aliases']
+
+    def test_taxonomy_endpoint_envelope(self, client, live_server):
+        # Verify the raw HTTP envelope directly, independent of the client.
+        resp = requests.get(f'{live_server.url}/api/taxonomy', timeout=10)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body['success'] is True
+        assert isinstance(body['taxonomy'], list)
+
+
 @pytest.mark.e2e
 class TestApiClientUploadPhoto:
     def test_upload_photo_for_existing_item(self, client, live_server, sample_image_path):

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -16,9 +16,47 @@ from app.api_client import (
     CreateItemResult,
     FieldSuggestionsResult,
     SUGGESTABLE_FIELDS,
+    TaxonomyResult,
     UploadPhotoResult,
     WorkshopInventoryClient,
 )
+
+
+def _sample_taxonomy() -> list[dict]:
+    """A minimal but representative nested taxonomy tree."""
+    return [
+        {
+            'id': 1,
+            'name': 'Steel',
+            'level': 1,
+            'active': True,
+            'notes': '',
+            'sort_order': 0,
+            'children': [
+                {
+                    'id': 5,
+                    'name': 'Alloy Steel',
+                    'level': 2,
+                    'parent': 'Steel',
+                    'active': True,
+                    'notes': '',
+                    'sort_order': 0,
+                    'children': [
+                        {
+                            'id': 9,
+                            'name': '4140',
+                            'level': 3,
+                            'parent': 'Alloy Steel',
+                            'active': True,
+                            'aliases': ['41400'],
+                            'notes': '',
+                            'sort_order': 0,
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
 
 
 def _mock_response(status_code: int, json_body: dict | list | None,
@@ -465,3 +503,104 @@ class TestGetFieldSuggestions:
             url
             == 'http://example.test/api/inventory/field-suggestions/a%2Fb%3Fc'
         )
+
+
+class TestGetTaxonomy:
+    def test_success(self, client, session):
+        session.get.return_value = _mock_response(200, {
+            'success': True,
+            'taxonomy': _sample_taxonomy(),
+        })
+
+        result = client.get_taxonomy()
+
+        assert isinstance(result, TaxonomyResult)
+        assert result.success is True
+        assert result.http_status == 200
+        assert result.errors == []
+        assert len(result.taxonomy) == 1
+        category = result.taxonomy[0]
+        assert category['name'] == 'Steel'
+        assert category['level'] == 1
+        family = category['children'][0]
+        assert family['name'] == 'Alloy Steel'
+        assert family['parent'] == 'Steel'
+        material = family['children'][0]
+        assert material['name'] == '4140'
+        assert material['aliases'] == ['41400']
+
+        call_args = session.get.call_args
+        assert call_args.args[0] == 'http://example.test/api/taxonomy'
+        # include_inactive omitted by default.
+        assert call_args.kwargs['params'] == {}
+
+    def test_include_inactive_param_sent(self, client, session):
+        session.get.return_value = _mock_response(200, {
+            'success': True, 'taxonomy': [],
+        })
+
+        client.get_taxonomy(include_inactive=True)
+
+        params = session.get.call_args.kwargs['params']
+        assert params == {'include_inactive': 'true'}
+
+    def test_empty_taxonomy(self, client, session):
+        session.get.return_value = _mock_response(200, {
+            'success': True, 'taxonomy': [],
+        })
+
+        result = client.get_taxonomy()
+
+        assert result.success is True
+        assert result.taxonomy == []
+        assert result.errors == []
+
+    def test_http_error_always_reports_failure(self, client, session):
+        session.get.return_value = _mock_response(500, {
+            'success': True,
+            'taxonomy': _sample_taxonomy(),
+        })
+
+        result = client.get_taxonomy()
+
+        assert result.success is False
+        assert result.http_status == 500
+        assert result.taxonomy == []
+        assert len(result.errors) == 1
+
+    def test_server_error_body_normalized(self, client, session):
+        session.get.return_value = _mock_response(500, {
+            'success': False,
+            'error': 'Failed to get materials taxonomy',
+        })
+
+        result = client.get_taxonomy()
+
+        assert result.success is False
+        assert result.http_status == 500
+        assert result.taxonomy == []
+        assert result.errors[0]['message'] == 'Failed to get materials taxonomy'
+
+    def test_non_json_response_returns_failure(self, client, session):
+        session.get.return_value = _mock_response(502, None, text='Bad Gateway')
+
+        result = client.get_taxonomy()
+
+        assert result.success is False
+        assert result.http_status == 502
+        assert result.taxonomy == []
+
+    def test_non_list_taxonomy_coerced_to_empty(self, client, session):
+        session.get.return_value = _mock_response(200, {
+            'success': True, 'taxonomy': 'not-a-list',
+        })
+
+        result = client.get_taxonomy()
+
+        assert result.success is True
+        assert result.taxonomy == []
+
+    def test_connection_error_propagates(self, client, session):
+        session.get.side_effect = requests.ConnectionError('refused')
+        with pytest.raises(requests.ConnectionError):
+            client.get_taxonomy()


### PR DESCRIPTION
## Summary

Implements the **Taxonomy API** feature (`docs/features/taxonomy_api.md`): a general-purpose REST endpoint that returns the hierarchical materials taxonomy, with matching support in the standalone Python client and full documentation.

## Background

An existing `GET /api/materials/hierarchy` endpoint already returned a tree, but investigation showed it is **production code consumed by the material-selector autocomplete UI** (`app/static/js/material-selector.js`) — despite a stale "(for testing)" docstring — with a frontend-tailored shape (`families`/`materials` + `summary`) that omits `id`/`active`/`aliases`/`parent`/`sort_order` and has no test coverage. Rather than repurpose that frontend contract, this PR adds a clean, documented, general-purpose endpoint and leaves the existing one's behavior untouched (only fixing its misleading docstring).

## Changes

- **`app/main/routes.py`** — new `GET /api/taxonomy` route reusing the canonical `MariaDBMaterialsAdminService.get_taxonomy_overview()` (nested category → family → material `children` structure). Supports an optional `include_inactive` query param and normalizes the raw comma-separated `aliases` column into a proper list (`_normalize_taxonomy_aliases()`). Corrected the inaccurate "(for testing)" docstring on `materials_hierarchy()`.
- **`app/api_client.py`** — new frozen `TaxonomyResult` dataclass and `WorkshopInventoryClient.get_taxonomy(include_inactive=False)` method, following the existing "HTTP errors never raise, network errors do" contract; `TaxonomyResult` exported in `__all__`.
- **Docs** — `docs/user-manual.md` REST API section documents the endpoint (query param, response shape, node fields, status codes) and the Python client example; `README.md` and `docs/development-testing-guide.md` updated for accuracy.
- **Tests** — unit tests (`TestGetTaxonomy`, session mocked) and e2e tests (`TestApiClientTaxonomy`, live endpoint).

## Response shape

```json
{
  "success": true,
  "taxonomy": [
    {"id": 1, "name": "Steel", "level": 1, "active": true, "notes": "", "sort_order": 0,
     "children": [
       {"id": 5, "name": "Alloy Steel", "level": 2, "parent": "Steel", "children": [
         {"id": 9, "name": "4140", "level": 3, "parent": "Alloy Steel", "aliases": ["41400"]}]}]}]
}
```

## Design note

`get_taxonomy_overview()` is shared with the admin UI and emits the raw `aliases` string; to avoid changing that shared method (and risking the admin UI), the new endpoint normalizes aliases to a list locally so the public API is consistently list-typed.

## Testing

- Full unit suite: **350 passed**.
- Full e2e suite: **304 passed, 1 skipped** (ran to completion, ~19 min).
- New taxonomy e2e tests verified passing individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)