### PR TITLE
deps: PR 1 — low-risk dependency batch

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -38,12 +38,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2  # Need history to compare
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -54,7 +54,7 @@ jobs:
             bluetooth libbluetooth-dev
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload regenerated screenshots
         if: steps.check_diff.outputs.status == 'outdated'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: regenerated-screenshots
           path: docs/images/screenshots/
@@ -129,7 +129,7 @@ jobs:
 
       - name: Comment on PR with screenshot info
         if: github.event_name == 'pull_request' && steps.check_diff.outputs.status == 'outdated'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Set up Python 3.13
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
 
@@ -26,7 +26,7 @@ jobs:
           bluetooth libbluetooth-dev
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -41,7 +41,7 @@ jobs:
       
     - name: Upload test artifacts on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: unit-test-artifacts
         path: |
@@ -58,10 +58,10 @@ jobs:
       issues: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Set up Python 3.13
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
 
@@ -72,7 +72,7 @@ jobs:
           bluetooth libbluetooth-dev
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -86,7 +86,7 @@ jobs:
       run: nox -s coverage
     
     - name: Upload coverage reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-reports
         path: |
@@ -130,7 +130,7 @@ jobs:
     
     - name: Comment PR with coverage
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');
@@ -188,15 +188,15 @@ jobs:
           --health-retries=3
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Set up Python 3.13
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
     
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -244,7 +244,7 @@ jobs:
     
     - name: Upload E2E artifacts on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: e2e-test-artifacts
         path: |
@@ -258,7 +258,7 @@ jobs:
     
     - name: Upload E2E test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: e2e-results
         path: |
@@ -273,7 +273,7 @@ jobs:
     
     steps:
     - name: Test Summary
-      uses: actions/github-script@v6
+      uses: actions/github-script@v9
       with:
         script: |
           const unitStatus = '${{ needs.unit-tests.result }}';

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,9 +1,9 @@
 # Testing Requirements
 pytest==8.4.2
 pytest-flask==1.3.0
-pytest-mock==3.15.0
-pytest-cov==7.0.0
-pytest-rerunfailures==16.0.1
+pytest-mock==3.15.1
+pytest-cov==7.1.0
+pytest-rerunfailures==16.4
 nox
 pytest-blockage==0.2.4
 
@@ -13,6 +13,4 @@ pytest-playwright==0.7.1
 testcontainers[mysql]==4.8.2
 
 # Additional test utilities
-factory-boy==3.3.3
-faker==37.8.0
-PyYAML==6.0.2
+PyYAML==6.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
-Flask==3.0.0
-python-dotenv==1.0.0
-google-auth==2.25.2
-google-auth-oauthlib==1.2.0
-google-auth-httplib2==0.2.0
-google-api-python-client==2.110.0
-Werkzeug==3.0.1
-Flask-WTF==1.2.1
-PyMySQL==1.1.0
+Flask==3.1.3
+python-dotenv==1.2.2
+google-auth==2.56.0
+google-auth-oauthlib==1.4.0
+google-auth-httplib2==0.4.0
+google-api-python-client==2.198.0
+Werkzeug==3.1.8
+Flask-WTF==1.3.0
+PyMySQL==1.2.0
 SQLAlchemy==1.4.53
 alembic==1.13.1
-click==8.1.7
+click==8.4.2
 pt-p710bt-label-maker @ git+https://github.com/jantman/pt-p710bt-label-maker.git@jantman
 Pillow>=11.0.0
 PyMuPDF==1.24.9


### PR DESCRIPTION
Batch 1 of the staged dependency-upgrade plan (#33). Low-risk bumps validated by the unit suite — **350 passed**, no new failures (remaining warnings are all pre-existing: SQLAlchemy Decimal/sqlite and `datetime.utcnow()` deprecations).

### Runtime (`requirements.txt`)
- **Flask stack (moved together):** Flask 3.0.0 → 3.1.3, Werkzeug 3.0.1 → 3.1.8, Flask-WTF 1.2.1 → 1.3.0 (Flask 3.1 requires Werkzeug ≥3.1)
- python-dotenv 1.0.0 → 1.2.2, click 8.1.7 → 8.4.2, PyMySQL 1.1.0 → 1.2.0
- Google cluster: google-auth 2.25.2 → 2.56.0, google-auth-oauthlib 1.2.0 → 1.4.0, google-auth-httplib2 0.2.0 → 0.4.0, google-api-python-client 2.110.0 → 2.198.0

### Test (`requirements-test.txt`)
- pytest-mock 3.15.0 → 3.15.1, pytest-cov 7.0.0 → 7.1.0, pytest-rerunfailures 16.0.1 → 16.4, PyYAML 6.0.2 → 6.0.3
- Removed unused `factory-boy` and `faker` (not imported anywhere in `tests/` or `app/`)

### CI (`.github/workflows/*`)
- actions/checkout v4 → v7, actions/setup-python v4 → v6, actions/cache v3 → v6, actions/upload-artifact v4 → v7, actions/github-script v6 → v9

### Deferred to later PRs (per plan)
SQLAlchemy, alembic, Pillow, PyMuPDF, pytest, and the playwright/pytest-playwright/testcontainers E2E stack are intentionally **not** touched here.

Part of #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)