### PR TITLE
deps: PR 2 — SQLAlchemy 1.4 → 2.0 + alembic 1.18

### DIFF
--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -18,15 +18,15 @@ _This file contains critical rules and patterns that AI agents must follow when 
 ## Technology Stack & Versions
 
 - **Language:** Python 3.13 (`nox` sessions pin `3.13`)
-- **Web framework:** Flask 3.0.0 + Werkzeug 3.0.1; app-factory pattern (`create_app()` in `app/__init__.py`)
-- **ORM:** SQLAlchemy **1.4.53** — NOT 2.x. Use 1.4 idioms (legacy `Query` API, `db.session.query(...)`). Do not write 2.0-style `select()` / `session.execute()` unless matching existing code.
-- **Migrations:** Alembic 1.13.1, driven through `manage.py db ...` (NOT Flask-Migrate)
-- **Database:** MariaDB/MySQL via PyMySQL 1.1.0 (primary). Google Sheets API (google-api-python-client 2.110.0) is **export-only / legacy**, not primary storage.
-- **Forms/CSRF:** Flask-WTF 1.2.1 (CSRF enabled in prod, disabled in tests)
+- **Web framework:** Flask 3.1.3 + Werkzeug 3.1.8; app-factory pattern (`create_app()` in `app/__init__.py`)
+- **ORM:** SQLAlchemy **2.0.51** (migrated from 1.4 in July 2026). The codebase uses the **legacy `Query` API** (`session.query(...)`), which remains fully supported in 2.0 — match the surrounding file's style. Writing 2.0-style `select()` / `session.execute()` is allowed for new code but prefer consistency with the existing service. Raw SQL strings passed to `.execute()` **must** be wrapped in `sqlalchemy.text(...)`.
+- **Migrations:** Alembic 1.18.5, driven through `manage.py db ...` (NOT Flask-Migrate)
+- **Database:** MariaDB/MySQL via PyMySQL 1.2.0 (primary). Google Sheets API (google-api-python-client 2.198.0) is **export-only / legacy**, not primary storage.
+- **Forms/CSRF:** Flask-WTF 1.3.0 (CSRF enabled in prod, disabled in tests)
 - **Frontend:** Server-rendered Jinja2 + Bootstrap 5.3.2 (`app/templates`, `app/static`)
-- **Testing:** nox + pytest 8.4.2, pytest-flask, Playwright 1.55.0 (e2e), testcontainers[mysql] 4.8.2 (integration), factory-boy/faker
+- **Testing:** nox + pytest 8.4.2, pytest-flask, Playwright 1.55.0 (e2e), testcontainers[mysql] 4.8.2 (integration)
 - **Other:** PyMuPDF (PDF), Pillow (images), pt-p710bt-label-maker (Brother label printing via git dependency)
-- **Config:** python-dotenv 1.0.0 — settings loaded from `.env`; `SQLALCHEMY_DATABASE_URI` read directly
+- **Config:** python-dotenv 1.2.2 — settings loaded from `.env`; `SQLALCHEMY_DATABASE_URI` read directly
 
 ## Critical Implementation Rules
 
@@ -74,7 +74,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 
 ### Critical Don't-Miss Rules
 
-- **Don't write SQLAlchemy 2.0 style** — this is 1.4.53. Use `session.query(...)`, not `session.execute(select(...))`, unless the file already does.
+- **Prefer the legacy `Query` API for consistency** — the codebase runs on SQLAlchemy 2.0.51 but overwhelmingly uses `session.query(...)`. Match the surrounding file; don't refactor working `query()` code to `select()` gratuitously. Always wrap raw SQL strings in `sqlalchemy.text(...)`.
 - **Don't bypass the `Storage`/service layers** by putting raw SQL or ORM queries in routes — go through `MariaDBStorage` + the `*_service.py` layer.
 - **Don't use `float` for measurements** — `Decimal` only (see item dimensions / `ROUND_HALF_UP`).
 - **Don't treat Google Sheets as live storage** — it's export/legacy only; MariaDB is the source of truth.
@@ -97,4 +97,4 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - Update when the technology stack or storage/service patterns change.
 - Review periodically and remove rules that become obvious over time.
 
-Last Updated: 2026-07-18
+Last Updated: 2026-07-19

--- a/app/database.py
+++ b/app/database.py
@@ -9,9 +9,8 @@ with proper constraints to ensure data integrity.
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, Text, UniqueConstraint, CheckConstraint, LargeBinary, ForeignKey, Index
 from sqlalchemy.sql.sqltypes import Numeric
 from sqlalchemy.dialects.mysql import MEDIUMBLOB
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 from sqlalchemy.sql import func
 from datetime import datetime
 from typing import Optional, List, Dict, Any

--- a/manage.py
+++ b/manage.py
@@ -514,13 +514,13 @@ def config_check():
 
     # Test database connection
     try:
-        from sqlalchemy import create_engine
+        from sqlalchemy import create_engine, text
         database_url = os.environ.get('SQLALCHEMY_DATABASE_URI') or AppConfig.SQLALCHEMY_DATABASE_URI
         engine = create_engine(database_url)
 
         # Test connection
         with engine.connect() as conn:
-            conn.execute("SELECT 1")
+            conn.execute(text("SELECT 1"))
         click.echo("Database connection: OK")
 
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ google-api-python-client==2.198.0
 Werkzeug==3.1.8
 Flask-WTF==1.3.0
 PyMySQL==1.2.0
-SQLAlchemy==1.4.53
-alembic==1.13.1
+SQLAlchemy==2.0.51
+alembic==1.18.5
 click==8.4.2
 pt-p710bt-label-maker @ git+https://github.com/jantman/pt-p710bt-label-maker.git@jantman
 Pillow>=11.0.0


### PR DESCRIPTION
## Summary

PR 2 of the staged dependency plan in #33. Upgrades **SQLAlchemy `1.4.53` → `2.0.51`** and **alembic `1.13.1` → `1.18.5`** (moved together, per the plan).

The codebase turned out to be largely 2.0-ready: it uses the legacy `Query` API (`session.query(...)`) and `Column`/`relationship` declarations, both of which remain **fully supported** in SQLAlchemy 2.0. The `case()` construct already used 2.0-style positional whens, and every Alembic migration already used `text()` / Core constructs. Only two real incompatibilities needed fixing.

## Changes

- **`requirements.txt`** — `SQLAlchemy==2.0.51`, `alembic==1.18.5`
- **`app/database.py`** — import `declarative_base` from `sqlalchemy.orm` instead of the deprecated `sqlalchemy.ext.declarative`
- **`manage.py`** — wrap the raw `conn.execute("SELECT 1")` connection test in `text()` (raw SQL strings passed to `.execute()` now require `text()` under 2.0)
- **`_bmad-output/project-context.md`** — this AI-agent grounding doc previously instructed agents to use "1.4 idioms" and "NOT 2.x"; corrected to reflect 2.0.51 + legacy-Query-API guidance, and refreshed other stale dependency versions in its tech-stack block

## Verification

- ✅ **Unit suite** (`nox -s tests`): **350 passed**, zero SQLAlchemy 2.0 deprecation warnings
- ✅ **E2E suite** (`nox -s e2e`): **304 passed, 1 skipped** (18:48)
- ✅ **Alembic 1.18.5**: full `upgrade head` verified against a fresh `mariadb:10.11` container; history + script parsing intact
- ✅ Reviewed the ~72 `session.query()` call sites and all ORM declarations — no 2.0-incompatible patterns remain

## Note — pre-existing downgrade bug (out of scope)

`alembic downgrade base` fails at revision `8213852b0b94` with `Cannot drop index 'ix_item_photo_associations_photo_id': needed in a foreign key constraint` (MariaDB won't drop an index still referenced by a FK). **This is pre-existing, not a regression** — I confirmed it fails identically under the old SQLAlchemy 1.4.53 + alembic 1.13.1. The forward `upgrade` path (what production uses) is fully working. Left for a separate fix so this dependency bump stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ruxhv1bUuMGeTUdQAcqBVB