### PR TITLE
deps: PR 3 — pytest 8 → 9

### DIFF
--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -24,7 +24,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - **Database:** MariaDB/MySQL via PyMySQL 1.2.0 (primary). Google Sheets API (google-api-python-client 2.198.0) is **export-only / legacy**, not primary storage.
 - **Forms/CSRF:** Flask-WTF 1.3.0 (CSRF enabled in prod, disabled in tests)
 - **Frontend:** Server-rendered Jinja2 + Bootstrap 5.3.2 (`app/templates`, `app/static`)
-- **Testing:** nox + pytest 8.4.2, pytest-flask, Playwright 1.55.0 (e2e), testcontainers[mysql] 4.8.2 (integration)
+- **Testing:** nox + pytest 9.1.1, pytest-flask, pytest-playwright 0.8.0 + Playwright 1.55.0 (e2e), testcontainers[mysql] 4.8.2 (integration)
 - **Other:** PyMuPDF (PDF), Pillow (images), pt-p710bt-label-maker (Brother label printing via git dependency)
 - **Config:** python-dotenv 1.2.2 — settings loaded from `.env`; `SQLALCHEMY_DATABASE_URI` read directly
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 # Testing Requirements
-pytest==8.4.2
+pytest==9.1.1
 pytest-flask==1.3.0
 pytest-mock==3.15.1
 pytest-cov==7.1.0
@@ -9,7 +9,7 @@ pytest-blockage==0.2.4
 
 # E2E Testing
 playwright==1.55.0
-pytest-playwright==0.7.1
+pytest-playwright==0.8.0
 testcontainers[mysql]==4.8.2
 
 # Additional test utilities


### PR DESCRIPTION
## Summary

PR 3 of the staged dependency plan in #33. Upgrades **pytest `8.4.2` → `9.1.1`**.

## Forced dependency: pytest-playwright pulled forward from PR 4

`pytest-playwright 0.7.1` pins `pytest<9.0.0`, so **pytest 9 is impossible without bumping it**. `pytest-playwright 0.8.0` requires only `playwright>=1.18`, so the current **playwright 1.55.0 satisfies it unchanged** — the `playwright 1.55→1.61` and `testcontainers` bumps stay isolated in PR 4 as planned. This one bump (`pytest-playwright 0.7.1 → 0.8.0`) is the minimal move to unblock pytest 9. (The plan's "each PR is independent" note didn't account for this cap.)

## pytest-blockage — the flagged risk

`pytest-blockage` (unmaintained, still 0.2.4) **works under pytest 9**. It only uses the stable `pytest_addoption` / `pytest_sessionstart` hooks and monkey-patches `http.client` / `smtplib` — none of which pytest 9 touched. Verified empirically:

- With `--blockage`: an `http.client.HTTPConnection(...)` raises `pytest_blockage.MockHttpCall` ✅ (network blocked)
- Without `--blockage`: no error ✅ (network allowed)

No replacement or removal needed.

## Changes

- **`requirements-test.txt`** — `pytest==9.1.1`, `pytest-playwright==0.8.0`
- **`_bmad-output/project-context.md`** — refreshed the testing line

## Verification

- ✅ **Unit suite** (`nox -s tests`): **350 passed**, no pytest 9 removal/deprecation warnings, all plugins (pytest-flask, pytest-mock, pytest-cov, pytest-rerunfailures) compatible
- ✅ **E2E suite** (`nox -s e2e`): **304 passed, 1 skipped** (18:50) — exercises pytest-playwright 0.8.0
- ✅ `pip check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ruxhv1bUuMGeTUdQAcqBVB