### PR TITLE
deps: PR 4 — Playwright / E2E stack

### DIFF
--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -24,7 +24,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - **Database:** MariaDB/MySQL via PyMySQL 1.2.0 (primary). Google Sheets API (google-api-python-client 2.198.0) is **export-only / legacy**, not primary storage.
 - **Forms/CSRF:** Flask-WTF 1.3.0 (CSRF enabled in prod, disabled in tests)
 - **Frontend:** Server-rendered Jinja2 + Bootstrap 5.3.2 (`app/templates`, `app/static`)
-- **Testing:** nox + pytest 9.1.1, pytest-flask, pytest-playwright 0.8.0 + Playwright 1.55.0 (e2e), testcontainers[mysql] 4.8.2 (integration)
+- **Testing:** nox + pytest 9.1.1, pytest-flask, pytest-playwright 0.8.0 + Playwright 1.61.0 (e2e), testcontainers[mysql] 4.14.2 (integration)
 - **Other:** PyMuPDF (PDF), Pillow (images), pt-p710bt-label-maker (Brother label printing via git dependency)
 - **Config:** python-dotenv 1.2.2 — settings loaded from `.env`; `SQLALCHEMY_DATABASE_URI` read directly
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,9 +8,9 @@ nox
 pytest-blockage==0.2.4
 
 # E2E Testing
-playwright==1.55.0
+playwright==1.61.0
 pytest-playwright==0.8.0
-testcontainers[mysql]==4.8.2
+testcontainers[mysql]==4.14.2
 
 # Additional test utilities
 PyYAML==6.0.3

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -32,12 +32,19 @@ def mariadb_testcontainer():
     except ImportError:
         pytest.skip("testcontainers not installed - run: pip install testcontainers[mysql]")
     
-    # Start MariaDB container with same config as CI
-    container = MySqlContainer("mariadb:10.11")
-    container = container.with_env("MYSQL_ROOT_PASSWORD", "test_root_password")
-    container = container.with_env("MYSQL_DATABASE", "workshop_inventory_test") 
-    container = container.with_env("MYSQL_USER", "inventory_test_user")
-    container = container.with_env("MYSQL_PASSWORD", "test_password")
+    # Start MariaDB container with same config as CI.
+    # testcontainers >= 4.9 takes credentials as constructor args and no longer
+    # honors .with_env("MYSQL_USER"/...) for them; it also defaults the SQLAlchemy
+    # dialect to bare "mysql://" (i.e. MySQLdb), so pymysql must be requested
+    # explicitly to match the driver the app uses.
+    container = MySqlContainer(
+        "mariadb:10.11",
+        dialect="pymysql",
+        username="inventory_test_user",
+        password="test_password",
+        root_password="test_root_password",
+        dbname="workshop_inventory_test",
+    )
     container = container.with_env("MARIADB_CHARACTER_SET_SERVER", "utf8mb4")
     container = container.with_env("MARIADB_COLLATION_SERVER", "utf8mb4_unicode_ci")
     


### PR DESCRIPTION
## Summary

PR 4 of the staged dependency plan in #33. Upgrades **playwright `1.55.0` → `1.61.0`** and **testcontainers[mysql] `4.8.2` → `4.14.2`**. (`pytest-playwright 0.7.1 → 0.8.0` was already pulled forward in PR 3 to unblock pytest 9.)

## testcontainers 4.14.2 broke the container fixture — fixed

`testcontainers` changed `MySqlContainer`'s API, which broke `tests/test_database.py::mariadb_testcontainer` in two ways:

1. **Dialect default changed** — `get_connection_url()` now returns a bare `mysql://…`, which SQLAlchemy routes to the `MySQLdb` driver (not installed → `ModuleNotFoundError`). Older versions defaulted to `pymysql`. Fixed by passing `dialect="pymysql"`.
2. **Credentials are now constructor params** — `.with_env("MYSQL_USER"/...)` is no longer honored (the container's `_configure()` overrides them to defaults, so the URL came back as `test:test@…/test`). Moved `username`/`password`/`root_password`/`dbname` to constructor args so the intended test user/db are used. The charset env vars stay as `.with_env` since they aren't credential params.

Caught with a standalone container smoke test **before** the ~19-min e2e run. The `CI=true` path is unaffected — it uses a MariaDB service container, not testcontainers.

## Changes

- **`requirements-test.txt`** — `playwright==1.61.0`, `testcontainers[mysql]==4.14.2`
- **`tests/test_database.py`** — rewrite `MySqlContainer(...)` construction for the new API (`dialect="pymysql"` + credentials as constructor args)
- **`_bmad-output/project-context.md`** — refreshed the testing line

## Verification

- ✅ **Standalone smoke test**: `get_connection_url()` → `mysql+pymysql://inventory_test_user:…@…/workshop_inventory_test`, connects, charset `utf8mb4`
- ✅ **E2E suite** (`nox -s e2e`): **304 passed, 1 skipped** (18:21) — the entire suite runs against the testcontainer, exercising both bumps together
- ✅ `pip check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ruxhv1bUuMGeTUdQAcqBVB