### PR TITLE
deps: PR 5 — media libs (Pillow 12 + PyMuPDF 1.28)

### DIFF
--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -25,7 +25,7 @@ _This file contains critical rules and patterns that AI agents must follow when 
 - **Forms/CSRF:** Flask-WTF 1.3.0 (CSRF enabled in prod, disabled in tests)
 - **Frontend:** Server-rendered Jinja2 + Bootstrap 5.3.2 (`app/templates`, `app/static`)
 - **Testing:** nox + pytest 9.1.1, pytest-flask, pytest-playwright 0.8.0 + Playwright 1.61.0 (e2e), testcontainers[mysql] 4.14.2 (integration)
-- **Other:** PyMuPDF (PDF), Pillow (images), pt-p710bt-label-maker (Brother label printing via git dependency)
+- **Other:** PyMuPDF 1.28.0 (PDF), Pillow 12.3.0 (images), pt-p710bt-label-maker (Brother label printing via git dependency)
 - **Config:** python-dotenv 1.2.2 — settings loaded from `.env`; `SQLALCHEMY_DATABASE_URI` read directly
 
 ## Critical Implementation Rules

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -457,7 +457,7 @@ The regeneration process:
 2. **Uses PyMuPDF** to generate JPEG thumbnails from the first page
 3. **Updates database** with new JPEG thumbnail and medium-size data
 4. **Preserves original PDF** data unchanged
-5. **Requires PyMuPDF** to be installed (`pip install PyMuPDF==1.24.9`)
+5. **Requires PyMuPDF** to be installed (`pip install PyMuPDF==1.28.0`)
 
 #### Best Practices
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ SQLAlchemy==2.0.51
 alembic==1.18.5
 click==8.4.2
 pt-p710bt-label-maker @ git+https://github.com/jantman/pt-p710bt-label-maker.git@jantman
-Pillow>=11.0.0
-PyMuPDF==1.24.9
+Pillow>=12.3.0
+PyMuPDF==1.28.0


### PR DESCRIPTION
## Summary

PR 5 (final) of the staged dependency plan in #33. Upgrades **Pillow** (floor `>=11.0.0` → `>=12.3.0`) and **PyMuPDF** `1.24.9` → `1.28.0`.

Both libraries are used only in `app/photo_service.py` for image and PDF thumbnail generation. The code already uses current APIs (`Image.Resampling.LANCZOS`, `ImageOps.exif_transpose`; `fitz.open` / `page.get_pixmap` / `pixmap.tobytes`), so **no code changes were needed**. `import fitz` still works under PyMuPDF 1.28.

## Changes

- **`requirements.txt`** — `Pillow>=12.3.0`, `PyMuPDF==1.28.0`
- **`docs/deployment-guide.md`** — refreshed the PyMuPDF version in the thumbnail-regeneration note
- **`_bmad-output/project-context.md`** — added media-lib versions to the tech-stack block

## Verification (label-printing + PDF paths exercised explicitly)

- ✅ **Standalone smoke test** of `PhotoService._process_photo` (image) and `_process_pdf` (PDF): both produce correct-size JPEG thumbnails/medium images; the original PDF is passed through unchanged
- ✅ **Unit suite** (`nox -s tests`): **350 passed**, incl. `test_photo_service.py` + `test_label_printer.py`
- ✅ **E2E suite** (`nox -s e2e`): **304 passed, 1 skipped** — covers photo upload and bulk label printing
- ✅ `pt-p710bt-label-maker` (Pillow-based label printing) coexists with Pillow 12; `pip check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ruxhv1bUuMGeTUdQAcqBVB