### PR TITLE
Upgrade MariaDB image 10.11 → 11.8 LTS

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.11
+        image: mariadb:11.8
         env:
           MYSQL_ROOT_PASSWORD: test_root_password
           MYSQL_DATABASE: workshop_inventory_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
     
     services:
       mariadb:
-        image: mariadb:10.11
+        image: mariadb:11.8
         env:
           MYSQL_ROOT_PASSWORD: test_root_password
           MYSQL_DATABASE: workshop_inventory_test

--- a/docs/development-testing-guide.md
+++ b/docs/development-testing-guide.md
@@ -67,7 +67,7 @@ The project uses **Nox** for consistent test execution across environments. All 
 - **Multi-Row Scenarios**: Testing active item lookup and history functionality
 - **API Endpoints**: Testing item history API and data retrieval logic
 
-**Technology**: Playwright with Chromium browser + MariaDB 10.11 testcontainer
+**Technology**: Playwright with Chromium browser + MariaDB 11.8 testcontainer
 
 **Runtime**: ~10-15 seconds (plus initial Docker container startup)
 
@@ -344,7 +344,7 @@ git commit -m "Add screenshot for new feature"
 
 **Test Server**: Dedicated Flask server with test configuration that uses MariaDB (testcontainer locally, service in CI). Direct database writes ensure test data is immediately available.
 
-**MariaDB Testcontainer**: Automatically managed Docker container with MariaDB 10.11, same version as production. No manual setup required.
+**MariaDB Testcontainer**: Automatically managed Docker container with MariaDB 11.8, same major version as production. No manual setup required.
 
 **Page Objects**: Organized test code that interacts with web elements using Playwright selectors.
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -38,7 +38,7 @@ def mariadb_testcontainer():
     # dialect to bare "mysql://" (i.e. MySQLdb), so pymysql must be requested
     # explicitly to match the driver the app uses.
     container = MySqlContainer(
-        "mariadb:10.11",
+        "mariadb:11.8",
         dialect="pymysql",
         username="inventory_test_user",
         password="test_password",


### PR DESCRIPTION
Closes #41.

Moves the MariaDB server image off `10.11` LTS to the newer `11.8` LTS. All three pinned references are updated in lockstep so local, CI, and screenshot environments test against the same server version, plus the two matching doc mentions.

## Changes
- `.github/workflows/test.yml` — CI service container `mariadb:10.11` → `mariadb:11.8`
- `.github/workflows/screenshots.yml` — screenshots CI service container
- `tests/test_database.py` — local e2e/integration testcontainer
- `docs/development-testing-guide.md` — doc references

## Validation (against `mariadb:11.8.8`)
- **`alembic upgrade head`**: all 8 migrations applied cleanly against a fresh 11.8 container, including the MariaDB-specific `REGEXP` check constraints and `MEDIUMBLOB` columns called out in the issue. `alembic current` at head; all expected tables created.
- **`nox -s e2e`**: **304 passed, 1 skipped, 0 failures** (~19 min).

## Notes
- Chose **11.8** (newest LTS, longest support horizon) over 11.4, per the issue.
- No collation/charset issues observed — the testcontainer and CI services still set `utf8mb4` / `utf8mb4_unicode_ci` explicitly.
- Left `docs/features/complete/gha_runs_failing.md` untouched: it's a historical record of completed work, not current-state config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)