### PR TITLE
Fix flaky test_material_selector_works_on_edit_form (#40)

### DIFF
--- a/tests/e2e/test_material_selector.py
+++ b/tests/e2e/test_material_selector.py
@@ -496,15 +496,27 @@ def test_material_selector_works_on_edit_form(page, live_server):
     
     # Should redirect to success or list page (inventory list)
     expect(page).to_have_url(re.compile(r'.*/inventory$'))
-    
-    # Navigate to edit the item we just created
-    page.goto(f'{live_server.url}/inventory/edit/JA999998')
-    
+
+    # Let the inventory list page finish loading before we navigate away, so its
+    # in-flight fetch isn't aborted mid-flight (that abort logs a red-herring
+    # "Error loading inventory: TypeError: Failed to fetch" console error).
+    page.wait_for_load_state('networkidle')
+
+    # Navigate to edit the item we just created. The MaterialSelector only wires
+    # up its focus handler after its taxonomy fetch (/api/materials/hierarchy)
+    # resolves, so wait for that response before interacting -- otherwise the
+    # click below can race initialization and the dropdown never opens.
+    with page.expect_response(re.compile(r'/api/materials/hierarchy')):
+        page.goto(f'{live_server.url}/inventory/edit/JA999998')
+
     # Material input should exist and be pre-filled
     material_input = page.locator('#material')
     expect(material_input).to_be_visible()
     expect(material_input).to_have_value('Steel')
-    
+
+    # Ensure the edit page (incl. MaterialSelector init) has fully settled.
+    page.wait_for_load_state('networkidle')
+
     # Clear and test MaterialSelector on edit form
     material_input.fill('')
     material_input.click()


### PR DESCRIPTION
Closes #40.

## Problem

`test_material_selector_works_on_edit_form` is flaky in CI — it failed both the PR #42 run and the post-merge run on `main` (all 4 attempts each time), while re-runs pass. The failure:

```
tests/e2e/test_material_selector.py:514: expect(suggestions_container).to_be_visible(timeout=3000)
E   AssertionError: Locator expected to be visible
E   Actual value: hidden
```

## Root cause

The debug artifacts show the taxonomy **did** load on the edit form (`Loaded taxonomy: 6 categories, 9 materials`) and the item was created fine — so this is **not** a MariaDB 11.8 data problem. It's a client-side timing race:

- `MaterialSelector.init()` `await`s its taxonomy fetch (`/api/materials/hierarchy`) and only attaches its `focus` handler *afterward* (`app/static/js/material-selector.js:56,59`).
- The test clicked the material input before `init()` finished, so the focus event was lost and the dropdown never opened. `to_be_visible(3000)` can't recover a click that had no handler.

The `Error loading inventory: TypeError: Failed to fetch` console errors are a **red herring** — a `/inventory` list fetch aborted when the test navigated away, exactly as diagnosed in #40.

This race pre-dates the MariaDB work (first seen on the Playwright bump, PR #38). MariaDB 11.8's slightly slower cold-start query timing just widened the window and made it fire often.

## Fix (test-side hardening, per #40)

- Wait for `networkidle` after the redirect to `/inventory` so its fetch isn't aborted mid-flight (removes the red-herring console error).
- Wait for the `/api/materials/hierarchy` response before interacting with the edit-form material input, so `MaterialSelector` is fully initialized (focus handler attached) before the click.

## Validation

`nox -s e2e -- -k test_material_selector_works_on_edit_form` against `mariadb:11.8`: **passes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)