### PR TITLE
Fix alembic downgrade at 8213852b0b94 (index/FK drop order on MariaDB)

### DIFF
--- a/migrations/versions/8213852b0b94_refactor_photo_schema_for_many_to_many.py
+++ b/migrations/versions/8213852b0b94_refactor_photo_schema_for_many_to_many.py
@@ -283,13 +283,12 @@ def downgrade() -> None:
 
     print("Data rolled back successfully!")
 
-    # Step 3: Drop new tables
-    op.drop_index('ix_item_photo_associations_ja_id_order', table_name='item_photo_associations')
-    op.drop_index('ix_item_photo_associations_photo_id', table_name='item_photo_associations')
-    op.drop_index('ix_item_photo_associations_ja_id', table_name='item_photo_associations')
+    # Step 3: Drop new tables.
+    # drop_table also drops the table's own indexes, so we must NOT drop them
+    # individually first: MariaDB refuses to drop ix_item_photo_associations_photo_id
+    # while it still backs the foreign key to photos.id. Drop the child table
+    # (item_photo_associations) before the parent (photos).
     op.drop_table('item_photo_associations')
-
-    op.drop_index('ix_photos_sha256_hash', table_name='photos')
     op.drop_table('photos')
 
     print("Rollback completed successfully!")


### PR DESCRIPTION
Closes #36.

## Problem

`alembic downgrade` past `8213852b0b94` (`refactor_photo_schema_for_many_to_many`) fails on MariaDB:

```
pymysql.err.OperationalError: (1553, "Cannot drop index
'ix_item_photo_associations_photo_id': needed in a foreign key constraint")
```

The forward `upgrade` path is fine — only downgrades are affected.

## Cause

The `downgrade()` dropped the `item_photo_associations` indexes individually **before** dropping the table. `photo_id` has a FK to `photos.id`, and MariaDB requires that index to back the foreign key, so it refuses to drop `ix_item_photo_associations_photo_id` while the FK still exists.

## Fix

`op.drop_table()` already drops the table's own indexes, so the individual `drop_index` calls were redundant — remove them and just drop the child table (`item_photo_associations`) before the parent (`photos`). The `photos` index drop was redundant for the same reason.

```diff
-    op.drop_index('ix_item_photo_associations_ja_id_order', table_name='item_photo_associations')
-    op.drop_index('ix_item_photo_associations_photo_id', table_name='item_photo_associations')
-    op.drop_index('ix_item_photo_associations_ja_id', table_name='item_photo_associations')
     op.drop_table('item_photo_associations')
-
-    op.drop_index('ix_photos_sha256_hash', table_name='photos')
     op.drop_table('photos')
```

## Not a regression

Confirmed in #36 to fail identically on the old SQLAlchemy 1.4.53 / alembic 1.13.1 stack — a latent migration bug, not introduced by the dependency upgrades.

## Validation

Against `mariadb:11.8`, the full round-trip now succeeds:
`alembic upgrade head` → `alembic downgrade base` (all 8 downgrades run cleanly, DB reduced to just `alembic_version`) → `alembic upgrade head`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)