### PR TITLE
Story 1.3: Product create/edit/detail

### DIFF
--- a/_bmad-output/implementation-artifacts/1-3-product-create-edit-detail.md
+++ b/_bmad-output/implementation-artifacts/1-3-product-create-edit-detail.md
@@ -4,7 +4,7 @@ baseline_commit: 3de56609a6223da14bdb3a5ee8f2253a2484f85f
 
 # Story 1.3: Product create/edit/detail
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -72,6 +72,19 @@ Ship exactly: the service, three routes (+ nav link), three templates, and their
   - [x] `venv/bin/nox -s tests` → **383 passed** (367 baseline + 16 new), 0 failures, no regressions. No MariaDB container needed (no schema change).
   - [x] E2E not added (optional for 1.3; NFR6 prioritizes scan/label E2E, delivered later). Route tests exercise the full render/flow via the Flask test client.
   - [x] Screenshots: product pages were **not** added to `tests/e2e/screenshot_config.yaml`, so no screenshot regen is required for this story (noted in Completion Notes).
+
+### Review Findings
+
+- [x] [Review][Patch] Edit POST non-success paths discard typed input (blank-description re-render fills from `product.*` not `form_data`; `not ok`/exception branches redirect and wipe input; error-branch title also differs from GET) [app/main/routes.py:815-838, app/templates/product/edit.html]
+- [x] [Review][Patch] DB errors masquerade as 404 — `get_product` swallows all exceptions to `None`, routes `abort(404)` for products that exist [app/mariadb_catalog_service.py:61-79]
+- [x] [Review][Patch] No length validation: >255-char description/manufacturer/mpn (>512 category) fails generically on strict MariaDB, succeeds on SQLite tests; templates lack `maxlength` [app/main/routes.py:747-838, app/templates/product/*.html]
+- [x] [Review][Patch] Partial POST nulls omitted fields — `update_product` receives `None` for absent form keys and wipes stored values; pass only keys present in the form [app/main/routes.py:820-828]
+- [x] [Review][Patch] `detail.html` 500s when `attributes` JSON is a non-dict (list/scalar passes the `{% if %}` guard, `.items()` raises) [app/templates/product/detail.html:35-44]
+- [x] [Review][Patch] `create_product` can report failure after a successful commit (post-commit `id`/`to_dict()` refresh may fail → retry duplicates); flush + capture before commit [app/mariadb_catalog_service.py:100-116]
+- [x] [Review][Patch] `mariadb_catalog_service` logger not registered in `setup_logging` — catalog audit records bypass the audit-enrichment handler config; route-level input audits also tagged with the service logger name [app/logging_config.py:127-145, app/main/routes.py:754,811]
+- [x] [Review][Patch] Weak test assertions — `updated_at >= before` is tautological at second resolution; blank-create route test doesn't assert the error message rendered [tests/unit/test_catalog_service.py, tests/unit/test_product_routes.py]
+- [x] [Review][Patch] Unused `Product` import in routes [app/main/routes.py:13]
+- [x] [Review][Defer] Per-request SQLAlchemy engine/pool creation — unconnected `MariaDBStorage()` in production makes `CatalogService` (and the pre-existing `InventoryService`) build an undisposed engine from `Config` per request, ignoring `storage.database_url` [app/mariadb_catalog_service.py:51-58] — deferred, pre-existing systemic pattern shared with InventoryService; needs an app-level engine-sharing fix covering both services
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/1-3-product-create-edit-detail.md
+++ b/_bmad-output/implementation-artifacts/1-3-product-create-edit-detail.md
@@ -1,0 +1,171 @@
+---
+baseline_commit: 3de56609a6223da14bdb3a5ee8f2253a2484f85f
+---
+
+# Story 1.3: Product create/edit/detail
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the workshop operator,
+I want to create, edit, and view a Product from the UI,
+so that I can catalog an item with as little or as much detail as I have.
+
+## Acceptance Criteria
+
+1. **Given** the product create form, **When** I create a Product with only a Label Description and no other fields, **Then** it saves successfully with `manufacturer`, `mpn`, `category_path`, `notes`, and all other optional fields empty (FR3, FR4).
+2. **And** creation requires no field that would be unavailable for a pre-existing item with no order — the only required field is the Label Description, which is always typeable (FR61).
+3. **Given** an existing Product, **When** I edit its Label Description and save, **Then** the change persists.
+4. **And** the Product's detail view is reachable by a direct URL (`/products/<id>`), rendering its stored fields (FR6).
+5. **And** all catalog business logic (create, read, update) lives in a new `app/mariadb_catalog_service.py` service — routes contain no ORM/SQL and delegate to it; mutations call `log_audit_operation` (AD-2).
+6. **And** existing metal-stock UI, routes, and behavior are unchanged (NFR9); the full test suite passes; new unit tests cover the service and new route/integration tests cover the create/edit/detail flows.
+
+## Scope Boundary — READ FIRST
+
+This story delivers **browser-based create / edit / detail for Products only**, on the existing Bootstrap UI, backed by a new catalog service. It is the first story to add routes, a service, and templates for the catalog — so it establishes patterns Epics 2–10 build on. **No schema change** (the `products` table already exists from Story 1.1).
+
+| Concern | Owned by | In 1.3? |
+| --- | --- | --- |
+| `CatalogService` create/get/update + product create/edit/detail pages | **Story 1.3 (this)** | ✅ |
+| Product **list / browse / search / facets** | Epic 8 (8.1–8.3) | ❌ — 1.3 adds only a nav link to "Add Product"; existing products are reached by direct URL |
+| `internal_id` generation + `internal_id`-keyed detail URL | Epic 2 (2.4) + Epic 8 (8.3) | ❌ — 1.3 keys the detail URL on the integer PK `id` |
+| **Specifications (`attributes`) editing UI** | later | ❌ — 1.3 does not add a JSON/spec editor to the form; the detail page *displays* `attributes` read-only if present |
+| Category **autocomplete-with-create + `normalize_category_path`** | Epic 3 (3.1) | ❌ — 1.3 uses a plain free-text `category_path` field, stored as entered (trimmed) |
+| Purchase history + "Last paid" on the product view | Story 1.4 | ❌ |
+| Attachments on the product view | Story 1.5 | ❌ |
+| Enrichment hook on the create path | Story 7.5 | ❌ — the create-service established here is the seam 7.5 and 2.4 later extend |
+| REST/JSON create endpoint (`@csrf.exempt`, fixed envelope) | Epic 7 (7.1) | ❌ — 1.3 is browser HTML forms only (CSRF-protected, flash+redirect) |
+| Tags | Epic 3 (3.3) | ❌ |
+
+Ship exactly: the service, three routes (+ nav link), three templates, and their tests. Nothing else.
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — Create `app/mariadb_catalog_service.py` (`CatalogService`) (AC: #1, #3, #5)**
+  - [x] Modeled on `MariaDBMaterialsAdminService`/`InventoryService`: `__init__(storage=None)` → `getattr(storage,'engine',None) or self._create_engine()` → `sessionmaker`; `_create_engine()` from `Config`.
+  - [x] Per-method `session = self.Session()` / `try` / `except`(rollback on mutations) / `finally` close.
+  - [x] `get_product(id) -> Optional[Product]` (read-only query, returns detached ORM object or None; no relationship access).
+  - [x] `create_product(*, ...) -> Optional[int]` (add+commit+audit, returns new id captured pre-close; None on failure).
+  - [x] `update_product(id, **fields) -> bool` (load-or-False, set recognized fields, commit; `updated_at` auto-bumps via `onupdate`).
+  - [x] `_clean()` trims strings and coerces blanks to `None`; only `_PRODUCT_FIELDS` applied on update; `app/models.py` untouched.
+
+- [x] **Task 2 — Add routes to `app/main/routes.py` (main blueprint) (AC: #1, #3, #4, #5)**
+  - [x] `_get_catalog_service()` helper added beside `_get_inventory_service()`; imported `CatalogService` + `Product` (`abort` already imported).
+  - [x] `product_add` (`/products/add`, GET/POST, CSRF-protected) — requires non-empty `description`, re-renders with `validation_errors` + `form_data` on blank, else creates and redirects to detail.
+  - [x] `product_detail` (`/products/<int:product_id>`) — `abort(404)` if missing, else renders `detail.html`.
+  - [x] `product_edit` (`/products/edit/<int:product_id>`, GET/POST) — `abort(404)` if missing; requires `description`; updates and redirects to detail.
+  - [x] All three are server-rendered HTML (render/flash/redirect); no JSON envelope, no `@csrf.exempt`.
+
+- [x] **Task 3 — Templates under `app/templates/product/` (AC: #1, #3, #4)**
+  - [x] `add.html` — extends base, `<form method="POST" novalidate>` + hidden `csrf_token()`, Bootstrap card, fields (description required, manufacturer, mpn, category_path, notes), `is-invalid`/`d-block` validation display, preserves `form_data`.
+  - [x] `edit.html` — same form pre-filled from `product.*`; Cancel → detail.
+  - [x] `detail.html` — read-only `<dl>` of all fields, Specifications rendered only if `product.attributes`, timestamps, Edit button.
+  - [x] Added a "Products" navbar dropdown in `base.html` with "Add Product" → `main.product_add`.
+  - [x] No autocomplete wired (not needed for 1.3's fields).
+
+- [x] **Task 4 — Tests (AC: #1, #3, #4, #6)**
+  - [x] `tests/unit/test_catalog_service.py` — 7 tests (create-minimal/full/blank-coercion, get-missing, update-persist/missing/blank-coerce).
+  - [x] `tests/unit/test_product_routes.py` — 9 tests (add form; create→302→detail; blank re-render; detail 404 + fields; edit prefilled/404/persist/blank).
+  - [x] `venv/bin/nox -s tests` → **383 passed** (367 baseline + 16 new), 0 failures, no regressions. No MariaDB container needed (no schema change).
+  - [x] E2E not added (optional for 1.3; NFR6 prioritizes scan/label E2E, delivered later). Route tests exercise the full render/flow via the Flask test client.
+  - [x] Screenshots: product pages were **not** added to `tests/e2e/screenshot_config.yaml`, so no screenshot regen is required for this story (noted in Completion Notes).
+
+## Dev Notes
+
+### Previous story intelligence — carried from Stories 1.1 & 1.2 (merged)
+- **`created_at`/`updated_at`** is the confirmed catalog timestamp convention; `Product`/`Purchase` already use it. `updated_at` auto-bumps via the model's `onupdate=func.now()` — don't set it manually in `update_product`.
+- **Detached-instance pitfall (hit in 1.2 tests):** after `session.commit()`, attributes expire; after the session closes, the instance is detached and lazy access raises `DetachedInstanceError`. That's why `create_product` returns the **int id** (captured pre-close), and why `get_product` (a read-only query with no commit) can safely return the ORM object for the route to render its scalar columns. In tests, use `session.expire_all()` (keeps objects bound) rather than `expunge_all()` when re-reading.
+- Baseline: full unit suite is **367 passed** on `main`. Keep it green.
+- **This story has NO migration** — `products` already exists (`c10caa1431c6`). AD-14/MariaDB-container verification does not apply here.
+
+### Service layer (AD-2) — mirror `MariaDBMaterialsAdminService` / `InventoryService`
+- Class + wiring (grounded references): `InventoryService.__init__` (`mariadb_inventory_service.py:130-148`) — `self.engine = storage.engine or self._create_engine()`, `self.Session = sessionmaker(bind=self.engine)`. Use the **safer** `getattr(storage, 'engine', None)` form from the admin service (`mariadb_materials_admin_service.py:42`), because a freshly-built `MariaDBStorage()` has `engine=None` until `connect()`.
+- Method shapes to copy: read → `get_active_item` (`mariadb_inventory_service.py:150-187`, returns object or `None`); create → `add_item` (`:1058-1167`, `session.add` + `commit` + audit); update → `update_item` (`:930-1056`, load-mutate-commit-audit, returns `bool`).
+- `log_audit_operation(operation_name, phase, *, item_id=None, item_after=None, error_details=None, logger_name='mariadb_catalog_service')` — defined `app/logging_config.py:250`; import lazily inside methods (`from .logging_config import log_audit_operation`); phases `'input'|'success'|'error'`; call on every mutation. Use a `product_id`/id string for `item_id`.
+- Services return domain objects / `bool` / `None` / int id — **never** a `StorageResult` (that dataclass is the storage-backend contract, `app/storage.py:5-11`). The route picks the HTTP status and renders.
+- Exceptions available in `app/exceptions.py`: `ValidationError`, `ItemNotFoundError`, `DuplicateItemError`, … (all subclass `WorkshopInventoryError(message, code, details)`).
+
+### Routes (AD-2) — mirror `inventory_add` / `inventory_edit`
+- Blueprint: `main` (`app/main/__init__.py`, root-mounted). Products are first-class inventory, so they belong in `main` alongside `/inventory/...`, not the `/admin`-prefixed blueprint. Attach routes by adding functions to `app/main/routes.py` decorated with `@bp.route`.
+- Per-request service construction: `service = _get_catalog_service()` at the top of each handler (no `g`-caching), exactly like `service = _get_inventory_service()` (`routes.py:498` etc.). The `_get_storage_backend()` indirection (`routes.py:20-28`) is what lets tests inject SQLite via `current_app.config['STORAGE_BACKEND']` — always go through it.
+- CSRF: browser HTML form POSTs are **CSRF-protected** (Flask-WTF `csrf.init_app` is global) — the template must include `<input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>` (as `inventory/add.html:31` does). Do **not** add `@csrf.exempt` (that is only for JSON APIs, e.g. `routes.py:460`). Tests disable CSRF via `TestConfig.WTF_CSRF_ENABLED=False`, so `client.post` works without a token.
+- Error/flash idiom: wrap bodies in `try/except Exception as e:` → `current_app.logger.error(f'...: {e}')` + `flash(msg, 'error')` + redirect (HTML routes). Missing product on a GET resource URL → `abort(404)` (renders `templates/errors/` via the registered `create_error_handlers`).
+
+### Templates (Bootstrap 5.3.2) — mirror `inventory/add.html` & `inventory/edit.html`
+- `base.html` exposes only two blocks: `content` and `scripts`; title is the `title` context var (not a block). Child templates `{% extends "base.html" %}`.
+- Form scaffold: `<form method="POST" novalidate>` with **no `action`** (posts to the rendering URL, since routes are `methods=['GET','POST']`); hidden `csrf_token()` input first; `.card`>`.card-header`/`.card-body`; fields as `.row`>`.col-md-* mb-3`>`<label class="form-label">`+`<input class="form-control">`; `<textarea class="form-control">` for notes.
+- Server-side validation display (copy `inventory/edit.html:113-121`): add `{% if validation_errors and validation_errors.description %} is-invalid{% endif %}` to the input class and a sibling `<div class="invalid-feedback{% if ... %} d-block{% endif %}">{{ validation_errors.description }}</div>`. Preserve typed values on re-render (`value="{{ form_data.get('manufacturer', '') }}"` for add; `value="{{ product.manufacturer or '' }}"` for edit).
+- Flash messages render globally in `base.html:92-103` (category `error`→`alert-danger`); you don't need to re-render them in the product templates.
+- Detail page is a **new pattern** — the existing app shows item details in a JS modal, but FR6 requires a direct-URL page, so build a proper read-only `detail.html`. The closest reference for read-only field display is the details-modal HTML table built in `static/js/inventory-list.js` (~lines 970-1000); render it server-side in Jinja instead.
+
+### Data / field notes
+- Product columns (from Story 1.1, `app/database.py`): `manufacturer`, `mpn`, `description` (Label Description), `notes`, `category_path`, `attributes` (JSON), `created_at`, `updated_at`, all nullable except PK/timestamps. `internal_id` does **not** exist yet — do not reference it (Epic 2). Detail URL keys on `id`.
+- Required field: only **`description`** (Label Description) — the one field always available even for backfill (FR61). Everything else optional (FR3/FR4). Coerce blank optional fields to `None`.
+- `category_path`: plain free-text in 1.3 (trim only). Epic 3 adds canonicalization + inline autocomplete-create; do not anticipate it.
+- `attributes`: not editable in 1.3; the create/edit form omits it (stays `NULL`). Detail displays it read-only if some later path set it.
+
+### What this story must NOT break (NFR9)
+- Additive only: a NEW service file, NEW routes/functions in `routes.py`, NEW `product/` templates, and ONE nav edit in `base.html`. Do not modify `InventoryService`, inventory routes, inventory templates, or `app/database.py`/`app/models.py`.
+- No dependency changes (`requirements.txt` untouched).
+
+### Testing standards (project-context.md + spine)
+- `venv/bin/nox -s tests` — never bare `pytest`; env needs Python 3.13 (`PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"`). Unit tests use SQLite through `MariaDBStorage`, network blocked; the `client` fixture builds the app via `create_app(TestConfig, storage_backend=test_storage)` (`tests/conftest.py:67-79`).
+- Route tests use `client` (see `tests/unit/test_routes.py` `TestAPIConsistency` for the pattern); service tests construct `CatalogService(test_storage)` directly.
+- `nox -s e2e` requires a **20-minute** tool timeout if used.
+
+### Project Structure Notes
+- New: `app/mariadb_catalog_service.py`, `app/templates/product/add.html`, `app/templates/product/edit.html`, `app/templates/product/detail.html`, `tests/unit/test_catalog_service.py`, `tests/unit/test_product_routes.py`. Modified: `app/main/routes.py` (routes + `_get_catalog_service` + imports), `app/templates/base.html` (nav). Matches the spine Structural Seed (`mariadb_catalog_service.py` NEW; `main/routes.py` + catalog endpoints; `templates/`).
+
+### References
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 1.3: Product create/edit/detail] (AC, FR3/FR4/FR6/FR61)
+- [Source: …/ARCHITECTURE-SPINE.md#AD-2] (business logic in `mariadb_catalog_service.py`; routes build response, no ORM/SQL in routes; per-method session lifecycle; `log_audit_operation` on mutations)
+- [Source: …/ARCHITECTURE-SPINE.md#AD-1] (enhanced-ORM `Product` already exists) · [#AD-3] (`internal_id` is the future URL key — Epic 2/8; 1.3 uses the surrogate id)
+- [Source: …/ARCHITECTURE-SPINE.md#Consistency Conventions] (JSON envelope + `@csrf.exempt` apply to JSON APIs — Epic 7, not 1.3; service `mariadb_catalog_service.py`; sessions `try/except-log/finally-close`)
+- [Source: _bmad-output/implementation-artifacts/1-1-product-entity-and-migration.md, 1-2-purchase-entity-and-migration.md] (timestamp convention, DetachedInstance lesson, 367-test baseline)
+- [Existing code: app/mariadb_inventory_service.py:130-187 (service ctor + read), :930-1056 (update), :1058-1167 (create); app/mariadb_materials_admin_service.py:40-197 (single-file service template + ValidationError use)]
+- [Existing code: app/main/routes.py:20-28 (`_get_storage_backend`), :73-78 (`_get_inventory_service`), :546-625 (`inventory_add`), :627-733 (`inventory_edit`), :460 (`@csrf.exempt` — JSON only)]
+- [Existing code: app/templates/base.html:26-103 (nav + flash blocks), app/templates/inventory/add.html:30-31 (form+CSRF), edit.html:113-121 (server-side validation display)]
+- [Existing code: app/storage.py:5-11 (`StorageResult` — the storage contract, NOT a service return), app/exceptions.py (ValidationError et al.), app/logging_config.py:250 (`log_audit_operation`)]
+- [Existing code: tests/conftest.py:35-79 (`test_storage`/`app`/`client` fixtures), tests/unit/test_routes.py (client-based route tests), tests/e2e/test_add_item.py (e2e add pattern)]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8[1m] (Opus 4.8, 1M context) — bmad-dev-story workflow.
+
+### Debug Log References
+
+- No migration/schema change in this story — pure app-layer (service + routes + templates). No MariaDB container run.
+- Route/integration tests drive the create→detail→edit flow end-to-end through the real Jinja templates via the Flask `client` fixture (SQLite backend), which also exercises the new `base.html` "Products" nav on every rendered page — a broken `url_for('main.product_add')` would 500 those renders; all pass.
+
+### Completion Notes List
+
+- Delivered browser create/edit/detail for Products backed by a new `CatalogService`. No schema change (the `products` table already exists from Story 1.1).
+- `CatalogService` mirrors `MariaDBMaterialsAdminService`/`InventoryService` exactly (ctor, session lifecycle, `log_audit_operation(..., logger_name='mariadb_catalog_service')`, returns id/object/bool — not `StorageResult`).
+- Detail page is keyed on the **integer PK** (`/products/<int:id>`); `internal_id`-keyed URLs are Epic 2/8. Create/edit redirect to the detail page (demonstrates FR6 direct-URL reachability).
+- Only **Label Description** (`description`) is required; all other fields optional, blanks coerced to `NULL` (AC #1, FR3/FR4/FR61). Category is plain free-text (Epic 3 adds normalization/autocomplete-create). Specifications (`attributes`) editing deferred; the detail page displays them read-only if present.
+- Browser forms are CSRF-protected with `{{ csrf_token() }}` (not `@csrf.exempt`); the JSON/REST create path is Epic 7.
+- Scope deferred by design: product list/browse/search (Epic 8), enrichment hook on create (Story 7.5), purchase history/attachments (Stories 1.4/1.5), tags (Epic 3).
+- Screenshots: the new `product/*` pages are **not** in `tests/e2e/screenshot_config.yaml`, so no screenshot regeneration was required.
+- All 6 ACs satisfied; full unit suite green (**383 passed**); metal-stock/inventory UI, routes, and templates unchanged (NFR9).
+
+### File List
+
+- `app/mariadb_catalog_service.py` (new) — `CatalogService` (create/get/update Products).
+- `app/main/routes.py` (modified) — `_get_catalog_service()` helper; `product_add`/`product_detail`/`product_edit` routes; `CatalogService`/`Product` imports.
+- `app/templates/product/add.html` (new), `app/templates/product/edit.html` (new), `app/templates/product/detail.html` (new).
+- `app/templates/base.html` (modified) — "Products" navbar dropdown with "Add Product".
+- `tests/unit/test_catalog_service.py` (new) — 7 service tests.
+- `tests/unit/test_product_routes.py` (new) — 9 route/integration tests.
+- `_bmad-output/implementation-artifacts/1-3-product-create-edit-detail.md` (modified) — story tracking.
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified) — status transitions.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| 2026-07-23 | Story 1.3 implemented: `CatalogService` (create/get/update) + product create/edit/detail routes + 3 templates + "Products" nav + 16 tests (7 service, 9 route). No schema change. Full suite green (383 passed). Status → review. |

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,5 @@
+# Deferred Work Ledger
+
+## Deferred from: code review of 1-3-product-create-edit-detail (2026-07-23)
+
+- **Per-request SQLAlchemy engine/pool creation (systemic).** In production, `_get_storage_backend()` returns a fresh unconnected `MariaDBStorage()` (`engine=None` until `connect()`, which routes never call), so both `CatalogService` and the pre-existing `InventoryService` fall back to `_create_engine()` — building a new pooled engine from class-level `Config.SQLALCHEMY_DATABASE_URI` on every request, never disposed, and ignoring `storage.database_url`. Fix belongs at the app level (shared/app-scoped engine or connected storage singleton) and should cover both services at once. Refs: `app/mariadb_catalog_service.py:51-58`, `app/mariadb_inventory_service.py:140`, `app/main/routes.py:20-28`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -57,7 +57,7 @@ development_status:
   epic-1: in-progress
   1-1-product-entity-and-migration: review
   1-2-purchase-entity-and-migration: review
-  1-3-product-create-edit-detail: review
+  1-3-product-create-edit-detail: done
   1-4-purchase-recording-and-history: backlog
   1-5-attachments-on-product-or-purchase: backlog
   epic-1-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -57,7 +57,7 @@ development_status:
   epic-1: in-progress
   1-1-product-entity-and-migration: review
   1-2-purchase-entity-and-migration: review
-  1-3-product-create-edit-detail: backlog
+  1-3-product-create-edit-detail: review
   1-4-purchase-recording-and-history: backlog
   1-5-attachments-on-product-or-purchase: backlog
   epic-1-retrospective: optional

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -142,6 +142,11 @@ def setup_logging(app):
     inventory_logger = logging.getLogger('inventory')
     inventory_logger.addHandler(stdout_handler)
     inventory_logger.setLevel(log_level)
+
+    # Catalog service operations logger (Products/Purchases)
+    catalog_logger = logging.getLogger('mariadb_catalog_service')
+    catalog_logger.addHandler(stdout_handler)
+    catalog_logger.setLevel(log_level)
     
     # Log startup information
     app.logger.info(f'Workshop Inventory Tracking started - Debug: {app.debug}, Log Level: {logging.getLevelName(log_level)}')

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -10,7 +10,7 @@ from app.mariadb_catalog_service import CatalogService
 # Performance optimizations removed - no longer needed with MariaDB
 from app.taxonomy import type_shape_validator
 from app.models import ItemType, ItemShape, Dimensions, Thread, ThreadSeries, ThreadHandedness
-from app.database import InventoryItem, Product
+from app.database import InventoryItem
 from app.error_handlers import with_error_handling, ErrorHandler
 from app.exceptions import ValidationError, StorageError, ItemNotFoundError
 from app.logging_config import log_audit_operation, log_audit_batch_operation
@@ -743,6 +743,38 @@ def inventory_edit(ja_id):
 # keyed on the integer PK; internal_id-keyed URLs arrive in Epic 8.
 # ---------------------------------------------------------------------------
 
+# Length limits mirroring the Product column definitions (app/database.py).
+_PRODUCT_FIELD_LIMITS = {
+    'description': ('Label Description', 255),
+    'manufacturer': ('Manufacturer', 255),
+    'mpn': ('MPN', 255),
+    'category_path': ('Category', 512),
+}
+
+
+def _validate_product_form(form_data):
+    """Validate product form input. Returns a dict of field -> error message."""
+    errors = {}
+    if not (form_data.get('description') or '').strip():
+        errors['description'] = 'Label Description is required.'
+    for field, (label, limit) in _PRODUCT_FIELD_LIMITS.items():
+        value = (form_data.get(field) or '').strip()
+        if value and len(value) > limit and field not in errors:
+            errors[field] = f'{label} must be {limit} characters or fewer.'
+    return errors
+
+
+def _product_form_data(product):
+    """Build the form_data mapping for rendering edit.html from a Product."""
+    return {
+        'description': product.description or '',
+        'manufacturer': product.manufacturer or '',
+        'mpn': product.mpn or '',
+        'category_path': product.category_path or '',
+        'notes': product.notes or '',
+    }
+
+
 @bp.route('/products/add', methods=['GET', 'POST'])
 def product_add():
     """Create a Product from the catalog UI."""
@@ -751,20 +783,18 @@ def product_add():
                                validation_errors={}, form_data={})
 
     form_data = request.form.to_dict()
-    log_audit_operation('product_add', 'input', form_data=form_data,
-                        logger_name='mariadb_catalog_service')
+    log_audit_operation('product_add', 'input', form_data=form_data)
 
-    description = (form_data.get('description') or '').strip()
-    if not description:
-        error_msg = 'Label Description is required.'
+    validation_errors = _validate_product_form(form_data)
+    if validation_errors:
         return render_template('product/add.html', title='Add Product',
-                               validation_errors={'description': error_msg},
+                               validation_errors=validation_errors,
                                form_data=form_data)
 
     try:
         service = _get_catalog_service()
         new_id = service.create_product(
-            description=description,
+            description=form_data.get('description'),
             manufacturer=form_data.get('manufacturer'),
             mpn=form_data.get('mpn'),
             category_path=form_data.get('category_path'),
@@ -803,39 +833,46 @@ def product_edit(product_id):
     if product is None:
         abort(404)
 
+    title = f'Edit {product.description or product_id}'
+
     if request.method == 'GET':
-        return render_template('product/edit.html', title=f'Edit {product.description or product_id}',
-                               product=product, validation_errors={})
+        return render_template('product/edit.html', title=title, product=product,
+                               form_data=_product_form_data(product),
+                               validation_errors={})
 
     form_data = request.form.to_dict()
     log_audit_operation('product_edit', 'input', item_id=str(product_id),
-                        form_data=form_data, logger_name='mariadb_catalog_service')
+                        form_data=form_data)
 
-    description = (form_data.get('description') or '').strip()
-    if not description:
-        error_msg = 'Label Description is required.'
-        return render_template('product/edit.html', title=f'Edit {product_id}',
-                               product=product,
-                               validation_errors={'description': error_msg})
+    validation_errors = _validate_product_form(form_data)
+    if validation_errors:
+        # Re-render with the SUBMITTED values so the user's in-flight edits
+        # survive the validation error (mirrors add.html's form_data round-trip).
+        return render_template('product/edit.html', title=title, product=product,
+                               form_data=form_data,
+                               validation_errors=validation_errors)
 
     try:
-        ok = service.update_product(
-            product_id,
-            description=description,
-            manufacturer=form_data.get('manufacturer'),
-            mpn=form_data.get('mpn'),
-            category_path=form_data.get('category_path'),
-            notes=form_data.get('notes'),
-        )
+        # Only update fields actually present in the POST body: an absent key
+        # means "not provided", not "clear this" — a present-but-empty field
+        # still clears (the service coerces blanks to NULL).
+        update_fields = {'description': form_data.get('description')}
+        for field in ('manufacturer', 'mpn', 'category_path', 'notes'):
+            if field in form_data:
+                update_fields[field] = form_data[field]
+
+        ok = service.update_product(product_id, **update_fields)
         if not ok:
             flash('Failed to update product. Please try again.', 'error')
-            return redirect(url_for('main.product_edit', product_id=product_id))
+            return render_template('product/edit.html', title=title, product=product,
+                                   form_data=form_data, validation_errors={})
         flash('Product updated successfully!', 'success')
         return redirect(url_for('main.product_detail', product_id=product_id))
     except Exception as e:
         current_app.logger.error(f'Error updating product {product_id}: {e}\n{traceback.format_exc()}')
         flash('An error occurred while updating the product. Please try again.', 'error')
-        return redirect(url_for('main.product_edit', product_id=product_id))
+        return render_template('product/edit.html', title=title, product=product,
+                               form_data=form_data, validation_errors={})
 
 
 @bp.route('/api/items/<ja_id>/duplicate', methods=['POST'])

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -6,10 +6,11 @@ from app import csrf
 from app.mariadb_storage import MariaDBStorage
 # Using unified InventoryService (MariaDB-based implementation)
 from app.mariadb_inventory_service import InventoryService
+from app.mariadb_catalog_service import CatalogService
 # Performance optimizations removed - no longer needed with MariaDB
 from app.taxonomy import type_shape_validator
 from app.models import ItemType, ItemShape, Dimensions, Thread, ThreadSeries, ThreadHandedness
-from app.database import InventoryItem
+from app.database import InventoryItem, Product
 from app.error_handlers import with_error_handling, ErrorHandler
 from app.exceptions import ValidationError, StorageError, ItemNotFoundError
 from app.logging_config import log_audit_operation, log_audit_batch_operation
@@ -73,9 +74,13 @@ def _detect_item_changes(item_before, item_after):
 def _get_inventory_service():
     """Get the MariaDB inventory service (only supported backend)"""
     storage = _get_storage_backend()
-    
+
     # All storage now uses MariaDB backend
     return InventoryService(storage)
+
+def _get_catalog_service():
+    """Get the MariaDB catalog service (Products, Purchases, etc.)"""
+    return CatalogService(_get_storage_backend())
 
 def _get_photo_info(ja_id):
     """Get photo information for an item"""
@@ -731,6 +736,107 @@ def inventory_edit(ja_id):
         current_app.logger.error(f'Error updating item {ja_id}: {e}\n{traceback.format_exc()}')
         flash('An error occurred while updating the item. Please try again.', 'error')
         return redirect(url_for('main.inventory_list'))
+
+# ---------------------------------------------------------------------------
+# Product catalog pages (Story 1.3). Browser HTML forms — CSRF-protected,
+# flash + redirect. Business logic lives in CatalogService (AD-2). Detail is
+# keyed on the integer PK; internal_id-keyed URLs arrive in Epic 8.
+# ---------------------------------------------------------------------------
+
+@bp.route('/products/add', methods=['GET', 'POST'])
+def product_add():
+    """Create a Product from the catalog UI."""
+    if request.method == 'GET':
+        return render_template('product/add.html', title='Add Product',
+                               validation_errors={}, form_data={})
+
+    form_data = request.form.to_dict()
+    log_audit_operation('product_add', 'input', form_data=form_data,
+                        logger_name='mariadb_catalog_service')
+
+    description = (form_data.get('description') or '').strip()
+    if not description:
+        error_msg = 'Label Description is required.'
+        return render_template('product/add.html', title='Add Product',
+                               validation_errors={'description': error_msg},
+                               form_data=form_data)
+
+    try:
+        service = _get_catalog_service()
+        new_id = service.create_product(
+            description=description,
+            manufacturer=form_data.get('manufacturer'),
+            mpn=form_data.get('mpn'),
+            category_path=form_data.get('category_path'),
+            notes=form_data.get('notes'),
+        )
+        if not new_id:
+            flash('Failed to create product. Please try again.', 'error')
+            return render_template('product/add.html', title='Add Product',
+                                   validation_errors={}, form_data=form_data)
+        flash('Product created successfully!', 'success')
+        return redirect(url_for('main.product_detail', product_id=new_id))
+    except Exception as e:
+        current_app.logger.error(f'Error creating product: {e}\n{traceback.format_exc()}')
+        flash('An error occurred while creating the product. Please try again.', 'error')
+        return render_template('product/add.html', title='Add Product',
+                               validation_errors={}, form_data=form_data)
+
+
+@bp.route('/products/<int:product_id>')
+def product_detail(product_id):
+    """View a Product by its direct URL (FR6)."""
+    service = _get_catalog_service()
+    product = service.get_product(product_id)
+    if product is None:
+        abort(404)
+    return render_template('product/detail.html',
+                           title=product.description or f'Product {product_id}',
+                           product=product)
+
+
+@bp.route('/products/edit/<int:product_id>', methods=['GET', 'POST'])
+def product_edit(product_id):
+    """Edit a Product from the catalog UI."""
+    service = _get_catalog_service()
+    product = service.get_product(product_id)
+    if product is None:
+        abort(404)
+
+    if request.method == 'GET':
+        return render_template('product/edit.html', title=f'Edit {product.description or product_id}',
+                               product=product, validation_errors={})
+
+    form_data = request.form.to_dict()
+    log_audit_operation('product_edit', 'input', item_id=str(product_id),
+                        form_data=form_data, logger_name='mariadb_catalog_service')
+
+    description = (form_data.get('description') or '').strip()
+    if not description:
+        error_msg = 'Label Description is required.'
+        return render_template('product/edit.html', title=f'Edit {product_id}',
+                               product=product,
+                               validation_errors={'description': error_msg})
+
+    try:
+        ok = service.update_product(
+            product_id,
+            description=description,
+            manufacturer=form_data.get('manufacturer'),
+            mpn=form_data.get('mpn'),
+            category_path=form_data.get('category_path'),
+            notes=form_data.get('notes'),
+        )
+        if not ok:
+            flash('Failed to update product. Please try again.', 'error')
+            return redirect(url_for('main.product_edit', product_id=product_id))
+        flash('Product updated successfully!', 'success')
+        return redirect(url_for('main.product_detail', product_id=product_id))
+    except Exception as e:
+        current_app.logger.error(f'Error updating product {product_id}: {e}\n{traceback.format_exc()}')
+        flash('An error occurred while updating the product. Please try again.', 'error')
+        return redirect(url_for('main.product_edit', product_id=product_id))
+
 
 @bp.route('/api/items/<ja_id>/duplicate', methods=['POST'])
 @csrf.exempt

--- a/app/mariadb_catalog_service.py
+++ b/app/mariadb_catalog_service.py
@@ -17,7 +17,6 @@ from sqlalchemy import create_engine
 
 from .database import Product
 from .mariadb_storage import MariaDBStorage
-from .exceptions import ValidationError
 from config import Config
 
 

--- a/app/mariadb_catalog_service.py
+++ b/app/mariadb_catalog_service.py
@@ -62,22 +62,19 @@ class CatalogService:
         """
         Return the Product with the given surrogate id, or None if not found.
 
-        This is a read-only query (no commit), so the returned detached ORM
-        object's scalar columns stay readable after the session closes. Do not
-        access relationship attributes (e.g. .purchases) on the result — that
-        would lazy-load on a detached instance (Story 1.4 concern).
+        None strictly means "no such product" — database errors propagate to
+        the caller (and Flask's error handlers) rather than masquerading as
+        not-found. This is a read-only query (no commit), so the returned
+        detached ORM object's scalar columns stay readable after the session
+        closes. Do not access relationship attributes (e.g. .purchases) on the
+        result — that would lazy-load on a detached instance (Story 1.4
+        concern).
         """
+        session = self.Session()
         try:
-            session = self.Session()
             return session.query(Product).filter(Product.id == product_id).first()
-        except Exception as e:
-            from .logging_config import log_audit_operation
-            log_audit_operation('get_product', 'error', item_id=str(product_id),
-                                error_details=str(e), logger_name='mariadb_catalog_service')
-            return None
         finally:
-            if 'session' in locals():
-                session.close()
+            session.close()
 
     def create_product(self, *, manufacturer=None, mpn=None, description=None,
                         notes=None, category_path=None, attributes=None) -> Optional[int]:
@@ -101,10 +98,17 @@ class CatalogService:
                 attributes=attributes,
             )
             session.add(product)
-            session.commit()
+            # Flush (assigns the PK, fires column defaults) and capture the id
+            # and audit snapshot BEFORE commit: a post-commit attribute access
+            # triggers a refresh SELECT that can fail even though the row was
+            # committed, which would falsely report failure and invite a
+            # duplicate-creating retry.
+            session.flush()
             new_id = product.id
+            audit_snapshot = product.to_dict()
+            session.commit()
             log_audit_operation('create_product', 'success', item_id=str(new_id),
-                                item_after=product.to_dict(),
+                                item_after=audit_snapshot,
                                 logger_name='mariadb_catalog_service')
             return new_id
         except Exception as e:
@@ -139,9 +143,12 @@ class CatalogService:
                     continue
                 setattr(product, key, value if key == 'attributes' else _clean(value))
 
+            # Flush and snapshot before commit (see create_product).
+            session.flush()
+            audit_snapshot = product.to_dict()
             session.commit()
             log_audit_operation('update_product', 'success', item_id=str(product_id),
-                                item_after=product.to_dict(),
+                                item_after=audit_snapshot,
                                 logger_name='mariadb_catalog_service')
             return True
         except Exception as e:

--- a/app/mariadb_catalog_service.py
+++ b/app/mariadb_catalog_service.py
@@ -1,0 +1,155 @@
+"""
+MariaDB Catalog Service
+
+Business logic for the product catalog (Products, and — in later epics —
+identifiers, scan resolution, search, capture, derived stock signals). All
+catalog queries and mutations go through this service (AD-2); routes contain no
+ORM/SQL and build the HTTP response themselves.
+
+Story 1.3 introduces the create / read / update surface for Products. Later
+stories extend this class (internal_id generation, scan resolution,
+search_products, capture, derived signals).
+"""
+
+from typing import Optional
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine
+
+from .database import Product
+from .mariadb_storage import MariaDBStorage
+from .exceptions import ValidationError
+from config import Config
+
+
+# Product fields the create/update surface accepts (Story 1.3 scope: FR2 minus
+# internal_id/stock/equivalence, which arrive in later epics).
+_PRODUCT_FIELDS = (
+    'manufacturer', 'mpn', 'description', 'notes', 'category_path', 'attributes',
+)
+
+
+def _clean(value):
+    """Trim strings and coerce blank strings to None (backfill-forward: absent
+    optional fields must store NULL, not '')."""
+    if isinstance(value, str):
+        value = value.strip()
+        return value or None
+    return value
+
+
+class CatalogService:
+    """Service for managing catalog Products through the MariaDB backend."""
+
+    def __init__(self, storage: MariaDBStorage = None):
+        """Initialize with MariaDB storage."""
+        if storage is None:
+            storage = MariaDBStorage()
+
+        self.storage = storage
+
+        # Direct database access for queries (same pattern as InventoryService).
+        self.engine = getattr(storage, 'engine', None) or self._create_engine()
+        self.Session = sessionmaker(bind=self.engine)
+
+    def _create_engine(self):
+        """Create database engine if not provided by storage."""
+        return create_engine(
+            Config.SQLALCHEMY_DATABASE_URI,
+            **Config.SQLALCHEMY_ENGINE_OPTIONS
+        )
+
+    def get_product(self, product_id: int) -> Optional[Product]:
+        """
+        Return the Product with the given surrogate id, or None if not found.
+
+        This is a read-only query (no commit), so the returned detached ORM
+        object's scalar columns stay readable after the session closes. Do not
+        access relationship attributes (e.g. .purchases) on the result — that
+        would lazy-load on a detached instance (Story 1.4 concern).
+        """
+        try:
+            session = self.Session()
+            return session.query(Product).filter(Product.id == product_id).first()
+        except Exception as e:
+            from .logging_config import log_audit_operation
+            log_audit_operation('get_product', 'error', item_id=str(product_id),
+                                error_details=str(e), logger_name='mariadb_catalog_service')
+            return None
+        finally:
+            if 'session' in locals():
+                session.close()
+
+    def create_product(self, *, manufacturer=None, mpn=None, description=None,
+                        notes=None, category_path=None, attributes=None) -> Optional[int]:
+        """
+        Create a Product and return its new integer id, or None on failure.
+
+        Every field is optional except the caller's own required-field policy
+        (the route requires a Label Description); blank strings are coerced to
+        NULL. Returns the id (captured before the session closes) rather than
+        the ORM object to avoid detached-attribute access downstream.
+        """
+        from .logging_config import log_audit_operation
+        try:
+            session = self.Session()
+            product = Product(
+                manufacturer=_clean(manufacturer),
+                mpn=_clean(mpn),
+                description=_clean(description),
+                notes=_clean(notes),
+                category_path=_clean(category_path),
+                attributes=attributes,
+            )
+            session.add(product)
+            session.commit()
+            new_id = product.id
+            log_audit_operation('create_product', 'success', item_id=str(new_id),
+                                item_after=product.to_dict(),
+                                logger_name='mariadb_catalog_service')
+            return new_id
+        except Exception as e:
+            if 'session' in locals():
+                session.rollback()
+            log_audit_operation('create_product', 'error',
+                                error_details=str(e), logger_name='mariadb_catalog_service')
+            return None
+        finally:
+            if 'session' in locals():
+                session.close()
+
+    def update_product(self, product_id: int, **fields) -> bool:
+        """
+        Update the given Product's fields. Returns True on success, False if the
+        product does not exist or the update fails. Only recognized product
+        fields are applied; blank strings become NULL. `updated_at` is bumped
+        automatically by the model's onupdate.
+        """
+        from .logging_config import log_audit_operation
+        try:
+            session = self.Session()
+            product = session.query(Product).filter(Product.id == product_id).first()
+            if product is None:
+                log_audit_operation('update_product', 'error', item_id=str(product_id),
+                                    error_details='Product not found',
+                                    logger_name='mariadb_catalog_service')
+                return False
+
+            for key, value in fields.items():
+                if key not in _PRODUCT_FIELDS:
+                    continue
+                setattr(product, key, value if key == 'attributes' else _clean(value))
+
+            session.commit()
+            log_audit_operation('update_product', 'success', item_id=str(product_id),
+                                item_after=product.to_dict(),
+                                logger_name='mariadb_catalog_service')
+            return True
+        except Exception as e:
+            if 'session' in locals():
+                session.rollback()
+            log_audit_operation('update_product', 'error', item_id=str(product_id),
+                                error_details=str(e), logger_name='mariadb_catalog_service')
+            return False
+        finally:
+            if 'session' in locals():
+                session.close()

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -54,6 +54,14 @@
                             <li><a class="dropdown-item" href="{{ url_for('main.inventory_shorten') }}"><i class="bi bi-scissors"></i> Shorten Items</a></li>
                         </ul>
                     </li>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+                            <i class="bi bi-upc-scan"></i> Products
+                        </a>
+                        <ul class="dropdown-menu">
+                            <li><a class="dropdown-item" href="{{ url_for('main.product_add') }}"><i class="bi bi-plus-circle"></i> Add Product</a></li>
+                        </ul>
+                    </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('admin.materials_overview') }}">
                             <i class="bi bi-gear-fill"></i> Admin

--- a/app/templates/product/add.html
+++ b/app/templates/product/add.html
@@ -18,7 +18,7 @@
                             <label for="description" class="form-label">Label Description *</label>
                             <input type="text"
                                    class="form-control{% if validation_errors and validation_errors.description %} is-invalid{% endif %}"
-                                   id="description" name="description"
+                                   id="description" name="description" maxlength="255"
                                    value="{{ form_data.get('description', '') }}" required autocomplete="off">
                             <div class="invalid-feedback{% if validation_errors and validation_errors.description %} d-block{% endif %}">
                                 {% if validation_errors and validation_errors.description %}{{ validation_errors.description }}{% else %}A Label Description is required.{% endif %}
@@ -28,21 +28,24 @@
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="manufacturer" class="form-label">Manufacturer</label>
-                            <input type="text" class="form-control" id="manufacturer" name="manufacturer"
+                            <input type="text" class="form-control{% if validation_errors and validation_errors.manufacturer %} is-invalid{% endif %}" id="manufacturer" name="manufacturer" maxlength="255"
                                    value="{{ form_data.get('manufacturer', '') }}" autocomplete="off">
+                            {% if validation_errors and validation_errors.manufacturer %}<div class="invalid-feedback d-block">{{ validation_errors.manufacturer }}</div>{% endif %}
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="mpn" class="form-label">Manufacturer Part Number (MPN)</label>
-                            <input type="text" class="form-control" id="mpn" name="mpn"
+                            <input type="text" class="form-control{% if validation_errors and validation_errors.mpn %} is-invalid{% endif %}" id="mpn" name="mpn" maxlength="255"
                                    value="{{ form_data.get('mpn', '') }}" autocomplete="off">
+                            {% if validation_errors and validation_errors.mpn %}<div class="invalid-feedback d-block">{{ validation_errors.mpn }}</div>{% endif %}
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-md-12 mb-3">
                             <label for="category_path" class="form-label">Category</label>
-                            <input type="text" class="form-control" id="category_path" name="category_path"
+                            <input type="text" class="form-control{% if validation_errors and validation_errors.category_path %} is-invalid{% endif %}" id="category_path" name="category_path" maxlength="512"
                                    value="{{ form_data.get('category_path', '') }}" autocomplete="off"
                                    placeholder="e.g. electronics/power/regulators">
+                            {% if validation_errors and validation_errors.category_path %}<div class="invalid-feedback d-block">{{ validation_errors.category_path }}</div>{% endif %}
                         </div>
                     </div>
                     <div class="row">

--- a/app/templates/product/add.html
+++ b/app/templates/product/add.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="row">
+    <div class="col-lg-8">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h1 class="h3 mb-0"><i class="bi bi-plus-circle"></i> Add Product</h1>
+        </div>
+
+        <form method="POST" novalidate>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+            <div class="card mb-3">
+                <div class="card-header">Product Information</div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-12 mb-3">
+                            <label for="description" class="form-label">Label Description *</label>
+                            <input type="text"
+                                   class="form-control{% if validation_errors and validation_errors.description %} is-invalid{% endif %}"
+                                   id="description" name="description"
+                                   value="{{ form_data.get('description', '') }}" required autocomplete="off">
+                            <div class="invalid-feedback{% if validation_errors and validation_errors.description %} d-block{% endif %}">
+                                {% if validation_errors and validation_errors.description %}{{ validation_errors.description }}{% else %}A Label Description is required.{% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="manufacturer" class="form-label">Manufacturer</label>
+                            <input type="text" class="form-control" id="manufacturer" name="manufacturer"
+                                   value="{{ form_data.get('manufacturer', '') }}" autocomplete="off">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="mpn" class="form-label">Manufacturer Part Number (MPN)</label>
+                            <input type="text" class="form-control" id="mpn" name="mpn"
+                                   value="{{ form_data.get('mpn', '') }}" autocomplete="off">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12 mb-3">
+                            <label for="category_path" class="form-label">Category</label>
+                            <input type="text" class="form-control" id="category_path" name="category_path"
+                                   value="{{ form_data.get('category_path', '') }}" autocomplete="off"
+                                   placeholder="e.g. electronics/power/regulators">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12 mb-3">
+                            <label for="notes" class="form-label">Notes</label>
+                            <textarea class="form-control" id="notes" name="notes" rows="3">{{ form_data.get('notes', '') }}</textarea>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="d-flex justify-content-between align-items-center mt-4 pt-3 border-top">
+                <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary">
+                    <i class="bi bi-x-circle"></i> Cancel
+                </a>
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-check-circle"></i> Add Product
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/product/detail.html
+++ b/app/templates/product/detail.html
@@ -32,7 +32,8 @@
             </div>
         </div>
 
-        {% if product.attributes %}
+        {# `is mapping` guards against non-dict JSON (list/scalar) stored in the column #}
+        {% if product.attributes is mapping and product.attributes %}
         <div class="card mb-3">
             <div class="card-header">Specifications</div>
             <div class="card-body">

--- a/app/templates/product/detail.html
+++ b/app/templates/product/detail.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="row">
+    <div class="col-lg-8">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h1 class="h3 mb-0">{{ product.description or 'Product' }}</h1>
+            <a href="{{ url_for('main.product_edit', product_id=product.id) }}" class="btn btn-outline-primary">
+                <i class="bi bi-pencil"></i> Edit
+            </a>
+        </div>
+
+        <div class="card mb-3">
+            <div class="card-header">Product Information</div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-sm-3">Label Description</dt>
+                    <dd class="col-sm-9">{{ product.description or '—' }}</dd>
+
+                    <dt class="col-sm-3">Manufacturer</dt>
+                    <dd class="col-sm-9">{{ product.manufacturer or '—' }}</dd>
+
+                    <dt class="col-sm-3">MPN</dt>
+                    <dd class="col-sm-9">{{ product.mpn or '—' }}</dd>
+
+                    <dt class="col-sm-3">Category</dt>
+                    <dd class="col-sm-9">{{ product.category_path or '—' }}</dd>
+
+                    <dt class="col-sm-3">Notes</dt>
+                    <dd class="col-sm-9">{{ product.notes or '—' }}</dd>
+                </dl>
+            </div>
+        </div>
+
+        {% if product.attributes %}
+        <div class="card mb-3">
+            <div class="card-header">Specifications</div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    {% for key, value in product.attributes.items() %}
+                    <dt class="col-sm-3">{{ key }}</dt>
+                    <dd class="col-sm-9">{{ value }}</dd>
+                    {% endfor %}
+                </dl>
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="text-muted small">
+            {% if product.created_at %}<div>Created: {{ product.created_at.strftime('%Y-%m-%d %H:%M') }}</div>{% endif %}
+            {% if product.updated_at %}<div>Updated: {{ product.updated_at.strftime('%Y-%m-%d %H:%M') }}</div>{% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/product/edit.html
+++ b/app/templates/product/edit.html
@@ -18,8 +18,8 @@
                             <label for="description" class="form-label">Label Description *</label>
                             <input type="text"
                                    class="form-control{% if validation_errors and validation_errors.description %} is-invalid{% endif %}"
-                                   id="description" name="description"
-                                   value="{{ product.description or '' }}" required autocomplete="off">
+                                   id="description" name="description" maxlength="255"
+                                   value="{{ form_data.get('description', '') }}" required autocomplete="off">
                             <div class="invalid-feedback{% if validation_errors and validation_errors.description %} d-block{% endif %}">
                                 {% if validation_errors and validation_errors.description %}{{ validation_errors.description }}{% else %}A Label Description is required.{% endif %}
                             </div>
@@ -28,27 +28,30 @@
                     <div class="row">
                         <div class="col-md-6 mb-3">
                             <label for="manufacturer" class="form-label">Manufacturer</label>
-                            <input type="text" class="form-control" id="manufacturer" name="manufacturer"
-                                   value="{{ product.manufacturer or '' }}" autocomplete="off">
+                            <input type="text" class="form-control{% if validation_errors and validation_errors.manufacturer %} is-invalid{% endif %}" id="manufacturer" name="manufacturer" maxlength="255"
+                                   value="{{ form_data.get('manufacturer', '') }}" autocomplete="off">
+                            {% if validation_errors and validation_errors.manufacturer %}<div class="invalid-feedback d-block">{{ validation_errors.manufacturer }}</div>{% endif %}
                         </div>
                         <div class="col-md-6 mb-3">
                             <label for="mpn" class="form-label">Manufacturer Part Number (MPN)</label>
-                            <input type="text" class="form-control" id="mpn" name="mpn"
-                                   value="{{ product.mpn or '' }}" autocomplete="off">
+                            <input type="text" class="form-control{% if validation_errors and validation_errors.mpn %} is-invalid{% endif %}" id="mpn" name="mpn" maxlength="255"
+                                   value="{{ form_data.get('mpn', '') }}" autocomplete="off">
+                            {% if validation_errors and validation_errors.mpn %}<div class="invalid-feedback d-block">{{ validation_errors.mpn }}</div>{% endif %}
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-md-12 mb-3">
                             <label for="category_path" class="form-label">Category</label>
-                            <input type="text" class="form-control" id="category_path" name="category_path"
-                                   value="{{ product.category_path or '' }}" autocomplete="off"
+                            <input type="text" class="form-control{% if validation_errors and validation_errors.category_path %} is-invalid{% endif %}" id="category_path" name="category_path" maxlength="512"
+                                   value="{{ form_data.get('category_path', '') }}" autocomplete="off"
                                    placeholder="e.g. electronics/power/regulators">
+                            {% if validation_errors and validation_errors.category_path %}<div class="invalid-feedback d-block">{{ validation_errors.category_path }}</div>{% endif %}
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-md-12 mb-3">
                             <label for="notes" class="form-label">Notes</label>
-                            <textarea class="form-control" id="notes" name="notes" rows="3">{{ product.notes or '' }}</textarea>
+                            <textarea class="form-control" id="notes" name="notes" rows="3">{{ form_data.get('notes', '') }}</textarea>
                         </div>
                     </div>
                 </div>

--- a/app/templates/product/edit.html
+++ b/app/templates/product/edit.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="row">
+    <div class="col-lg-8">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h1 class="h3 mb-0"><i class="bi bi-pencil"></i> Edit Product</h1>
+        </div>
+
+        <form method="POST" novalidate>
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+            <div class="card mb-3">
+                <div class="card-header">Product Information</div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-12 mb-3">
+                            <label for="description" class="form-label">Label Description *</label>
+                            <input type="text"
+                                   class="form-control{% if validation_errors and validation_errors.description %} is-invalid{% endif %}"
+                                   id="description" name="description"
+                                   value="{{ product.description or '' }}" required autocomplete="off">
+                            <div class="invalid-feedback{% if validation_errors and validation_errors.description %} d-block{% endif %}">
+                                {% if validation_errors and validation_errors.description %}{{ validation_errors.description }}{% else %}A Label Description is required.{% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="manufacturer" class="form-label">Manufacturer</label>
+                            <input type="text" class="form-control" id="manufacturer" name="manufacturer"
+                                   value="{{ product.manufacturer or '' }}" autocomplete="off">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="mpn" class="form-label">Manufacturer Part Number (MPN)</label>
+                            <input type="text" class="form-control" id="mpn" name="mpn"
+                                   value="{{ product.mpn or '' }}" autocomplete="off">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12 mb-3">
+                            <label for="category_path" class="form-label">Category</label>
+                            <input type="text" class="form-control" id="category_path" name="category_path"
+                                   value="{{ product.category_path or '' }}" autocomplete="off"
+                                   placeholder="e.g. electronics/power/regulators">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12 mb-3">
+                            <label for="notes" class="form-label">Notes</label>
+                            <textarea class="form-control" id="notes" name="notes" rows="3">{{ product.notes or '' }}</textarea>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="d-flex justify-content-between align-items-center mt-4 pt-3 border-top">
+                <a href="{{ url_for('main.product_detail', product_id=product.id) }}" class="btn btn-outline-secondary">
+                    <i class="bi bi-arrow-left"></i> Cancel
+                </a>
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-check-circle"></i> Update Product
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/tests/unit/test_catalog_service.py
+++ b/tests/unit/test_catalog_service.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for CatalogService (catalog subsystem, Story 1.3).
+
+Exercises product create / get / update via the SQLite test engine
+(the `test_storage` fixture). Mirrors the InventoryService test approach.
+"""
+
+import pytest
+
+from app.mariadb_catalog_service import CatalogService
+
+
+@pytest.fixture
+def catalog_service(test_storage):
+    return CatalogService(test_storage)
+
+
+class TestCatalogServiceCreate:
+
+    @pytest.mark.unit
+    def test_create_with_only_description(self, catalog_service):
+        """A Product created with only a Label Description saves; other fields NULL."""
+        new_id = catalog_service.create_product(description='LM317 regulator')
+        assert isinstance(new_id, int)
+
+        product = catalog_service.get_product(new_id)
+        assert product is not None
+        assert product.description == 'LM317 regulator'
+        assert product.manufacturer is None
+        assert product.mpn is None
+        assert product.category_path is None
+        assert product.notes is None
+        assert product.attributes is None
+
+    @pytest.mark.unit
+    def test_create_with_all_fields(self, catalog_service):
+        new_id = catalog_service.create_product(
+            manufacturer='TI',
+            mpn='LM317T',
+            description='LM317 adjustable regulator',
+            notes='reel of these',
+            category_path='electronics/power/regulators',
+        )
+        product = catalog_service.get_product(new_id)
+        assert product.manufacturer == 'TI'
+        assert product.mpn == 'LM317T'
+        assert product.description == 'LM317 adjustable regulator'
+        assert product.notes == 'reel of these'
+        assert product.category_path == 'electronics/power/regulators'
+
+    @pytest.mark.unit
+    def test_blank_optional_fields_coerced_to_none(self, catalog_service):
+        """Empty-string optional fields are stored as NULL, not ''."""
+        new_id = catalog_service.create_product(
+            description='  Widget  ',
+            manufacturer='',
+            mpn='   ',
+            category_path='',
+            notes='',
+        )
+        product = catalog_service.get_product(new_id)
+        assert product.description == 'Widget'  # trimmed
+        assert product.manufacturer is None
+        assert product.mpn is None
+        assert product.category_path is None
+        assert product.notes is None
+
+
+class TestCatalogServiceGet:
+
+    @pytest.mark.unit
+    def test_get_missing_returns_none(self, catalog_service):
+        assert catalog_service.get_product(999999) is None
+
+
+class TestCatalogServiceUpdate:
+
+    @pytest.mark.unit
+    def test_update_changes_persist(self, catalog_service):
+        new_id = catalog_service.create_product(description='original')
+        before = catalog_service.get_product(new_id)
+        before_updated = before.updated_at
+
+        ok = catalog_service.update_product(new_id, description='changed', manufacturer='Bourns')
+        assert ok is True
+
+        after = catalog_service.get_product(new_id)
+        assert after.description == 'changed'
+        assert after.manufacturer == 'Bourns'
+        # updated_at should have advanced (or at least not regressed)
+        assert after.updated_at >= before_updated
+
+    @pytest.mark.unit
+    def test_update_missing_returns_false(self, catalog_service):
+        assert catalog_service.update_product(999999, description='nope') is False
+
+    @pytest.mark.unit
+    def test_update_blank_optional_coerced_to_none(self, catalog_service):
+        new_id = catalog_service.create_product(description='keep', manufacturer='TI')
+        catalog_service.update_product(new_id, manufacturer='')
+        product = catalog_service.get_product(new_id)
+        assert product.manufacturer is None

--- a/tests/unit/test_catalog_service.py
+++ b/tests/unit/test_catalog_service.py
@@ -77,9 +77,23 @@ class TestCatalogServiceUpdate:
 
     @pytest.mark.unit
     def test_update_changes_persist(self, catalog_service):
+        from datetime import datetime
+        from sqlalchemy.orm import sessionmaker
+        from app.database import Product
+
         new_id = catalog_service.create_product(description='original')
-        before = catalog_service.get_product(new_id)
-        before_updated = before.updated_at
+
+        # Backdate updated_at so the onupdate bump is observable (func.now()
+        # has second resolution — asserting >= creation time is tautological).
+        backdated = datetime(2020, 1, 1, 12, 0, 0)
+        Session = sessionmaker(bind=catalog_service.engine)
+        session = Session()
+        try:
+            session.query(Product).filter(Product.id == new_id).update(
+                {'updated_at': backdated}, synchronize_session=False)
+            session.commit()
+        finally:
+            session.close()
 
         ok = catalog_service.update_product(new_id, description='changed', manufacturer='Bourns')
         assert ok is True
@@ -87,8 +101,8 @@ class TestCatalogServiceUpdate:
         after = catalog_service.get_product(new_id)
         assert after.description == 'changed'
         assert after.manufacturer == 'Bourns'
-        # updated_at should have advanced (or at least not regressed)
-        assert after.updated_at >= before_updated
+        # onupdate must have replaced the backdated timestamp
+        assert after.updated_at > backdated
 
     @pytest.mark.unit
     def test_update_missing_returns_false(self, catalog_service):

--- a/tests/unit/test_product_routes.py
+++ b/tests/unit/test_product_routes.py
@@ -38,11 +38,18 @@ class TestProductRoutes:
         assert product.manufacturer is None
 
     def test_create_blank_description_rerenders_with_error(self, client, test_storage):
-        resp = client.post('/products/add', data={'description': '   '})
+        resp = client.post('/products/add', data={'description': '   ',
+                                                  'manufacturer': 'KeepMe'})
         assert resp.status_code == 200  # re-rendered form, not a redirect
-        assert b'Add Product' in resp.data
-        # nothing created
-        # (no product with id 1 should exist)
+        assert b'Label Description is required.' in resp.data
+        assert b'KeepMe' in resp.data  # typed input preserved on re-render
+        # nothing created (no product with id 1 should exist)
+        assert CatalogService(test_storage).get_product(1) is None
+
+    def test_create_overlong_field_rerenders_with_error(self, client, test_storage):
+        resp = client.post('/products/add', data={'description': 'x' * 300})
+        assert resp.status_code == 200
+        assert b'must be 255 characters or fewer' in resp.data
         assert CatalogService(test_storage).get_product(1) is None
 
     def test_detail_missing_is_404(self, client):
@@ -79,8 +86,21 @@ class TestProductRoutes:
 
     def test_edit_blank_description_rerenders(self, client, test_storage):
         pid = self._make_product(test_storage, description='keep me')
-        resp = client.post(f'/products/edit/{pid}', data={'description': ''})
+        resp = client.post(f'/products/edit/{pid}',
+                           data={'description': '', 'manufacturer': 'TypedNotSaved'})
         assert resp.status_code == 200
-        # unchanged
+        assert b'Label Description is required.' in resp.data
+        # the user's in-flight edits survive the error re-render...
+        assert b'TypedNotSaved' in resp.data
+        # ...but nothing was written to the database
         product = CatalogService(test_storage).get_product(pid)
         assert product.description == 'keep me'
+        assert product.manufacturer is None
+
+    def test_edit_omitted_field_left_unchanged(self, client, test_storage):
+        """A POST body missing a field must not null the stored value."""
+        pid = self._make_product(test_storage, description='thing', manufacturer='TI')
+        resp = client.post(f'/products/edit/{pid}', data={'description': 'thing'})
+        assert resp.status_code == 302
+        product = CatalogService(test_storage).get_product(pid)
+        assert product.manufacturer == 'TI'  # absent key != clear

--- a/tests/unit/test_product_routes.py
+++ b/tests/unit/test_product_routes.py
@@ -1,0 +1,86 @@
+"""
+Route/integration tests for the Product create/edit/detail pages (Story 1.3).
+
+Uses the `client` fixture (CSRF disabled in TestConfig, so POSTs need no token).
+"""
+
+import pytest
+
+from app.mariadb_catalog_service import CatalogService
+
+
+@pytest.mark.unit
+class TestProductRoutes:
+
+    def _make_product(self, test_storage, **kwargs):
+        kwargs.setdefault('description', 'Seed product')
+        return CatalogService(test_storage).create_product(**kwargs)
+
+    def test_add_form_renders(self, client):
+        resp = client.get('/products/add')
+        assert resp.status_code == 200
+        assert b'Add Product' in resp.data
+
+    def test_create_with_only_description_redirects_to_detail(self, client, test_storage):
+        resp = client.post('/products/add', data={'description': 'LM317 regulator'})
+        assert resp.status_code == 302
+        assert '/products/' in resp.headers['Location']
+
+        # follow to the detail page
+        detail = client.get(resp.headers['Location'])
+        assert detail.status_code == 200
+        assert b'LM317 regulator' in detail.data
+
+        # persisted with other fields empty
+        product_id = int(resp.headers['Location'].rstrip('/').split('/')[-1])
+        product = CatalogService(test_storage).get_product(product_id)
+        assert product.description == 'LM317 regulator'
+        assert product.manufacturer is None
+
+    def test_create_blank_description_rerenders_with_error(self, client, test_storage):
+        resp = client.post('/products/add', data={'description': '   '})
+        assert resp.status_code == 200  # re-rendered form, not a redirect
+        assert b'Add Product' in resp.data
+        # nothing created
+        # (no product with id 1 should exist)
+        assert CatalogService(test_storage).get_product(1) is None
+
+    def test_detail_missing_is_404(self, client):
+        resp = client.get('/products/999999')
+        assert resp.status_code == 404
+
+    def test_detail_renders_fields(self, client, test_storage):
+        pid = self._make_product(test_storage, description='Trimmer pot',
+                                 manufacturer='Bourns', mpn='3386P')
+        resp = client.get(f'/products/{pid}')
+        assert resp.status_code == 200
+        assert b'Trimmer pot' in resp.data
+        assert b'Bourns' in resp.data
+        assert b'3386P' in resp.data
+
+    def test_edit_form_prefilled(self, client, test_storage):
+        pid = self._make_product(test_storage, description='Editable', manufacturer='TI')
+        resp = client.get(f'/products/edit/{pid}')
+        assert resp.status_code == 200
+        assert b'Editable' in resp.data
+        assert b'TI' in resp.data
+
+    def test_edit_missing_is_404(self, client):
+        assert client.get('/products/edit/999999').status_code == 404
+
+    def test_edit_persists_change(self, client, test_storage):
+        pid = self._make_product(test_storage, description='before')
+        resp = client.post(f'/products/edit/{pid}', data={'description': 'after'})
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/products/{pid}')
+
+        product = CatalogService(test_storage).get_product(pid)
+        assert product.description == 'after'
+
+    def test_edit_blank_description_rerenders(self, client, test_storage):
+        pid = self._make_product(test_storage, description='keep me')
+        resp = client.post(f'/products/edit/{pid}', data={'description': ''})
+        assert resp.status_code == 200
+        # unchanged
+        product = CatalogService(test_storage).get_product(pid)
+        assert product.description == 'keep me'


### PR DESCRIPTION
## Story 1.3 — Product create/edit/detail

Third story of the **Product Catalog & Purchase Tracking** enhancement (Epic 1), and the first to add a catalog **service, routes, and templates**. Delivers browser-based create / edit / detail for Products on the existing Bootstrap UI.

### What's included
- **`app/mariadb_catalog_service.py` (`CatalogService`)** — mirrors `MariaDBMaterialsAdminService`/`InventoryService` (ctor binding a `sessionmaker` to `storage.engine`, per-method `try`/`except`-rollback/`finally`-close, `log_audit_operation` on mutations, returns id/object/bool — not `StorageResult`). Methods: `create_product` → new id, `get_product` → ORM object or `None`, `update_product` → bool. Blank inputs coerced to `NULL` (FR3/FR4/FR61).
- **Routes** in `app/main/routes.py` (main blueprint, CSRF-protected HTML forms): `GET/POST /products/add`, `GET /products/<int:id>` (direct-URL detail, FR6), `GET/POST /products/edit/<int:id>`, plus a `_get_catalog_service()` helper. Only **Label Description** is required; create/edit redirect to the detail page.
- **Templates** `app/templates/product/{add,edit,detail}.html` + a "Products" navbar dropdown in `base.html`.
- **16 tests**: `tests/unit/test_catalog_service.py` (7) + `tests/unit/test_product_routes.py` (9).

### Key decisions
- **No schema change** — the `products` table already exists (Story 1.1). Pure app-layer.
- **Detail keyed on the integer PK** (`/products/<int:id>`) — `internal_id` doesn't exist until Epic 2; `internal_id`-keyed URLs are Epic 8.
- **Server-rendered forms** with `{{ csrf_token() }}` (not `@csrf.exempt`) — the JSON/REST create path is Epic 7.

### Scope deferred by design
Product list/browse/**search** (Epic 8), Specifications (`attributes`) editor, category normalization + autocomplete-with-create (Epic 3), enrichment hook on create (Story 7.5), purchase history/"Last paid"/attachments (Stories 1.4/1.5), tags (Epic 3).

### Verification
- Route/integration tests drive create→detail→edit end-to-end through the real Jinja templates via the Flask `client` fixture (which also renders the new nav on every page).
- **Full unit suite: 383 passed** (367 baseline + 16 new), no regressions (NFR9).

### Acceptance criteria
- [x] AC1/AC2: create with only a Label Description; all other fields optional/empty (FR3/FR4/FR61)
- [x] AC3: edit persists
- [x] AC4: detail reachable by direct URL `/products/<id>` (FR6)
- [x] AC5: all catalog logic in `CatalogService`; routes delegate; audit logging (AD-2)
- [x] AC6: metal-stock/inventory UI unchanged; suite green; service + route tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvNxyuJiBQvRUvrM1iaGHB