### PR TITLE
Story 1.4: Purchase recording and history

### DIFF
--- a/_bmad-output/implementation-artifacts/1-4-purchase-recording-and-history.md
+++ b/_bmad-output/implementation-artifacts/1-4-purchase-recording-and-history.md
@@ -1,0 +1,157 @@
+---
+baseline_commit: b28c9cdabcaa944a7105e6abe13aeb487f417f42
+---
+
+# Story 1.4: Purchase recording and history
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the workshop operator,
+I want to record purchases against a Product and see their history,
+so that I can tell what I paid and where, over time.
+
+## Acceptance Criteria
+
+1. **Given** a Product with three Purchases across two vendors, **When** I open the Product detail view (`/products/<id>`), **Then** all its Purchases list in chronological order showing date, vendor, and unit price (FR20).
+2. **And** the most recent prior unit price is shown in a labeled "Last paid" field (FR21).
+3. **Given** a JSON payload describing a purchase, **When** I POST it to `POST /api/products/<id>/purchases` (`@csrf.exempt`), **Then** a Purchase is created and attached to that Product and the response is `201` with `{success: true, purchase: {…}, product_url: …}` (FR18, FR22).
+4. **And** the endpoint returns the **fixed catalog error envelope** `{success: false, error: {code, message, field?}}` on failure — `404` when the Product does not exist, `400` on an invalid field — never a raw `500`/`IntegrityError` for those cases (AD-13, Conventions).
+5. **And** the endpoint has a matching `record_purchase(product_id, purchase)` method + a frozen `RecordPurchaseResult` dataclass in `app/api_client.py`, using only `requests` (AD-13, NFR10).
+6. **And** all purchase logic (history retrieval, last-paid, recording) lives in `CatalogService`; routes contain no ORM/SQL (AD-2). Existing behavior is unchanged (NFR9) and the full test suite passes with new service, route, and api_client tests.
+
+## Scope Boundary — READ FIRST
+
+This story adds **purchase-history display + "Last paid" on the product detail page** and a **basic REST endpoint to record a purchase against an existing Product** (FR22), plus its api_client mirror. It establishes the **first catalog JSON endpoint** and therefore the AD-13 request/response/error conventions the rest of the API inherits. No schema change (the `purchases` table exists from Story 1.2).
+
+| Concern | Owned by | In 1.4? |
+| --- | --- | --- |
+| Purchase-history table + "Last paid" on `/products/<id>` | **Story 1.4 (this)** | ✅ |
+| `POST /api/products/<id>/purchases` (attach to a known Product) + api_client method/dataclass | **Story 1.4 (this)** | ✅ |
+| **Manual browser "Add Purchase" form** | later (or Epic 7) | ❌ confirmed — recording in 1.4 is the REST/api_client path per the AC ("service/REST path"); no manual UI form this story |
+| `request_key` idempotency (same key → same record) | Epic 7 (7.4) | ❌ — 1.4's endpoint does not accept `request_key`; idempotent capture is Epic 7 |
+| De-dup / attach-to-existing by Vendor SKU or ASIN; ASIN confirm-not-merge; create-a-Product-if-no-match | Epic 7 (7.1, 7.2) | ❌ — 1.4 attaches only to the `<id>` in the URL |
+| Derived **On Order** / Recently Received signals (group-aware) | Epic 5 (5.4) / Epic 10 | ❌ — 1.4 shows `received_date` as a plain column; it does NOT compute the On-Order signal |
+| `order_date` "defaults to capture date when omitted" | convention seeded here | ✅ — `record_purchase` defaults a missing `order_date` to today (Epic 7 reuses it) |
+| "Last paid" group-awareness across Equivalent Products | Epic 10 | ❌ — 1.4 is per-Product |
+| Enrichment hook on the record path | Epic 7 (7.5) | ❌ |
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — Extend `CatalogService` with purchase methods (AC: #1, #2, #3, #6)**
+  - [x] Added `List`/`date`/`Decimal` imports and `Purchase` to the `.database` import.
+  - [x] `get_purchases_for_product` — dedicated query ordered `order_date.asc(), id.asc()`; returns `[]` for unknown product; never touches `product.purchases`.
+  - [x] `get_last_paid_price` — most recent priced purchase (`unit_price.isnot(None)`, `order_date.desc(), id.desc()`), else `None`.
+  - [x] `record_purchase(...) -> Optional[dict]` — verifies product exists (`None` if not), defaults `order_date` to today, cleans text fields, flush→snapshot→commit, returns the `to_dict()` snapshot; audit on success/error; no `request_key`.
+  - [x] Established session lifecycle + flush-before-commit snapshot pattern reused.
+
+- [x] **Task 2 — Purchase history + "Last paid" on the product detail page (AC: #1, #2)**
+  - [x] `product_detail` now fetches `purchases` + `last_paid` (dedicated queries) and passes them; 404 guard preserved.
+  - [x] `detail.html` "Purchases" card: "Last paid" (null-safe currency), chronological table (Order Date / Vendor / Unit Price / plain Received), empty-state "No purchases recorded.". Received shows the stored date only — no derived On-Order label.
+  - [x] All currency/date cells null-safe.
+
+- [x] **Task 3 — REST endpoint `POST /api/products/<int:product_id>/purchases` (AC: #3, #4, #6)**
+  - [x] `@bp.route(...)` + `@csrf.exempt`; body via `request.get_json(silent=True) or {}`.
+  - [x] Added `_catalog_json_error(code, message, status, field=None)` — the AD-13 **object** envelope helper (reused by future catalog routes).
+  - [x] 404 (`not_found`) when product missing; boundary parsing → 400 with `error.field` for bad `unit_price`/`quantity`/`order_date`/`received_date`; typed values passed to `record_purchase`.
+  - [x] Success → 201 `{success, purchase: <snapshot>, product_url}`; `None`/exception → 500 `server_error`. No template/flash/redirect.
+
+- [x] **Task 4 — `api_client.py` mirror (AC: #5)**
+  - [x] Added frozen `RecordPurchaseResult` (`purchase: dict|None` + trailing trio + `message` property that reads the object envelope) and registered it in `__all__`.
+  - [x] Added `record_purchase(product_id, purchase)` mirroring `upload_photo` (path-param POST, `timeout`, HTTP≥400 → not success).
+  - [x] Error extraction handles the object envelope (`error.message`/`code`/`field`) and falls back to `_safe_json`'s string form; `requests`-only, no new imports.
+
+- [x] **Task 5 — Tests (AC: #1–#6)**
+  - [x] `test_catalog_service.py` — +7 (record/attach, order-date default, missing→None, chronological order, empty, last-paid most-recent-priced/skip-null, none-when-unpriced).
+  - [x] `test_product_routes.py` — +5 (detail history+last-paid, empty-state, POST 201+persist, 404 object envelope, 400 field).
+  - [x] `test_api_client.py` — +3 (success URL/json/timeout, object-error message surfaced, non-JSON error).
+  - [x] `venv/bin/nox -s tests` → **400 passed** (385 baseline + 15 new), 0 failures, no regressions. No MariaDB container needed.
+
+## Dev Notes
+
+### The live "detached relationship" hazard (flagged in 1.3, now real)
+`get_product` returns a **detached** `Product` (session closed, no commit). Its docstring explicitly warns: *do not access `.purchases`* — a relationship lazy-load on a detached instance raises `DetachedInstanceError`. Story 1.4 therefore loads purchases with a **dedicated query** (`get_purchases_for_product`), never via `product.purchases`. This is the whole reason the method exists. (Story 1.2 wired the `Product.purchases` ↔ `Purchase.product` relationship, but it's for in-session use, not detached template rendering.)
+
+### The AD-13 error envelope — this story sets the precedent
+This is the **first catalog JSON endpoint**. Two things diverge from the legacy inventory JSON routes, and every future catalog route (Epic 7 especially) inherits what you establish here:
+- **Success:** `{success: true, …}` + explicit HTTP status; body read via `request.get_json(silent=True) or {}`.
+- **Errors:** the **object** envelope `{success: false, error: {code: str, message: str, field?: str}}`. Legacy routes (`api_create_items`, etc.) return `error` as a **plain string** — do NOT copy that. `WorkshopInventoryError.code` (`app/exceptions.py`) maps into `error.code`; `ValidationError.field` into the optional `field`. Build it once via the `_catalog_json_error` helper so 7.1's capture endpoint reuses it verbatim.
+- Because the client sees `error` as a dict, `api_client.record_purchase` must read `body.get('error', {}).get('message')`, unlike `create_item`/`upload_photo` which read the legacy string `body.get('error')`. This is the single conscious mismatch with the existing client methods.
+
+### api_client (AD-13 / NFR10) — mirror `UploadPhotoResult` + `upload_photo`
+- `app/api_client.py` is **`requests`-only** (module docstring asserts it; only third-party import is `requests`). Add no dependencies. Register `RecordPurchaseResult` in `__all__`.
+- Result dataclasses are `@dataclass(frozen=True)` with the trailing trio `errors: list[dict]`, `http_status: int`, `raw: dict` + a leading `success: bool`, plus a `message` property. `UploadPhotoResult` (single created object + `photo: dict|None`) is the exact template — model `purchase: dict|None` on it.
+- `upload_photo` is the path-param POST template (`f'{base_url}/api/items/{ja_id}/photos'`, `json=…`, `timeout=self.timeout`; HTTP≥400 forces `success=False`). `_safe_json` is a shared static method — reuse as-is. `WorkshopInventoryClient.__init__(base_url, *, timeout=30.0, session=None)` — there is **no `auth` param**.
+
+### Service layer (AD-2) — extend the established `CatalogService`
+- Reuse the merged patterns: ctor/`sessionmaker`, per-method `try/except-rollback/finally-close`, flush-before-commit snapshot (`create_product`/`update_product`), `log_audit_operation(..., logger_name='mariadb_catalog_service')` (the logger is registered in `setup_logging` since the 1.3 review). Services return dict/list/`Optional[...]`/`bool` — never `StorageResult`.
+- Money is `Decimal` (`unit_price` is `Numeric(10,2)`); never `float`. `Purchase.to_dict()` (from 1.2) already serializes `unit_price` via `float()` at the JSON boundary and ISO-formats the dates — reuse it for the snapshot/response.
+- `order_date` default-to-today lives in `record_purchase` (the Dates convention). Do not add a DB default.
+
+### Routes (AD-2) — extend `product_detail`, add the JSON endpoint
+- `product_detail` currently: `get_product` → `abort(404)` → render. Add the two service reads and pass `purchases`/`last_paid`; keep the 404 guard. No ORM in the route.
+- The JSON endpoint is `@csrf.exempt` (JSON APIs only; browser forms stay CSRF-protected — the 1.3 product forms are unchanged). Reuse the existing `_get_catalog_service()` helper.
+- Parse/validate request types at the boundary (Decimal/int/date) and return 400 with `error.field`; keep parsing out of the service (the service takes typed values), mirroring how 1.3 validated in the route.
+
+### Previous story intelligence (Stories 1.1–1.3, all merged)
+- `created_at`/`updated_at` timestamp convention; flush-before-commit to avoid false-failure on post-commit refresh; `_clean()` blank→NULL; `session.expire_all()` (not `expunge_all`) when re-reading in a test; 1.3 code-review lessons already applied (input preservation, length validation, object-vs-string errors). Baseline suite: **385 passed** on `main`.
+- 1.3's review **deferred** the per-request engine/pool creation (systemic, shared with `InventoryService`) to `deferred-work.md` — do not try to fix it here; just don't make it worse (reuse `_get_catalog_service()`).
+
+### What this story must NOT break (NFR9)
+- Additive: new `CatalogService` methods, a modified `product_detail` + one new JSON route in `routes.py`, an extended `detail.html`, and new `api_client` symbols. Do not touch inventory routes/templates, `app/database.py`, `app/models.py`, or existing api_client methods.
+- No schema change, no migration, no dependency change.
+
+### Testing standards
+- `venv/bin/nox -s tests` (never bare pytest; `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"`). SQLite via `test_storage`, network blocked. Route tests: `create_app(TestConfig, storage_backend=test_storage)` + `client` (CSRF disabled in tests). api_client tests: `MagicMock(spec=requests.Session)`, assert `session.post.call_args` (URL/json/timeout) — never a live server. No MariaDB container needed (no schema/migration).
+
+### Project Structure Notes
+- Modified: `app/mariadb_catalog_service.py`, `app/main/routes.py`, `app/templates/product/detail.html`, `app/api_client.py`. New tests appended to `tests/unit/test_catalog_service.py`, `tests/unit/test_product_routes.py`, `tests/unit/test_api_client.py`. `app/database.py`/`app/models.py` unchanged. Matches the spine Structural Seed (`api_client.py + capture/product methods + frozen result dataclasses`; `main/routes.py + catalog JSON endpoints`).
+
+### References
+- [Source: epics.md#Story 1.4: Purchase recording and history] (AC, FR18/FR20/FR21/FR22)
+- [Source: ARCHITECTURE-SPINE.md#AD-13] (endpoint ↔ api_client method + frozen dataclass; `@csrf.exempt`; fixed error envelope) · [#AD-2] (service owns logic; per-method session lifecycle; audit) · [#AD-3] (`purchases.product_id` FK)
+- [Source: ARCHITECTURE-SPINE.md#Consistency Conventions] ("API success" and "API errors" rows — the exact success/`{code,message,field?}` envelopes; Money = Decimal; Dates = tolerant parse + `order_date` server-default)
+- [Source: 1-2-purchase-entity-and-migration.md] (`Purchase` columns, `to_dict()`, `Product.purchases`↔`Purchase.product`) · [1-3-product-create-edit-detail.md] (CatalogService/route/detail patterns; deferred engine item)
+- [Existing code: app/mariadb_catalog_service.py:60-161 (merged service — ctor, get_product detached-warning, flush-before-commit); app/api_client.py:46-58,84-96 (result dataclasses), :426-537 (`upload_photo` path-param POST), :538-561 (`_safe_json`), :108-117 (ctor, no auth); app/main/routes.py:464-548 (legacy `@csrf.exempt` JSON route — note its STRING error, to diverge from); app/exceptions.py:8-15 (`WorkshopInventoryError(message, code, details)`), :17-28 (`ValidationError.field`)]
+- [Existing code: app/templates/product/detail.html (extend), tests/unit/test_api_client.py:62-109 (session-mock idiom), tests/unit/test_routes.py:142-287 (client JSON-route idiom)]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8[1m] (Opus 4.8, 1M context) — bmad-dev-story workflow.
+
+### Debug Log References
+
+- No migration/schema change (pure app-layer). No MariaDB container run.
+- Route + api_client tests exercise the full JSON contract end-to-end (Flask `client` and mocked `requests.Session` respectively).
+
+### Completion Notes List
+
+- Added purchase history + "Last paid" to the product detail page, and the first catalog JSON endpoint (`POST /api/products/<id>/purchases`) with its `api_client` mirror.
+- **Detached-relationship hazard handled:** purchases are loaded with dedicated `CatalogService` queries (`get_purchases_for_product`, `get_last_paid_price`), never via `product.purchases` on the detached `Product` — the pitfall `get_product`'s docstring warned about since 1.2/1.3.
+- **AD-13 precedent set:** introduced `_catalog_json_error(code, message, status, field=None)` producing the OBJECT error envelope `{success:false, error:{code, message, field?}}` — distinct from the legacy inventory routes' string `error`. Epic 7's capture endpoint reuses this helper.
+- **api_client divergence handled:** `RecordPurchaseResult.message` and `record_purchase` read the object envelope (`error.message`) rather than the legacy string `body.get('error')`, while still degrading gracefully to `_safe_json`'s string fallback. `requests`-only (NFR10).
+- `order_date` defaults to today in `record_purchase` (server-side capture-date convention seeded here; Epic 7 reuses).
+- Scope honored: no manual browser add-purchase form (per Jason), no `request_key`/idempotency/de-dup/ASIN (Epic 7), no derived On-Order signal (Epic 5).
+- All 6 ACs satisfied; full suite **400 passed**; inventory UI/routes, `app/database.py`, `app/models.py`, and existing api_client methods unchanged (NFR9).
+
+### File List
+
+- `app/mariadb_catalog_service.py` (modified) — `get_purchases_for_product`, `get_last_paid_price`, `record_purchase`; `Purchase`/`List`/`date`/`Decimal` imports.
+- `app/main/routes.py` (modified) — `product_detail` fetches purchases/last_paid; new `api_record_purchase` JSON route; `_catalog_json_error` helper; `date` import.
+- `app/templates/product/detail.html` (modified) — Purchases card (history table + "Last paid" + empty-state).
+- `app/api_client.py` (modified) — `RecordPurchaseResult` dataclass + `record_purchase` method + `__all__` entry.
+- `tests/unit/test_catalog_service.py` (modified) — +7 purchase tests.
+- `tests/unit/test_product_routes.py` (modified) — +5 purchase/endpoint tests.
+- `tests/unit/test_api_client.py` (modified) — +3 `record_purchase` tests.
+- `_bmad-output/implementation-artifacts/1-4-purchase-recording-and-history.md`, `sprint-status.yaml` (modified) — tracking.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| 2026-07-24 | Story 1.4 implemented: purchase history + "Last paid" on the product detail page; `POST /api/products/<id>/purchases` (first catalog JSON endpoint, AD-13 object error envelope); `api_client.record_purchase` + `RecordPurchaseResult`; +15 tests. No schema change. Full suite green (400 passed). Status → review. |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -58,7 +58,7 @@ development_status:
   1-1-product-entity-and-migration: review
   1-2-purchase-entity-and-migration: review
   1-3-product-create-edit-detail: done
-  1-4-purchase-recording-and-history: backlog
+  1-4-purchase-recording-and-history: review
   1-5-attachments-on-product-or-purchase: backlog
   epic-1-retrospective: optional
 

--- a/app/api_client.py
+++ b/app/api_client.py
@@ -23,6 +23,7 @@ import requests
 __all__ = [
     'CreateItemResult',
     'FieldSuggestionsResult',
+    'RecordPurchaseResult',
     'SUGGESTABLE_FIELDS',
     'TaxonomyResult',
     'UploadPhotoResult',
@@ -94,6 +95,26 @@ class UploadPhotoResult:
     @property
     def message(self) -> str | None:
         return self.raw.get('message')
+
+
+@dataclass(frozen=True)
+class RecordPurchaseResult:
+    """Outcome of a ``record_purchase`` call."""
+
+    success: bool
+    purchase: dict[str, Any] | None
+    errors: list[dict[str, Any]]
+    http_status: int
+    raw: dict[str, Any]
+
+    @property
+    def message(self) -> str | None:
+        # Catalog routes use the AD-13 OBJECT error envelope
+        # ({error: {code, message, field?}}), unlike the legacy string form.
+        error = self.raw.get('error')
+        if isinstance(error, dict):
+            return error.get('message')
+        return error or self.raw.get('message')
 
 
 class WorkshopInventoryClient:
@@ -530,6 +551,53 @@ class WorkshopInventoryClient:
         return UploadPhotoResult(
             success=success,
             photo=body.get('photo') if isinstance(body.get('photo'), dict) else None,
+            errors=errors,
+            http_status=response.status_code,
+            raw=body,
+        )
+
+    def record_purchase(
+        self, product_id: int, purchase: dict[str, Any]
+    ) -> RecordPurchaseResult:
+        """Record a Purchase against an existing Product.
+
+        POSTs ``purchase`` (vendor, vendor_sku, order_date, received_date,
+        quantity, unit_price, order_number, source_url) to
+        ``/api/products/<product_id>/purchases`` and returns the outcome.
+        """
+        response = self.session.post(
+            f'{self.base_url}/api/products/{product_id}/purchases',
+            json=purchase,
+            timeout=self.timeout,
+        )
+        body = self._safe_json(response)
+
+        # HTTP error → never report success, regardless of body content.
+        if response.status_code >= 400:
+            success = False
+        else:
+            success = bool(body.get('success', False))
+
+        errors: list[dict[str, Any]] = []
+        if not success:
+            # Catalog routes use the AD-13 OBJECT error envelope; _safe_json's
+            # own fallback uses a string 'error'. Handle both.
+            error = body.get('error')
+            if isinstance(error, dict):
+                err_msg = error.get('message') or f'HTTP {response.status_code}'
+                entry: dict[str, Any] = {'index': 0, 'message': err_msg}
+                if error.get('code'):
+                    entry['code'] = error['code']
+                if error.get('field'):
+                    entry['field'] = error['field']
+            else:
+                err_msg = error or body.get('message') or f'HTTP {response.status_code}'
+                entry = {'index': 0, 'message': err_msg}
+            errors = [entry]
+
+        return RecordPurchaseResult(
+            success=success,
+            purchase=body.get('purchase') if isinstance(body.get('purchase'), dict) else None,
             errors=errors,
             http_status=response.status_code,
             raw=body,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,5 +1,5 @@
 from flask import render_template, current_app, jsonify, abort, request, flash, redirect, url_for, send_file
-from datetime import datetime
+from datetime import datetime, date
 from typing import Any
 from app.main import bp
 from app import csrf
@@ -815,14 +815,92 @@ def product_add():
 
 @bp.route('/products/<int:product_id>')
 def product_detail(product_id):
-    """View a Product by its direct URL (FR6)."""
+    """View a Product by its direct URL (FR6), with purchase history (FR20/FR21)."""
     service = _get_catalog_service()
     product = service.get_product(product_id)
     if product is None:
         abort(404)
+    # Load purchases with a dedicated query (never product.purchases — that
+    # would lazy-load on the detached Product).
+    purchases = service.get_purchases_for_product(product_id)
+    last_paid = service.get_last_paid_price(product_id)
     return render_template('product/detail.html',
                            title=product.description or f'Product {product_id}',
-                           product=product)
+                           product=product, purchases=purchases, last_paid=last_paid)
+
+
+def _catalog_json_error(code, message, status, field=None):
+    """Build the fixed catalog JSON error envelope (AD-13): an OBJECT error,
+    unlike the legacy inventory routes' string `error`. Reused by all catalog
+    JSON endpoints (Epic 7 onward)."""
+    error = {'code': code, 'message': message}
+    if field:
+        error['field'] = field
+    return jsonify({'success': False, 'error': error}), status
+
+
+@bp.route('/api/products/<int:product_id>/purchases', methods=['POST'])
+@csrf.exempt
+def api_record_purchase(product_id):
+    """Record a Purchase against an existing Product (FR22). JSON API."""
+    service = _get_catalog_service()
+    if service.get_product(product_id) is None:
+        return _catalog_json_error('not_found', f'Product {product_id} not found', 404)
+
+    body = request.get_json(silent=True) or {}
+
+    # Parse/validate typed fields at the boundary; the service takes typed values.
+    try:
+        unit_price = body.get('unit_price')
+        unit_price = Decimal(str(unit_price)) if unit_price not in (None, '') else None
+    except (InvalidOperation, ValueError):
+        return _catalog_json_error('invalid_field', 'unit_price must be a decimal number', 400, field='unit_price')
+
+    try:
+        quantity = body.get('quantity')
+        quantity = int(quantity) if quantity not in (None, '') else None
+    except (TypeError, ValueError):
+        return _catalog_json_error('invalid_field', 'quantity must be an integer', 400, field='quantity')
+
+    def _parse_date(value, field):
+        if value in (None, ''):
+            return None, None
+        try:
+            return date.fromisoformat(str(value)), None
+        except ValueError:
+            return None, _catalog_json_error('invalid_field', f'{field} must be an ISO date (YYYY-MM-DD)', 400, field=field)
+
+    order_date, err = _parse_date(body.get('order_date'), 'order_date')
+    if err:
+        return err
+    received_date, err = _parse_date(body.get('received_date'), 'received_date')
+    if err:
+        return err
+
+    try:
+        snapshot = service.record_purchase(
+            product_id,
+            vendor=body.get('vendor'),
+            vendor_sku=body.get('vendor_sku'),
+            order_date=order_date,
+            received_date=received_date,
+            quantity=quantity,
+            unit_price=unit_price,
+            order_number=body.get('order_number'),
+            source_url=body.get('source_url'),
+        )
+    except Exception as e:
+        current_app.logger.error(f'Error recording purchase for product {product_id}: {e}\n{traceback.format_exc()}')
+        return _catalog_json_error('server_error', 'Failed to record purchase', 500)
+
+    if snapshot is None:
+        return _catalog_json_error('server_error', 'Failed to record purchase', 500)
+
+    return jsonify({
+        'success': True,
+        'purchase': snapshot,
+        'product_url': url_for('main.product_detail', product_id=product_id),
+    }), 201
 
 
 @bp.route('/products/edit/<int:product_id>', methods=['GET', 'POST'])

--- a/app/mariadb_catalog_service.py
+++ b/app/mariadb_catalog_service.py
@@ -11,11 +11,13 @@ stories extend this class (internal_id generation, scan resolution,
 search_products, capture, derived signals).
 """
 
-from typing import Optional
+from typing import List, Optional
+from datetime import date
+from decimal import Decimal
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
 
-from .database import Product
+from .database import Product, Purchase
 from .mariadb_storage import MariaDBStorage
 from config import Config
 
@@ -156,6 +158,98 @@ class CatalogService:
             log_audit_operation('update_product', 'error', item_id=str(product_id),
                                 error_details=str(e), logger_name='mariadb_catalog_service')
             return False
+        finally:
+            if 'session' in locals():
+                session.close()
+
+    # --- Purchases (Story 1.4) -------------------------------------------
+
+    def get_purchases_for_product(self, product_id: int) -> List[Purchase]:
+        """
+        Return the product's Purchases in chronological order (oldest first).
+
+        A dedicated query — NOT `product.purchases` relationship navigation,
+        which would lazy-load on the detached Product `get_product` returns
+        (DetachedInstanceError). Read-only, so the returned detached rows keep
+        their scalar columns for template rendering. Returns [] for an unknown
+        product.
+        """
+        session = self.Session()
+        try:
+            return (session.query(Purchase)
+                    .filter(Purchase.product_id == product_id)
+                    .order_by(Purchase.order_date.asc(), Purchase.id.asc())
+                    .all())
+        finally:
+            session.close()
+
+    def get_last_paid_price(self, product_id: int) -> Optional[Decimal]:
+        """
+        Return the unit_price of the most recent priced Purchase (by order_date,
+        tie-break id), or None if the product has no purchase with a price
+        (FR21 "Last paid"). Per-product; group-awareness is Epic 10.
+        """
+        session = self.Session()
+        try:
+            purchase = (session.query(Purchase)
+                        .filter(Purchase.product_id == product_id,
+                                Purchase.unit_price.isnot(None))
+                        .order_by(Purchase.order_date.desc(), Purchase.id.desc())
+                        .first())
+            return purchase.unit_price if purchase else None
+        finally:
+            session.close()
+
+    def record_purchase(self, product_id: int, *, vendor=None, vendor_sku=None,
+                        order_date=None, received_date=None, quantity=None,
+                        unit_price=None, order_number=None, source_url=None
+                        ) -> Optional[dict]:
+        """
+        Record a Purchase against an existing Product (FR18, FR22).
+
+        Returns the created purchase's to_dict() snapshot (captured before the
+        session closes, so the caller can echo the resource without a detached
+        re-fetch), or None if the product does not exist or the insert fails.
+        A missing order_date defaults to today (the server-side capture-date
+        convention; Epic 7 reuses it). Callers pass already-typed values
+        (Decimal price, date fields, int quantity); parsing is the route's job.
+        Does not accept request_key — idempotent capture is Epic 7.
+        """
+        from .logging_config import log_audit_operation
+        try:
+            session = self.Session()
+            product = session.query(Product).filter(Product.id == product_id).first()
+            if product is None:
+                log_audit_operation('record_purchase', 'error', item_id=str(product_id),
+                                    error_details='Product not found',
+                                    logger_name='mariadb_catalog_service')
+                return None
+
+            purchase = Purchase(
+                product_id=product_id,
+                vendor=_clean(vendor),
+                vendor_sku=_clean(vendor_sku),
+                order_date=order_date if order_date is not None else date.today(),
+                received_date=received_date,
+                quantity=quantity,
+                unit_price=unit_price,
+                order_number=_clean(order_number),
+                source_url=_clean(source_url),
+            )
+            session.add(purchase)
+            # Flush + snapshot before commit (see create_product rationale).
+            session.flush()
+            snapshot = purchase.to_dict()
+            session.commit()
+            log_audit_operation('record_purchase', 'success', item_id=str(product_id),
+                                item_after=snapshot, logger_name='mariadb_catalog_service')
+            return snapshot
+        except Exception as e:
+            if 'session' in locals():
+                session.rollback()
+            log_audit_operation('record_purchase', 'error', item_id=str(product_id),
+                                error_details=str(e), logger_name='mariadb_catalog_service')
+            return None
         finally:
             if 'session' in locals():
                 session.close()

--- a/app/templates/product/detail.html
+++ b/app/templates/product/detail.html
@@ -47,6 +47,43 @@
         </div>
         {% endif %}
 
+        <div class="card mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span>Purchases</span>
+                <span class="text-muted small">
+                    Last paid: {% if last_paid is not none %}${{ '%.2f'|format(last_paid) }}{% else %}—{% endif %}
+                </span>
+            </div>
+            <div class="card-body">
+                {% if purchases %}
+                <div class="table-responsive">
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Order Date</th>
+                                <th>Vendor</th>
+                                <th class="text-end">Unit Price</th>
+                                <th>Received</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for purchase in purchases %}
+                            <tr>
+                                <td>{% if purchase.order_date %}{{ purchase.order_date.isoformat() }}{% else %}—{% endif %}</td>
+                                <td>{{ purchase.vendor or '—' }}</td>
+                                <td class="text-end">{% if purchase.unit_price is not none %}${{ '%.2f'|format(purchase.unit_price) }}{% else %}—{% endif %}</td>
+                                <td>{% if purchase.received_date %}{{ purchase.received_date.isoformat() }}{% else %}—{% endif %}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                {% else %}
+                <p class="text-muted mb-0">No purchases recorded.</p>
+                {% endif %}
+            </div>
+        </div>
+
         <div class="text-muted small">
             {% if product.created_at %}<div>Created: {{ product.created_at.strftime('%Y-%m-%d %H:%M') }}</div>{% endif %}
             {% if product.updated_at %}<div>Updated: {{ product.updated_at.strftime('%Y-%m-%d %H:%M') }}</div>{% endif %}

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -15,6 +15,7 @@ import requests
 from app.api_client import (
     CreateItemResult,
     FieldSuggestionsResult,
+    RecordPurchaseResult,
     SUGGESTABLE_FIELDS,
     TaxonomyResult,
     UploadPhotoResult,
@@ -82,6 +83,50 @@ def session():
 @pytest.fixture
 def client(session):
     return WorkshopInventoryClient('http://example.test', session=session)
+
+
+class TestRecordPurchase:
+    def test_success(self, client, session):
+        session.post.return_value = _mock_response(201, {
+            'success': True,
+            'purchase': {'id': 3, 'product_id': 7, 'vendor': 'DigiKey', 'unit_price': 2.34},
+            'product_url': 'http://example.test/products/7',
+        })
+
+        result = client.record_purchase(7, {'vendor': 'DigiKey', 'unit_price': '2.34'})
+
+        assert isinstance(result, RecordPurchaseResult)
+        assert result.success is True
+        assert result.purchase == {'id': 3, 'product_id': 7, 'vendor': 'DigiKey', 'unit_price': 2.34}
+        assert result.errors == []
+        assert result.http_status == 201
+
+        session.post.assert_called_once()
+        call_args = session.post.call_args
+        assert call_args.args[0] == 'http://example.test/api/products/7/purchases'
+        assert call_args.kwargs['json'] == {'vendor': 'DigiKey', 'unit_price': '2.34'}
+        assert call_args.kwargs['timeout'] == 30.0
+
+    def test_object_error_envelope_surfaces_message(self, client, session):
+        session.post.return_value = _mock_response(404, {
+            'success': False,
+            'error': {'code': 'not_found', 'message': 'Product 999 not found'},
+        })
+
+        result = client.record_purchase(999, {'vendor': 'X'})
+
+        assert result.success is False
+        assert result.http_status == 404
+        assert result.purchase is None
+        assert result.message == 'Product 999 not found'
+        assert result.errors[0]['code'] == 'not_found'
+
+    def test_non_json_error(self, client, session):
+        session.post.return_value = _mock_response(502, None, text='Bad Gateway')
+        result = client.record_purchase(7, {'vendor': 'X'})
+        assert result.success is False
+        assert result.http_status == 502
+        assert result.errors  # a synthesized error entry is present
 
 
 class TestCreateItem:

--- a/tests/unit/test_catalog_service.py
+++ b/tests/unit/test_catalog_service.py
@@ -114,3 +114,65 @@ class TestCatalogServiceUpdate:
         catalog_service.update_product(new_id, manufacturer='')
         product = catalog_service.get_product(new_id)
         assert product.manufacturer is None
+
+
+class TestCatalogServicePurchases:
+
+    @pytest.mark.unit
+    def test_record_purchase_creates_and_attaches(self, catalog_service):
+        from datetime import date
+        from decimal import Decimal
+        pid = catalog_service.create_product(description='widget')
+        snap = catalog_service.record_purchase(
+            pid, vendor='DigiKey', unit_price=Decimal('1.50'),
+            quantity=10, order_date=date(2026, 7, 1))
+        assert isinstance(snap, dict)
+        assert snap['product_id'] == pid
+        assert snap['vendor'] == 'DigiKey'
+
+        purchases = catalog_service.get_purchases_for_product(pid)
+        assert len(purchases) == 1
+        assert purchases[0].vendor == 'DigiKey'
+        assert purchases[0].product_id == pid
+
+    @pytest.mark.unit
+    def test_record_purchase_defaults_order_date_to_today(self, catalog_service):
+        from datetime import date
+        pid = catalog_service.create_product(description='widget')
+        snap = catalog_service.record_purchase(pid, vendor='Mouser')
+        assert snap['order_date'] == date.today().isoformat()
+
+    @pytest.mark.unit
+    def test_record_purchase_missing_product_returns_none(self, catalog_service):
+        assert catalog_service.record_purchase(999999, vendor='X') is None
+
+    @pytest.mark.unit
+    def test_get_purchases_chronological_order(self, catalog_service):
+        from datetime import date
+        pid = catalog_service.create_product(description='widget')
+        catalog_service.record_purchase(pid, vendor='B', order_date=date(2026, 7, 5))
+        catalog_service.record_purchase(pid, vendor='A', order_date=date(2026, 7, 1))
+        catalog_service.record_purchase(pid, vendor='C', order_date=date(2026, 7, 9))
+        purchases = catalog_service.get_purchases_for_product(pid)
+        assert [p.vendor for p in purchases] == ['A', 'B', 'C']
+
+    @pytest.mark.unit
+    def test_get_purchases_empty_for_unknown_product(self, catalog_service):
+        assert catalog_service.get_purchases_for_product(999999) == []
+
+    @pytest.mark.unit
+    def test_get_last_paid_price_most_recent_priced(self, catalog_service):
+        from datetime import date
+        from decimal import Decimal
+        pid = catalog_service.create_product(description='widget')
+        catalog_service.record_purchase(pid, order_date=date(2026, 7, 1), unit_price=Decimal('1.00'))
+        catalog_service.record_purchase(pid, order_date=date(2026, 7, 9), unit_price=Decimal('2.50'))
+        # a later-dated purchase with NO price must be skipped
+        catalog_service.record_purchase(pid, order_date=date(2026, 7, 12), unit_price=None)
+        assert catalog_service.get_last_paid_price(pid) == Decimal('2.50')
+
+    @pytest.mark.unit
+    def test_get_last_paid_price_none_when_unpriced(self, catalog_service):
+        pid = catalog_service.create_product(description='widget')
+        catalog_service.record_purchase(pid, vendor='X', unit_price=None)
+        assert catalog_service.get_last_paid_price(pid) is None

--- a/tests/unit/test_product_routes.py
+++ b/tests/unit/test_product_routes.py
@@ -104,3 +104,72 @@ class TestProductRoutes:
         assert resp.status_code == 302
         product = CatalogService(test_storage).get_product(pid)
         assert product.manufacturer == 'TI'  # absent key != clear
+
+
+@pytest.mark.unit
+class TestProductPurchases:
+    """Detail-page purchase history + the REST record endpoint (Story 1.4)."""
+
+    def _seed(self, test_storage):
+        from datetime import date
+        from decimal import Decimal
+        svc = CatalogService(test_storage)
+        pid = svc.create_product(description='LM317')
+        svc.record_purchase(pid, vendor='DigiKey', order_date=date(2026, 7, 1),
+                            unit_price=Decimal('1.00'))
+        svc.record_purchase(pid, vendor='Mouser', order_date=date(2026, 7, 5),
+                            unit_price=Decimal('1.25'))
+        svc.record_purchase(pid, vendor='DigiKey', order_date=date(2026, 7, 9),
+                            unit_price=Decimal('1.50'))
+        return pid
+
+    def test_detail_shows_history_and_last_paid(self, client, test_storage):
+        pid = self._seed(test_storage)
+        resp = client.get(f'/products/{pid}')
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        # all three vendors present, chronological
+        assert body.index('Mouser') > body.index('DigiKey')  # first row is 2026-07-01 DigiKey
+        # last paid is the most recent price
+        assert '1.50' in body
+        assert 'Last paid' in body
+
+    def test_detail_no_purchases_empty_state(self, client, test_storage):
+        pid = CatalogService(test_storage).create_product(description='bare')
+        resp = client.get(f'/products/{pid}')
+        assert resp.status_code == 200
+        assert b'No purchases recorded' in resp.data
+
+    def test_record_purchase_endpoint_creates_201(self, client, test_storage):
+        pid = CatalogService(test_storage).create_product(description='widget')
+        resp = client.post(f'/api/products/{pid}/purchases',
+                           json={'vendor': 'DigiKey', 'unit_price': '2.34',
+                                 'quantity': 5, 'order_date': '2026-07-10'})
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data['success'] is True
+        assert data['purchase']['vendor'] == 'DigiKey'
+        assert data['purchase']['product_id'] == pid
+        assert data['product_url'].endswith(f'/products/{pid}')
+        # persisted
+        assert len(CatalogService(test_storage).get_purchases_for_product(pid)) == 1
+
+    def test_record_purchase_missing_product_404_object_envelope(self, client):
+        resp = client.post('/api/products/999999/purchases', json={'vendor': 'X'})
+        assert resp.status_code == 404
+        data = resp.get_json()
+        assert data['success'] is False
+        # AD-13 object envelope, NOT a bare string
+        assert isinstance(data['error'], dict)
+        assert data['error']['code'] == 'not_found'
+
+    def test_record_purchase_invalid_unit_price_400_field(self, client, test_storage):
+        pid = CatalogService(test_storage).create_product(description='widget')
+        resp = client.post(f'/api/products/{pid}/purchases',
+                           json={'vendor': 'X', 'unit_price': 'not-a-number'})
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data['success'] is False
+        assert data['error']['field'] == 'unit_price'
+        # nothing created
+        assert CatalogService(test_storage).get_purchases_for_product(pid) == []


### PR DESCRIPTION
## Story 1.4 — Purchase recording and history

Fourth story of the **Product Catalog & Purchase Tracking** enhancement (Epic 1). Adds purchase history + "Last paid" to the product detail page and the **first catalog JSON endpoint** for recording a purchase.

### What's included
- **`CatalogService`**: `get_purchases_for_product` (chronological), `get_last_paid_price` (FR21), `record_purchase` (attach to an existing Product, default `order_date` to today, return the created-row snapshot; FR18/FR22).
- **Detail page**: a Purchases card — "Last paid" + a chronological table (Order Date / Vendor / Unit Price / plain Received) with an empty-state (FR20).
- **`POST /api/products/<id>/purchases`** (`@csrf.exempt`): `201 {success, purchase, product_url}` on success; **404** `not_found` for a missing product; **400** with `error.field` for bad input.
- **`api_client.record_purchase` + `RecordPurchaseResult`** (frozen dataclass), `requests`-only (AD-13/NFR10).
- **+15 tests** (7 service, 5 route, 3 api_client).

### Two precedents this story sets
1. **AD-13 object error envelope.** The first catalog JSON route introduces `_catalog_json_error()` → `{success:false, error:{code, message, field?}}` — deliberately **different** from the legacy inventory routes' string `error`. Epic 7's capture endpoint reuses the helper. The api_client mirror reads the object form (not the neighbor methods' string form) — the copy-the-neighbor trap, headed off.
2. **Query-not-relationship.** Purchases load via dedicated `CatalogService` queries, never `product.purchases` on the detached `Product` (the `DetachedInstanceError` hazard flagged since 1.2/1.3).

### Scope (deferred by design)
No manual browser "Add Purchase" form (recording is the REST/api_client path per the AC); no `request_key`/idempotency/de-dup/ASIN (Epic 7); no derived On-Order signal (Epic 5, shows the stored `received_date` only).

### Verification
- Route tests drive the endpoint + detail page via the Flask `client`; api_client tests mock `requests.Session` and assert URL/json/timeout + object-envelope handling.
- **Full unit suite: 400 passed** (385 baseline + 15 new), no regressions (NFR9). No schema change.

### Acceptance criteria
- [x] AC1: purchases listed chronologically (date/vendor/price) on detail (FR20)
- [x] AC2: "Last paid" field (FR21)
- [x] AC3: `POST /api/products/<id>/purchases` → 201, attached (FR18/FR22)
- [x] AC4: fixed object error envelope; 404 missing / 400 invalid field (AD-13)
- [x] AC5: `api_client.record_purchase` + frozen `RecordPurchaseResult`, requests-only
- [x] AC6: logic in `CatalogService`; no ORM in routes; suite green; tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvNxyuJiBQvRUvrM1iaGHB