### PR TITLE
Story 1.5: Attachments on product or purchase

### DIFF
--- a/_bmad-output/implementation-artifacts/1-5-attachments-on-product-or-purchase.md
+++ b/_bmad-output/implementation-artifacts/1-5-attachments-on-product-or-purchase.md
@@ -1,0 +1,145 @@
+---
+baseline_commit: 34d76e56a7b145c8a86706df61c6e0fcedb579f0
+---
+
+# Story 1.5: Attachments on product or purchase
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As the workshop operator,
+I want to attach datasheets, diagrams, or photos to a Product or a Purchase,
+so that reference material lives with the record and survives with my backups.
+
+## Acceptance Criteria
+
+1. **Given** a Product detail view, **When** I upload a PDF datasheet (or an image), **Then** the file is stored as a BLOB in the database (AD-12) and is retrievable/viewable from the Product view via a direct link (FR5).
+2. **Given** the `attachments` table, **When** a row is written, **Then** exactly one of `product_id` / `purchase_id` is non-null — enforced by a DB `CHECK ((product_id IS NULL) <> (purchase_id IS NULL))` **and** an application invariant that rejects both-null or both-set as a caught domain error (not a raw `IntegrityError`) (AD-12).
+3. **And** the new migration is chained from HEAD `46393d2e6c96`, `manage.py db downgrade 46393d2e6c96` cleanly reverses it, and existing metal-stock / product / purchase tables are unchanged (NFR9, AD-14).
+4. **And** all attachment logic (store, list, retrieve) lives in `CatalogService`; routes contain no ORM/SQL (AD-2). The attachment list on the detail page does not load BLOB bytes.
+5. **And** the full test suite passes with new service tests, route tests (including a multipart upload), and a MariaDB migration round-trip verification.
+
+## Scope Boundary — READ FIRST
+
+This story adds an `attachments` table (BLOB-in-DB, AD-12), the `CatalogService` store/list/retrieve surface, a **browser upload on the Product detail view**, and a **serve route**. It closes Epic 1.
+
+| Concern | Owned by | In 1.5? |
+| --- | --- | --- |
+| `attachments` schema (XOR one-owner), migration, ORM | **Story 1.5 (this)** | ✅ |
+| Upload from the **Product** detail page + list + serve/download | **Story 1.5 (this)** | ✅ |
+| **Purchase**-attachment UI | later | ❌ — the schema/service support `purchase_id` (XOR is meaningful + tested), but there is no Purchase detail surface yet, so no purchase upload UI this story |
+| Attachment **size caps beyond the MEDIUMBLOB limit / PDF thumbnailing** (PyMuPDF) | Epic 8 (Deferred in the spine) | ❌ — 1.5 enforces a simple app-level size limit only |
+| Delete / replace attachment | later | ❌ — AC covers upload + retrieve; delete is not required |
+| Programmatic REST attachment API + api_client method | later (Epic 8) | ❌ — 1.5's upload/serve are browser routes (CSRF-protected form + a GET serve), not an AD-13 JSON endpoint |
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — `Attachment` ORM model + `attachments` migration (AC: #1, #2, #3)**
+  - [x] Added `class Attachment(Base)` in the catalog section: `product_id`/`purchase_id` nullable FKs (indexed), `filename`, `content_type`, `file_size`, `content` (`LargeBinary().with_variant(MEDIUMBLOB,'mysql')`), `created_at` (write-once).
+  - [x] `__table_args__`: `ck_attachment_one_owner` (XOR) + `ck_attachment_positive_file_size`.
+  - [x] One-directional `relationship('Product')`/`relationship('Purchase')` (no back_populates); BLOB-free `to_dict()`.
+  - [x] `migrations/versions/f771284e1478_add_attachments_table.py`, `down_revision='46393d2e6c96'` (verified single head). `upgrade` creates the table with both FKs, both CHECKs, PK, and the two indexes; `content` as MEDIUMBLOB variant. `downgrade` is a single `op.drop_table('attachments')` (PR #44 discipline).
+
+- [x] **Task 2 — `CatalogService` attachment methods (AC: #1, #2, #4)**
+  - [x] `ATTACHMENT_ALLOWED_TYPES` (pdf/jpeg/png/webp/gif — **excludes svg**) + `ATTACHMENT_MAX_SIZE = 16MB`; whitelist enforced app-side only.
+  - [x] `add_attachment(...) -> dict` — raises `ValidationError` for XOR violation / empty / oversize / disallowed type / missing owner; else flush→snapshot→commit; returns BLOB-free snapshot.
+  - [x] `get_attachments_for_product` uses `defer(Attachment.content)` (never loads BLOBs when listing); ordered; `[]` for none.
+  - [x] `get_attachment_data -> (bytes, content_type, filename) | None`. `ValidationError` propagates (not swallowed).
+
+- [x] **Task 3 — Routes: upload + serve; detail list (AC: #1, #4)**
+  - [x] `product_detail` also fetches `attachments` (deferred BLOB) and passes them.
+  - [x] `product_upload_attachment` (`/products/<id>/attachments`, POST, CSRF-protected multipart) — 404 if product missing; no-file → flash+redirect; delegates to `add_attachment`; catches `ValidationError` → flash; success flash + redirect.
+  - [x] `serve_attachment` (`/attachments/<id>`) — 404 if missing; `send_file(BytesIO, mimetype, download_name)` + `X-Content-Type-Options: nosniff`.
+
+- [x] **Task 4 — Detail template: attachments card (AC: #1)**
+  - [x] "Attachments" card: list (filename → serve URL, content_type + KB size), empty-state, and a CSRF-protected `enctype="multipart/form-data"` upload form.
+
+- [x] **Task 5 — Verify the migration on real MariaDB (AC: #2, #3)**
+  - [x] MariaDB 11.8 container: `SHOW CREATE TABLE attachments` confirmed `content mediumblob NOT NULL`, FKs `attachments_ibfk_1/2` → products/purchases, `ck_attachment_one_owner` + `ck_attachment_positive_file_size`, both indexes.
+  - [x] XOR enforced on MariaDB: one-owner INSERT OK; both-owners → `ERROR 4025` (`ck_attachment_one_owner`); no-owner → `ERROR 4025`.
+  - [x] `downgrade 46393d2e6c96` (row present) dropped `attachments` cleanly; products/purchases/metal-stock intact; `current` = `46393d2e6c96`. Container removed.
+
+- [x] **Task 6 — Tests (AC: #1–#5)**
+  - [x] `test_catalog_service.py` — +10 (product/purchase attach, XOR both/neither → ValidationError, oversize, disallowed type, empty, missing owner, order+empty, get_attachment_data + None).
+  - [x] `test_product_routes.py` — +6 (detail card+form, multipart upload persists, no-file flash, upload-missing-product 404, serve bytes+content-type+nosniff, serve-missing 404). Introduces the repo's first Flask-client multipart test.
+  - [x] `venv/bin/nox -s tests` → **416 passed** (400 baseline + 16 new), 0 failures, no regressions.
+
+## Dev Notes
+
+### AD-12 — BLOB-in-DB, exactly one owner
+- Bytes live in a DB BLOB column (backed up with the database), matching the `Photo` precedent — **not** the filesystem. Column idiom: `LargeBinary().with_variant(MEDIUMBLOB, 'mysql')` (`database.py:707-708`).
+- The one-owner rule is enforced **twice** (belt-and-suspenders, as AD-12 says "CHECK … / application invariant"): the DB `CHECK ((product_id IS NULL) <> (purchase_id IS NULL))` AND the service's XOR guard. The service guard fires first and raises a **caught `ValidationError`** so the operator sees a clean message, never a raw `IntegrityError` — the same "UNIQUE/constraint violations surface as domain errors" philosophy as AD-9.
+
+### Testing split — different from Story 1.2's FK
+- **The XOR CHECK IS enforced by SQLite** (verified empirically: both-set and both-null both raise `CHECK constraint failed`). So unlike Story 1.2's foreign key (which SQLite ignores unless `PRAGMA foreign_keys=ON`), the DB-level XOR is exercised by the unit suite via `Base.metadata.create_all` — plus the app-level guard. Task 6 tests the app-level `ValidationError`; the DB CHECK is a backstop also verified on MariaDB (Task 5).
+- **The MEDIUMBLOB size ceiling and the two FKs still need MariaDB verification** (SQLite's `LargeBinary` has no length cap and doesn't enforce FKs by default), so Task 5's container round-trip is mandatory — same rationale as 1.1/1.2.
+- **New pattern:** there is no existing Flask-test-client multipart upload in the repo (`upload_photo` is exercised via the `requests`-based api_client / e2e only). Task 6 introduces `client.post(url, data={'file': (io.BytesIO(b'…'), 'name.pdf')}, content_type='multipart/form-data')` — spelled out so you don't hunt for a template that isn't there.
+
+### Upload/serve — mirror `Photo`, but simpler and CSRF-protected
+- `upload_photo` (`routes.py:2856`) is `@csrf.exempt` JSON/AJAX. **1.5 diverges deliberately:** the attachment upload is a plain **CSRF-protected browser multipart form** on the product detail page (consistent with the 1.3/1.4 catalog browser-form convention — hidden `csrf_token()`, flash+redirect). Read bytes via `file.read()`, MIME via `file.content_type` (`routes.py:2864-2879`).
+- Serve mirrors `get_photo_data`/`download_photo` (`routes.py:2957-3001`): `send_file(io.BytesIO(bytes), mimetype=content_type, as_attachment=False, download_name=filename)`. Add `X-Content-Type-Options: nosniff`. Inline viewing is safe because the whitelist admits only PDF/raster images (no HTML, no SVG).
+- **Do NOT set a global `MAX_CONTENT_LENGTH`** — none exists today, and a global cap below `PhotoService.MAX_FILE_SIZE` (20 MB) would regress photo uploads (NFR9). Enforce the attachment size at the service level instead (read-then-check-`len`, same as `PhotoService`; whole file is read into memory — acceptable at this scale).
+- Attachment logic goes on **`CatalogService`** (not a separate `AttachmentService`) to keep the catalog surface unified per AD-2 — even though `Photo` uses a standalone `PhotoService`. Reuse the merged `CatalogService` session/audit/flush-snapshot patterns.
+
+### Previous story intelligence (1.1–1.4, all merged)
+- Migration playbook (from 1.1/1.2): hand-write, chain from HEAD, verify on a throwaway `mariadb:11.8` container, single `drop_table` on downgrade for a table with FKs (PR #44). Alembic HEAD is `46393d2e6c96` (1.3/1.4 added no migrations).
+- `created_at` convention; flush-before-commit snapshot (avoids false-failure on post-commit refresh); dedicated queries not detached-relationship navigation; `session.expire_all()` (not `expunge_all`) when re-reading in a test; `ValidationError` for domain rejections; catalog audit logger already registered (`logger_name='mariadb_catalog_service'`). Baseline suite: **400 passed**.
+- The 1.3-review **deferred** per-request engine/pool item (systemic, `deferred-work.md`) — don't touch it; reuse `_get_catalog_service()`.
+
+### What this story must NOT break (NFR9)
+- Additive: new `Attachment` class + migration, new `CatalogService` methods, `product_detail` modification + 2 new routes, `detail.html` extension, new tests. Do NOT touch `InventoryItem`/`Photo`/`ItemPhotoAssociation`, `PhotoService`, existing migrations, or `Product`/`Purchase` (Attachment's relationships are one-directional). No dependency change (Pillow already present for test fixtures).
+
+### Project Structure Notes
+- New: `migrations/versions/<hex>_add_attachments_table.py`. Modified: `app/database.py` (Attachment), `app/mariadb_catalog_service.py` (methods + constants), `app/main/routes.py` (`product_detail` + upload/serve routes + `defer` import consideration), `app/templates/product/detail.html`. Tests appended to `test_catalog_service.py`, `test_product_routes.py`. Matches the spine Structural Seed (`attachments` table; AD-12).
+
+### References
+- [Source: epics.md#Story 1.5: Attachments on product or purchase] (AC, FR5) · [#FR Coverage Map] (FR5 → Epic 1)
+- [Source: ARCHITECTURE-SPINE.md#AD-12] (BLOB-in-DB; `CHECK ((product_id IS NULL) <> (purchase_id IS NULL))`; Photo precedent) · [#AD-2] (logic in CatalogService) · [#AD-3] (relationships via `relationship()`) · [#AD-14] (Alembic from HEAD; metal stock untouched) · [#Deferred] (attachment size limits / PDF thumbnailing → Epic 8)
+- [Source: 1-1…/1-2… story files] (migration + MariaDB-container playbook, PR #44 downgrade lesson) · [1-3…/1-4… story files] (CatalogService/route/detail patterns; ValidationError; deferred engine item)
+- [Existing code: app/database.py:687-742 (`Photo` — BLOB column idiom, CheckConstraints, BLOB-free `to_dict`), :9/:11 (`LargeBinary`/`CheckConstraint`/`MEDIUMBLOB` imports); app/photo_service.py:68-140 (store), :166-195 (retrieve), :44-52 (size/type constants); app/main/routes.py:2856-2907 (upload), :2931-3001 (serve/download via `send_file`); app/exceptions.py:17-28 (`ValidationError` + `.field`)]
+- [Existing code: migrations/versions/8213852b0b94_…py:44 & dce1254cd381_…py (MEDIUMBLOB migration column idiom); migrations/versions/46393d2e6c96_add_purchases_table.py (current HEAD; single-drop_table downgrade with an FK)]
+- [Existing code: tests/unit/test_photo_service.py:55-107 (Pillow/PDF byte fixtures), :349-398 (store test); tests/conftest.py:35-79 (fixtures) — note: NO prior Flask-client multipart test exists to copy]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8[1m] (Opus 4.8, 1M context) — bmad-dev-story workflow.
+
+### Debug Log References
+
+- Migration verified on a disposable `mariadb:11.8` container (port 13306), isolated from the `.env` dev DB. Container removed after.
+- Alembic chain: `heads == ['f771284e1478']`, `down_revision == '46393d2e6c96'`.
+- MariaDB DDL: `content mediumblob NOT NULL`; FKs `attachments_ibfk_1` (→products), `attachments_ibfk_2` (→purchases); CHECKs `ck_attachment_one_owner` + `ck_attachment_positive_file_size`; indexes on both FK columns.
+- XOR enforced on MariaDB (`ERROR 4025` for both-owners and no-owner). Also enforced on SQLite (unit tests) — verified during story creation — so the app-level `ValidationError` guard and the DB CHECK are both exercised.
+- Downgrade with a row present dropped `attachments` cleanly via a single `DROP TABLE` (PR #44 lesson holds for the two FK-backing indexes).
+
+### Completion Notes List
+
+- Closes Epic 1: `attachments` table (BLOB-in-DB, AD-12), `CatalogService` store/list/retrieve, a CSRF-protected browser upload on the product detail page, and an inline serve route.
+- **Dual XOR enforcement** (AD-12 "CHECK … / application invariant"): the service raises a caught `ValidationError` for both-set/neither/oversize/bad-type/missing-owner; the DB `ck_attachment_one_owner` CHECK is the backstop. Unlike 1.2's FK, the CHECK is enforced by SQLite too, so it's covered by the unit suite as well as the MariaDB round-trip.
+- **BLOB never over-fetched:** `get_attachments_for_product` uses `defer(Attachment.content)` for listing; `to_dict()` excludes the bytes; only `serve_attachment` loads the content.
+- **Security:** content-type whitelist excludes `image/svg+xml` (script-carrying); serve sets `X-Content-Type-Options: nosniff`; inline viewing is safe since only PDF/raster images are admitted. No global `MAX_CONTENT_LENGTH` set (would regress the 20 MB photo uploads, NFR9) — size enforced app-side.
+- **New test pattern:** first Flask-test-client multipart upload in the repo (`data={'file': (BytesIO, name)}`, `content_type='multipart/form-data'`).
+- Attachment logic lives on `CatalogService` (unified catalog surface, AD-2), not a separate service like `Photo`. Scope honored: product-attachment UI only (schema/service support `purchase_id`, tested); no delete/thumbnailing (later/Epic 8).
+- All 5 ACs satisfied; full suite **416 passed**; `Photo`/`PhotoService`/`Product`/`Purchase`/existing migrations untouched (NFR9).
+
+### File List
+
+- `app/database.py` (modified) — `Attachment` ORM class.
+- `migrations/versions/f771284e1478_add_attachments_table.py` (new) — Alembic migration, chained from `46393d2e6c96`.
+- `app/mariadb_catalog_service.py` (modified) — `add_attachment`/`get_attachments_for_product`/`get_attachment_data`; `ATTACHMENT_ALLOWED_TYPES`/`ATTACHMENT_MAX_SIZE`; `Attachment`/`defer`/`ValidationError`/`Tuple` imports.
+- `app/main/routes.py` (modified) — `product_detail` fetches attachments; new `product_upload_attachment` + `serve_attachment` routes.
+- `app/templates/product/detail.html` (modified) — Attachments card (list + upload form).
+- `tests/unit/test_catalog_service.py` (modified) — +10 attachment tests.
+- `tests/unit/test_product_routes.py` (modified) — +6 attachment route tests.
+- `_bmad-output/implementation-artifacts/1-5-attachments-on-product-or-purchase.md`, `sprint-status.yaml` (modified) — tracking.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| 2026-07-24 | Story 1.5 implemented: `attachments` table (BLOB-in-DB, XOR one-owner CHECK) + `CatalogService` store/list/retrieve + product-detail upload/serve + 16 tests. Verified DDL/XOR/downgrade on MariaDB 11.8. Full suite green (416 passed). Closes Epic 1. Status → review. |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -59,7 +59,7 @@ development_status:
   1-2-purchase-entity-and-migration: done
   1-3-product-create-edit-detail: done
   1-4-purchase-recording-and-history: done
-  1-5-attachments-on-product-or-purchase: backlog
+  1-5-attachments-on-product-or-purchase: review
   epic-1-retrospective: optional
 
   # Epic 2 — Identifiers & Internal Encoding

--- a/app/database.py
+++ b/app/database.py
@@ -938,3 +938,58 @@ class Purchase(Base):
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,
         }
+
+
+class Attachment(Base):
+    """
+    File attachment (datasheet, diagram, photo) owned by exactly one of a
+    Product or a Purchase (Story 1.5). Bytes are stored in a DB BLOB column
+    (AD-12), backed up with the database — matching the Photo precedent.
+
+    The XOR one-owner rule is enforced both by the CHECK constraint below and
+    by an application invariant in CatalogService (which raises a caught
+    ValidationError, never a raw IntegrityError).
+    """
+    __tablename__ = 'attachments'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+
+    # Exactly one owner (XOR) — enforced by ck_attachment_one_owner.
+    product_id = Column(Integer, ForeignKey('products.id'), nullable=True, index=True)
+    purchase_id = Column(Integer, ForeignKey('purchases.id'), nullable=True, index=True)
+
+    filename = Column(String(255), nullable=False)
+    content_type = Column(String(100), nullable=False)  # MIME (realizes the ERD 'kind')
+    file_size = Column(Integer, nullable=False)
+
+    # BLOB bytes: MEDIUMBLOB (16MB) on MySQL/MariaDB, LargeBinary on SQLite tests.
+    content = Column(LargeBinary().with_variant(MEDIUMBLOB, 'mysql'), nullable=False)
+
+    created_at = Column(DateTime, nullable=False, default=func.now())  # write-once
+
+    __table_args__ = (
+        # AD-12: exactly one of product_id / purchase_id is non-null.
+        CheckConstraint('(product_id IS NULL) <> (purchase_id IS NULL)',
+                        name='ck_attachment_one_owner'),
+        CheckConstraint('file_size > 0', name='ck_attachment_positive_file_size'),
+    )
+
+    # One-directional (no back_populates → Product/Purchase are untouched).
+    product = relationship('Product')
+    purchase = relationship('Purchase')
+
+    def __repr__(self):
+        return (f"<Attachment(id={self.id}, product_id={self.product_id}, "
+                f"purchase_id={self.purchase_id}, filename='{self.filename}')>")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for API responses (EXCLUDES the BLOB content)."""
+        return {
+            'id': self.id,
+            'product_id': self.product_id,
+            'purchase_id': self.purchase_id,
+            'filename': self.filename,
+            'content_type': self.content_type,
+            'file_size': self.file_size,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+        }

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -824,9 +824,55 @@ def product_detail(product_id):
     # would lazy-load on the detached Product).
     purchases = service.get_purchases_for_product(product_id)
     last_paid = service.get_last_paid_price(product_id)
+    attachments = service.get_attachments_for_product(product_id)
     return render_template('product/detail.html',
                            title=product.description or f'Product {product_id}',
-                           product=product, purchases=purchases, last_paid=last_paid)
+                           product=product, purchases=purchases, last_paid=last_paid,
+                           attachments=attachments)
+
+
+@bp.route('/products/<int:product_id>/attachments', methods=['POST'])
+def product_upload_attachment(product_id):
+    """Upload a file attachment to a Product (browser multipart form, CSRF-protected)."""
+    service = _get_catalog_service()
+    if service.get_product(product_id) is None:
+        abort(404)
+
+    file = request.files.get('file')
+    if file is None or file.filename == '':
+        flash('No file selected.', 'error')
+        return redirect(url_for('main.product_detail', product_id=product_id))
+
+    try:
+        service.add_attachment(
+            product_id=product_id,
+            filename=file.filename,
+            content=file.read(),
+            content_type=file.content_type,
+        )
+        flash('Attachment uploaded.', 'success')
+    except ValidationError as e:
+        flash(str(e), 'error')
+    except Exception as e:
+        current_app.logger.error(f'Error uploading attachment for product {product_id}: {e}\n{traceback.format_exc()}')
+        flash('An error occurred while uploading the attachment.', 'error')
+    return redirect(url_for('main.product_detail', product_id=product_id))
+
+
+@bp.route('/attachments/<int:attachment_id>')
+def serve_attachment(attachment_id):
+    """Serve an attachment's bytes (FR5). Inline-safe: the content-type
+    whitelist admits only PDF/raster images (no HTML/SVG)."""
+    import io
+    service = _get_catalog_service()
+    result = service.get_attachment_data(attachment_id)
+    if result is None:
+        abort(404)
+    content, content_type, filename = result
+    response = send_file(io.BytesIO(content), mimetype=content_type,
+                         as_attachment=False, download_name=filename)
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    return response
 
 
 def _catalog_json_error(code, message, status, field=None):

--- a/app/mariadb_catalog_service.py
+++ b/app/mariadb_catalog_service.py
@@ -11,14 +11,15 @@ stories extend this class (internal_id generation, scan resolution,
 search_products, capture, derived signals).
 """
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from datetime import date
 from decimal import Decimal
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, defer
 from sqlalchemy import create_engine
 
-from .database import Product, Purchase
+from .database import Product, Purchase, Attachment
 from .mariadb_storage import MariaDBStorage
+from .exceptions import ValidationError
 from config import Config
 
 
@@ -27,6 +28,14 @@ from config import Config
 _PRODUCT_FIELDS = (
     'manufacturer', 'mpn', 'description', 'notes', 'category_path', 'attributes',
 )
+
+# Attachment policy (Story 1.5). Whitelist is enforced only here (single source
+# of truth); the DB carries the structural XOR + positive-size CHECKs.
+# image/svg+xml is deliberately excluded (script-carrying → inline-XSS vector).
+ATTACHMENT_ALLOWED_TYPES = {
+    'application/pdf', 'image/jpeg', 'image/png', 'image/webp', 'image/gif',
+}
+ATTACHMENT_MAX_SIZE = 16 * 1024 * 1024  # MEDIUMBLOB ceiling
 
 
 def _clean(value):
@@ -253,3 +262,92 @@ class CatalogService:
         finally:
             if 'session' in locals():
                 session.close()
+
+    # --- Attachments (Story 1.5) -----------------------------------------
+
+    def add_attachment(self, *, product_id=None, purchase_id=None, filename,
+                       content, content_type) -> dict:
+        """
+        Store a file attachment owned by exactly one of a Product or Purchase
+        (AD-12). Returns the created attachment's BLOB-free to_dict() snapshot.
+
+        Validation failures are raised as ValidationError (caught domain errors,
+        not raw IntegrityError): the XOR one-owner rule, empty/oversize content,
+        disallowed content_type, and a non-existent owner.
+        """
+        from .logging_config import log_audit_operation
+
+        # --- Validation (app-level invariants) ---
+        if (product_id is None) == (purchase_id is None):
+            raise ValidationError('An attachment must have exactly one owner '
+                                  '(a product or a purchase, not both or neither).')
+        if not content:
+            raise ValidationError('Attachment content is empty.')
+        if len(content) > ATTACHMENT_MAX_SIZE:
+            raise ValidationError(
+                f'Attachment exceeds the maximum size of {ATTACHMENT_MAX_SIZE // (1024 * 1024)} MB.')
+        if content_type not in ATTACHMENT_ALLOWED_TYPES:
+            raise ValidationError(f'Unsupported attachment type: {content_type}.')
+
+        owner_label = f'product:{product_id}' if product_id is not None else f'purchase:{purchase_id}'
+        try:
+            session = self.Session()
+            owner_cls = Product if product_id is not None else Purchase
+            owner_id = product_id if product_id is not None else purchase_id
+            if session.query(owner_cls).filter(owner_cls.id == owner_id).first() is None:
+                raise ValidationError(f'Owner not found ({owner_label}).')
+
+            attachment = Attachment(
+                product_id=product_id,
+                purchase_id=purchase_id,
+                filename=(filename or '').strip() or 'attachment',
+                content_type=content_type,
+                file_size=len(content),
+                content=content,
+            )
+            session.add(attachment)
+            session.flush()
+            snapshot = attachment.to_dict()
+            session.commit()
+            log_audit_operation('add_attachment', 'success', item_id=owner_label,
+                                item_after=snapshot, logger_name='mariadb_catalog_service')
+            return snapshot
+        except ValidationError:
+            if 'session' in locals():
+                session.rollback()
+            raise
+        except Exception as e:
+            if 'session' in locals():
+                session.rollback()
+            log_audit_operation('add_attachment', 'error', item_id=owner_label,
+                                error_details=str(e), logger_name='mariadb_catalog_service')
+            raise
+        finally:
+            if 'session' in locals():
+                session.close()
+
+    def get_attachments_for_product(self, product_id: int) -> List[Attachment]:
+        """
+        Return a product's attachments (metadata only — the BLOB is deferred so
+        listing never pulls megabytes into memory), oldest first. [] if none.
+        """
+        session = self.Session()
+        try:
+            return (session.query(Attachment)
+                    .options(defer(Attachment.content))
+                    .filter(Attachment.product_id == product_id)
+                    .order_by(Attachment.created_at.asc(), Attachment.id.asc())
+                    .all())
+        finally:
+            session.close()
+
+    def get_attachment_data(self, attachment_id: int) -> Optional[Tuple[bytes, str, str]]:
+        """Return (content_bytes, content_type, filename) for serving, or None."""
+        session = self.Session()
+        try:
+            att = session.query(Attachment).filter(Attachment.id == attachment_id).first()
+            if att is None:
+                return None
+            return att.content, att.content_type, att.filename
+        finally:
+            session.close()

--- a/app/mariadb_catalog_service.py
+++ b/app/mariadb_catalog_service.py
@@ -35,7 +35,11 @@ _PRODUCT_FIELDS = (
 ATTACHMENT_ALLOWED_TYPES = {
     'application/pdf', 'image/jpeg', 'image/png', 'image/webp', 'image/gif',
 }
-ATTACHMENT_MAX_SIZE = 16 * 1024 * 1024  # MEDIUMBLOB ceiling
+# Exact MEDIUMBLOB ceiling: 2**24 - 1 bytes. Using the full column capacity
+# while rejecting anything the DB can't store (so oversize surfaces as a clean
+# ValidationError, never a raw DB error at insert time).
+ATTACHMENT_MAX_SIZE = 16 * 1024 * 1024 - 1
+ATTACHMENT_MAX_FILENAME = 255  # matches the filename column length
 
 
 def _clean(value):
@@ -285,9 +289,13 @@ class CatalogService:
             raise ValidationError('Attachment content is empty.')
         if len(content) > ATTACHMENT_MAX_SIZE:
             raise ValidationError(
-                f'Attachment exceeds the maximum size of {ATTACHMENT_MAX_SIZE // (1024 * 1024)} MB.')
+                f'Attachment exceeds the maximum size of {round(ATTACHMENT_MAX_SIZE / (1024 * 1024))} MB.')
         if content_type not in ATTACHMENT_ALLOWED_TYPES:
             raise ValidationError(f'Unsupported attachment type: {content_type}.')
+        clean_filename = (filename or '').strip() or 'attachment'
+        if len(clean_filename) > ATTACHMENT_MAX_FILENAME:
+            raise ValidationError(
+                f'Filename is too long (max {ATTACHMENT_MAX_FILENAME} characters).')
 
         owner_label = f'product:{product_id}' if product_id is not None else f'purchase:{purchase_id}'
         try:
@@ -300,7 +308,7 @@ class CatalogService:
             attachment = Attachment(
                 product_id=product_id,
                 purchase_id=purchase_id,
-                filename=(filename or '').strip() or 'attachment',
+                filename=clean_filename,
                 content_type=content_type,
                 file_size=len(content),
                 content=content,

--- a/app/templates/product/detail.html
+++ b/app/templates/product/detail.html
@@ -84,6 +84,38 @@
             </div>
         </div>
 
+        <div class="card mb-3">
+            <div class="card-header">Attachments</div>
+            <div class="card-body">
+                {% if attachments %}
+                <ul class="list-group list-group-flush mb-3">
+                    {% for attachment in attachments %}
+                    <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                        <a href="{{ url_for('main.serve_attachment', attachment_id=attachment.id) }}" target="_blank" rel="noopener">
+                            <i class="bi bi-paperclip"></i> {{ attachment.filename }}
+                        </a>
+                        <span class="text-muted small">{{ attachment.content_type }} · {{ (attachment.file_size / 1024) | round(1) }} KB</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% else %}
+                <p class="text-muted">No attachments.</p>
+                {% endif %}
+
+                <form method="POST" enctype="multipart/form-data"
+                      action="{{ url_for('main.product_upload_attachment', product_id=product.id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <div class="input-group">
+                        <input type="file" name="file" class="form-control" required>
+                        <button type="submit" class="btn btn-outline-primary">
+                            <i class="bi bi-upload"></i> Upload
+                        </button>
+                    </div>
+                    <div class="form-text">PDF or image (JPEG, PNG, WebP, GIF), up to 16 MB.</div>
+                </form>
+            </div>
+        </div>
+
         <div class="text-muted small">
             {% if product.created_at %}<div>Created: {{ product.created_at.strftime('%Y-%m-%d %H:%M') }}</div>{% endif %}
             {% if product.updated_at %}<div>Updated: {{ product.updated_at.strftime('%Y-%m-%d %H:%M') }}</div>{% endif %}

--- a/migrations/versions/f771284e1478_add_attachments_table.py
+++ b/migrations/versions/f771284e1478_add_attachments_table.py
@@ -1,0 +1,50 @@
+"""add attachments table
+
+Revision ID: f771284e1478
+Revises: 46393d2e6c96
+Create Date: 2026-07-24 12:00:00.000000
+
+Story 1.5 — Attachments on product or purchase. BLOB-in-DB attachment owned by
+exactly one of a Product or a Purchase (AD-12), enforced by the XOR CHECK.
+Metal stock / products / purchases untouched (NFR9).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f771284e1478'
+down_revision: Union[str, None] = '46393d2e6c96'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'attachments',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('product_id', sa.Integer(), nullable=True),
+        sa.Column('purchase_id', sa.Integer(), nullable=True),
+        sa.Column('filename', sa.String(length=255), nullable=False),
+        sa.Column('content_type', sa.String(length=100), nullable=False),
+        sa.Column('file_size', sa.Integer(), nullable=False),
+        sa.Column('content', sa.LargeBinary().with_variant(mysql.MEDIUMBLOB, 'mysql'), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.CheckConstraint('(product_id IS NULL) <> (purchase_id IS NULL)', name='ck_attachment_one_owner'),
+        sa.CheckConstraint('file_size > 0', name='ck_attachment_positive_file_size'),
+        sa.ForeignKeyConstraint(['product_id'], ['products.id']),
+        sa.ForeignKeyConstraint(['purchase_id'], ['purchases.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_attachments_product_id'), 'attachments', ['product_id'], unique=False)
+    op.create_index(op.f('ix_attachments_purchase_id'), 'attachments', ['purchase_id'], unique=False)
+
+
+def downgrade() -> None:
+    # Single drop_table only. The product_id/purchase_id indexes back live FKs,
+    # and MariaDB refuses to DROP INDEX while an FK depends on it (issue #36 /
+    # PR #44). DROP TABLE removes the FKs, indexes, and table atomically.
+    op.drop_table('attachments')

--- a/tests/unit/test_catalog_service.py
+++ b/tests/unit/test_catalog_service.py
@@ -276,6 +276,26 @@ class TestCatalogServiceAttachments:
         assert [r.filename for r in rows] == ['a.pdf', 'b.pdf']
 
     @pytest.mark.unit
+    def test_get_attachments_defers_blob(self, catalog_service):
+        """AC #4: listing must NOT load the BLOB content column."""
+        from sqlalchemy import inspect
+        pid = catalog_service.create_product(description='widget')
+        catalog_service.add_attachment(product_id=pid, filename='a.pdf',
+                                       content=_PDF_BYTES, content_type='application/pdf')
+        rows = catalog_service.get_attachments_for_product(pid)
+        # 'content' is deferred → reported as unloaded on the returned row.
+        assert 'content' in inspect(rows[0]).unloaded
+
+    @pytest.mark.unit
+    def test_add_attachment_overlong_filename_rejected(self, catalog_service):
+        from app.exceptions import ValidationError
+        pid = catalog_service.create_product(description='widget')
+        with pytest.raises(ValidationError):
+            catalog_service.add_attachment(
+                product_id=pid, filename='x' * 300 + '.pdf', content=_PDF_BYTES,
+                content_type='application/pdf')
+
+    @pytest.mark.unit
     def test_get_attachment_data(self, catalog_service):
         pid = catalog_service.create_product(description='widget')
         snap = catalog_service.add_attachment(

--- a/tests/unit/test_catalog_service.py
+++ b/tests/unit/test_catalog_service.py
@@ -176,3 +176,111 @@ class TestCatalogServicePurchases:
         pid = catalog_service.create_product(description='widget')
         catalog_service.record_purchase(pid, vendor='X', unit_price=None)
         assert catalog_service.get_last_paid_price(pid) is None
+
+
+_PDF_BYTES = b'%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF'
+
+
+class TestCatalogServiceAttachments:
+
+    @pytest.mark.unit
+    def test_add_attachment_to_product(self, catalog_service):
+        pid = catalog_service.create_product(description='widget')
+        snap = catalog_service.add_attachment(
+            product_id=pid, filename='ds.pdf', content=_PDF_BYTES,
+            content_type='application/pdf')
+        assert snap['product_id'] == pid
+        assert snap['purchase_id'] is None
+        assert snap['filename'] == 'ds.pdf'
+        assert snap['file_size'] == len(_PDF_BYTES)
+        assert 'content' not in snap  # BLOB never serialized
+
+        rows = catalog_service.get_attachments_for_product(pid)
+        assert len(rows) == 1
+        assert rows[0].filename == 'ds.pdf'
+
+    @pytest.mark.unit
+    def test_add_attachment_to_purchase(self, catalog_service):
+        pid = catalog_service.create_product(description='widget')
+        snap = catalog_service.record_purchase(pid, vendor='DigiKey')
+        purchase_id = snap['id']
+        att = catalog_service.add_attachment(
+            purchase_id=purchase_id, filename='receipt.pdf', content=_PDF_BYTES,
+            content_type='application/pdf')
+        assert att['purchase_id'] == purchase_id
+        assert att['product_id'] is None
+
+    @pytest.mark.unit
+    def test_add_attachment_xor_both_owners_rejected(self, catalog_service):
+        from app.exceptions import ValidationError
+        pid = catalog_service.create_product(description='widget')
+        snap = catalog_service.record_purchase(pid, vendor='X')
+        with pytest.raises(ValidationError):
+            catalog_service.add_attachment(
+                product_id=pid, purchase_id=snap['id'], filename='x.pdf',
+                content=_PDF_BYTES, content_type='application/pdf')
+
+    @pytest.mark.unit
+    def test_add_attachment_xor_no_owner_rejected(self, catalog_service):
+        from app.exceptions import ValidationError
+        with pytest.raises(ValidationError):
+            catalog_service.add_attachment(
+                filename='x.pdf', content=_PDF_BYTES, content_type='application/pdf')
+
+    @pytest.mark.unit
+    def test_add_attachment_oversize_rejected(self, catalog_service):
+        from app.exceptions import ValidationError
+        from app.mariadb_catalog_service import ATTACHMENT_MAX_SIZE
+        pid = catalog_service.create_product(description='widget')
+        with pytest.raises(ValidationError):
+            catalog_service.add_attachment(
+                product_id=pid, filename='big.pdf',
+                content=b'x' * (ATTACHMENT_MAX_SIZE + 1),
+                content_type='application/pdf')
+
+    @pytest.mark.unit
+    def test_add_attachment_disallowed_type_rejected(self, catalog_service):
+        from app.exceptions import ValidationError
+        pid = catalog_service.create_product(description='widget')
+        with pytest.raises(ValidationError):
+            catalog_service.add_attachment(
+                product_id=pid, filename='x.svg', content=b'<svg/>',
+                content_type='image/svg+xml')
+
+    @pytest.mark.unit
+    def test_add_attachment_empty_content_rejected(self, catalog_service):
+        from app.exceptions import ValidationError
+        pid = catalog_service.create_product(description='widget')
+        with pytest.raises(ValidationError):
+            catalog_service.add_attachment(
+                product_id=pid, filename='x.pdf', content=b'',
+                content_type='application/pdf')
+
+    @pytest.mark.unit
+    def test_add_attachment_missing_owner_rejected(self, catalog_service):
+        from app.exceptions import ValidationError
+        with pytest.raises(ValidationError):
+            catalog_service.add_attachment(
+                product_id=999999, filename='x.pdf', content=_PDF_BYTES,
+                content_type='application/pdf')
+
+    @pytest.mark.unit
+    def test_get_attachments_empty_and_ordered(self, catalog_service):
+        pid = catalog_service.create_product(description='widget')
+        assert catalog_service.get_attachments_for_product(pid) == []
+        catalog_service.add_attachment(product_id=pid, filename='a.pdf',
+                                       content=_PDF_BYTES, content_type='application/pdf')
+        catalog_service.add_attachment(product_id=pid, filename='b.pdf',
+                                       content=_PDF_BYTES, content_type='application/pdf')
+        rows = catalog_service.get_attachments_for_product(pid)
+        assert [r.filename for r in rows] == ['a.pdf', 'b.pdf']
+
+    @pytest.mark.unit
+    def test_get_attachment_data(self, catalog_service):
+        pid = catalog_service.create_product(description='widget')
+        snap = catalog_service.add_attachment(
+            product_id=pid, filename='ds.pdf', content=_PDF_BYTES,
+            content_type='application/pdf')
+        result = catalog_service.get_attachment_data(snap['id'])
+        assert result == (_PDF_BYTES, 'application/pdf', 'ds.pdf')
+        assert catalog_service.get_attachment_data(999999) is None

--- a/tests/unit/test_product_routes.py
+++ b/tests/unit/test_product_routes.py
@@ -173,3 +173,61 @@ class TestProductPurchases:
         assert data['error']['field'] == 'unit_price'
         # nothing created
         assert CatalogService(test_storage).get_purchases_for_product(pid) == []
+
+
+_PDF = b'%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF'
+
+
+@pytest.mark.unit
+class TestProductAttachments:
+    """Attachment upload/serve + detail-page card (Story 1.5)."""
+
+    def test_detail_shows_attachments_card_and_form(self, client, test_storage):
+        pid = CatalogService(test_storage).create_product(description='widget')
+        resp = client.get(f'/products/{pid}')
+        assert resp.status_code == 200
+        body = resp.data
+        assert b'Attachments' in body
+        assert b'enctype="multipart/form-data"' in body
+        assert b'No attachments' in body  # empty state
+
+    def test_upload_attachment_multipart(self, client, test_storage):
+        import io
+        pid = CatalogService(test_storage).create_product(description='widget')
+        resp = client.post(
+            f'/products/{pid}/attachments',
+            data={'file': (io.BytesIO(_PDF), 'datasheet.pdf')},
+            content_type='multipart/form-data',
+        )
+        assert resp.status_code == 302
+        rows = CatalogService(test_storage).get_attachments_for_product(pid)
+        assert len(rows) == 1
+        assert rows[0].filename == 'datasheet.pdf'
+
+    def test_upload_no_file_flashes_and_creates_nothing(self, client, test_storage):
+        pid = CatalogService(test_storage).create_product(description='widget')
+        resp = client.post(f'/products/{pid}/attachments', data={},
+                           content_type='multipart/form-data', follow_redirects=True)
+        assert resp.status_code == 200
+        assert CatalogService(test_storage).get_attachments_for_product(pid) == []
+
+    def test_upload_to_missing_product_404(self, client):
+        import io
+        resp = client.post('/products/999999/attachments',
+                           data={'file': (io.BytesIO(_PDF), 'x.pdf')},
+                           content_type='multipart/form-data')
+        assert resp.status_code == 404
+
+    def test_serve_attachment_returns_bytes_and_content_type(self, client, test_storage):
+        svc = CatalogService(test_storage)
+        pid = svc.create_product(description='widget')
+        snap = svc.add_attachment(product_id=pid, filename='ds.pdf', content=_PDF,
+                                  content_type='application/pdf')
+        resp = client.get(f'/attachments/{snap["id"]}')
+        assert resp.status_code == 200
+        assert resp.data == _PDF
+        assert resp.headers['Content-Type'] == 'application/pdf'
+        assert resp.headers.get('X-Content-Type-Options') == 'nosniff'
+
+    def test_serve_missing_attachment_404(self, client):
+        assert client.get('/attachments/999999').status_code == 404


### PR DESCRIPTION
## Story 1.5 — Attachments on product or purchase

Final story of **Epic 1 — Product & Purchase Foundation**. Adds file attachments (datasheets, diagrams, photos) stored as BLOBs in the database, owned by exactly one of a Product or a Purchase (AD-12).

### What's included
- **`attachments` table + `Attachment` ORM**: nullable `product_id`/`purchase_id` FKs, `filename`, `content_type`, `file_size`, `content` (`MEDIUMBLOB` on MariaDB / `LargeBinary` on SQLite), `created_at`. The **AD-12 XOR** one-owner rule via `CHECK ((product_id IS NULL) <> (purchase_id IS NULL))` + `file_size > 0`. Migration `f771284e1478` chained from HEAD `46393d2e6c96`.
- **`CatalogService`**: `add_attachment` (XOR / non-empty / 16 MB max / content-type whitelist — all caught `ValidationError`s), `get_attachments_for_product` (BLOB **deferred** so listing never loads bytes), `get_attachment_data`.
- **Product detail page**: an Attachments card (list + CSRF-protected multipart upload). Routes: `POST /products/<id>/attachments` and `GET /attachments/<id>` (inline serve via `send_file` + `X-Content-Type-Options: nosniff`).
- **+16 tests** (10 service, 6 route) — including the repo's first Flask-test-client multipart upload.

### AD-12 dual enforcement
The one-owner rule is enforced **both** in the service (clean `ValidationError`, never a raw `IntegrityError`) **and** by the DB CHECK. Notably, SQLite enforces this CHECK too, so it's covered by the unit suite in addition to the MariaDB round-trip.

### Security
Content-type whitelist admits only PDF + raster images (**SVG excluded** — script-carrying inline-XSS vector); serve sets `nosniff`; no global `MAX_CONTENT_LENGTH` (would regress the 20 MB photo uploads — NFR9), size enforced app-side.

### Verification (disposable MariaDB 11.8 container)
- `SHOW CREATE TABLE attachments`: `content mediumblob NOT NULL`, both FKs, `ck_attachment_one_owner` + `ck_attachment_positive_file_size`, both indexes.
- XOR enforced: one-owner OK; both-owners → `ERROR 4025`; no-owner → `ERROR 4025`.
- `downgrade 46393d2e6c96` (row present) drops `attachments` cleanly; products/purchases/metal-stock intact.
- **Full unit suite: 416 passed** (400 baseline + 16), no regressions.

### Acceptance criteria
- [x] AC1: upload a PDF/image → stored as a DB BLOB, retrievable from the Product view (FR5)
- [x] AC2: XOR one-owner enforced by CHECK + application invariant (AD-12)
- [x] AC3: migration chained from HEAD; clean downgrade; other tables unchanged (AD-14/NFR9)
- [x] AC4: logic in `CatalogService`; routes have no ORM; list defers the BLOB
- [x] AC5: service + route tests (incl. multipart) + MariaDB round-trip verified

**Closes Epic 1.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvNxyuJiBQvRUvrM1iaGHB