### PR TITLE
fix: two async races — the move queue read before its finalize, and the Add Item JA ID overwrite

### DIFF
--- a/app/static/js/inventory-add.js
+++ b/app/static/js/inventory-add.js
@@ -225,6 +225,16 @@ class InventoryAddForm {
             const data = await response.json();
             
             if (response.ok && data.success) {
+                // Re-check the guard on this side of the await. The field was empty
+                // when we started the fetch, but the user (or a barcode scanner) may
+                // have typed into it since, and overwriting that both loses their
+                // input and can concatenate with it -- a programmatic fill selects
+                // the field's contents and then inserts, and a write landing between
+                // those two steps collapses the selection so the insert appends.
+                if (jaIdInput.value.trim() !== '') {
+                    return;
+                }
+
                 jaIdInput.value = data.next_ja_id;
                 console.log(`Auto-populated JA ID: ${data.next_ja_id}`);
                 
@@ -1071,5 +1081,7 @@ class InventoryAddForm {
 
 // Initialize when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
-    new InventoryAddForm();
+    // Exposed like window.moveManager on the move page, so a test can drive
+    // autoPopulateJaId() across its own await boundary.
+    window.addItemForm = new InventoryAddForm();
 });

--- a/app/static/js/inventory-move.js
+++ b/app/static/js/inventory-move.js
@@ -357,7 +357,7 @@ class InventoryMoveManager {
         console.log('Added to move queue:', moveItem);
     }
     
-    handleDoneCode() {
+    async handleDoneCode() {
         this.clearInput();
 
         // If we were in the middle of entering a move, finalize or clear it
@@ -367,8 +367,11 @@ class InventoryMoveManager {
             this.currentExpectedInput = 'ja_id';
             this.showAlert('Partial entry cleared (JA ID without location).', 'info');
         } else if (this.currentExpectedInput === 'ja_id_or_sub_location') {
-            // We have JA ID and location but no sub-location - finalize without sub-location
-            this.finalizeCurrentMove(null);
+            // We have JA ID and location but no sub-location - finalize without sub-location.
+            // Await it: finalizeCurrentMove() pushes to moveQueue on the far side of a
+            // fetch, so without the await the length check below reads 0 and reports the
+            // queue empty for the move it is in the middle of queueing.
+            await this.finalizeCurrentMove(null);
             this.showAlert('Finalized last entry without sub-location.', 'info');
         }
 

--- a/tests/e2e/pages/add_item_page.py
+++ b/tests/e2e/pages/add_item_page.py
@@ -46,16 +46,15 @@ class AddItemPage(BasePage):
         directly rather than coming through here.
         """
         # The add page fills #ja_id itself, from GET /api/inventory/next-ja-id.
-        # Its "only if the field is empty" guard is checked *before* that await
-        # and the write lands *after* it, so a fill() issued in the gap has its
-        # selection collapsed by the page's write and appends instead of
-        # replacing -- leaving "JA000123JA000123", which fails the field's
-        # pattern. The browser then refuses the submit, and native constraint
-        # validation leaves no trace in the DOM, so the test carries on as though
-        # the item exists and fails much later somewhere else.
+        # autoPopulateJaId() re-checks "only if the field is empty" on the far
+        # side of that fetch, so it will not clobber a value we have already
+        # typed -- but fill() is select-then-insert, and a write landing between
+        # those two steps still collapses the selection and appends, leaving
+        # "JA000123JA000123". That fails the field's pattern, the browser refuses
+        # the submit, and native constraint validation leaves no trace in the DOM.
         #
-        # Let the page's own write land first. It is a one-shot on init, so once
-        # the field is non-empty nothing else will touch it.
+        # Let the page's own write land first and confirm ours stuck. It is a
+        # one-shot on init, so once the field is non-empty nothing else touches it.
         ja_field = self.page.locator(self.JA_ID_INPUT)
         expect(ja_field).not_to_have_value("")
         self.fill_and_wait(self.JA_ID_INPUT, ja_id)

--- a/tests/e2e/test_ja_id_generation.py
+++ b/tests/e2e/test_ja_id_generation.py
@@ -197,6 +197,44 @@ def test_ja_id_auto_population_with_existing_items(page, live_server):
 
 
 @pytest.mark.e2e
+def test_auto_population_does_not_overwrite_input_typed_during_its_fetch(page, live_server):
+    """#69: a value typed while GET /api/inventory/next-ja-id is in flight survives.
+
+    autoPopulateJaId() used to check "only if the field is empty" *before* its
+    await and write the result *after* it, so anything entered in between was
+    silently overwritten -- and, because a programmatic fill selects the field's
+    contents and then inserts, a write landing between those two steps collapsed
+    the selection and produced `JA000123JA000123`. That fails the field's
+    `pattern`, the browser refuses the submit, and native constraint validation
+    leaves nothing in the DOM to say so.
+
+    The race is reproduced exactly rather than approximated. autoPopulateJaId()
+    runs synchronously up to `await fetch(...)`, so the guard has already been
+    evaluated against an empty field by the time the call returns its promise;
+    typing at that point lands squarely inside the window. page.evaluate()
+    awaits the returned promise, so when it comes back the response has been
+    handled and the field holds whatever the handler decided to leave there.
+    """
+    add_page = AddItemPage(page, live_server.url)
+    add_page.navigate()
+
+    ja_id_field = page.locator('#ja_id')
+    # The page's own one-shot population, so the re-population below is the only
+    # fetch in flight when we type.
+    expect(ja_id_field).not_to_have_value('')
+
+    page.evaluate("""() => {
+        const field = document.getElementById('ja_id');
+        field.value = '';                                  // empty when the guard reads it
+        const populated = window.addItemForm.autoPopulateJaId();
+        field.value = 'JA999999';                          // typed while the fetch is in flight
+        return populated;
+    }""")
+
+    expect(ja_id_field).to_have_value('JA999999')
+
+
+@pytest.mark.e2e
 def test_api_next_ja_id_endpoint(page, live_server):
     """Test the API endpoint directly"""
     # Navigate to any page to establish session

--- a/tests/e2e/test_move_items_sub_location.py
+++ b/tests/e2e/test_move_items_sub_location.py
@@ -25,12 +25,13 @@ class TestMoveItemsSubLocation:
 
         Two things here are load-bearing and neither is obvious.
 
-        The add page fills #ja_id itself, from GET /api/inventory/next-ja-id. Its
-        "only if the field is empty" guard is checked *before* that await and the
-        write lands *after* it, so a fill() issued in the gap has its selection
-        collapsed by the page's write and appends instead of replacing --
-        leaving "JA000102JA000102", which fails the field's pattern. Let the
-        page's own write land first, and confirm ours stuck.
+        The add page fills #ja_id itself, from GET /api/inventory/next-ja-id.
+        autoPopulateJaId() re-checks "only if the field is empty" on the far side
+        of that fetch, so it will not clobber a value we have already typed -- but
+        fill() is select-then-insert, and a write landing between those two steps
+        still collapses the selection and appends, leaving "JA000102JA000102",
+        which fails the field's pattern. Let the page's own write land first, and
+        confirm ours stuck.
 
         And a submit the browser refuses leaves no trace in the DOM, so an item
         that was never created is invisible here. It resurfaces much later as a
@@ -84,6 +85,18 @@ class TestMoveItemsSubLocation:
 
         # Complete scanning
         scan_on_move_page(page, '>>DONE<<')
+
+        # #67: handleDoneCode() used to read moveQueue.length before its own
+        # un-awaited finalise had pushed to it, so on this path -- one move
+        # pending, nothing else queued -- it warned that the queue was empty and
+        # returned before setting either of these. The queue row and an enabled
+        # Validate button appeared a moment later regardless, which is why the
+        # rest of this test passed throughout. Assert the reporting, not just the
+        # outcome.
+        expect(page.locator('#scanner-status')).to_have_text('Done - Ready to Validate')
+        expect(page.locator('#status-text')).to_contain_text(
+            'Scan completed. 1 items queued for moving.'
+        )
 
         # Verify queue shows correct sub-location info
         queue_table = page.locator('#queue-items')

--- a/tests/e2e/waits.py
+++ b/tests/e2e/waits.py
@@ -42,9 +42,11 @@ def scan_on_move_page(page: Page, value: str) -> None:
 
     The pre-scan state and queue length are read from the page before typing,
     because which transition this is depends on where the state machine already
-    was. `Done - Ready to Validate` is deliberately not used after >>DONE<<: on
-    the one-pending-move path handleDoneCode() tests moveQueue.length before its
-    own un-awaited finalise has landed, returns early, and never sets it.
+    was. `Done - Ready to Validate` is still not used as the signal after
+    >>DONE<<, even though #67 made it reachable on the one-pending-move path:
+    handleDoneCode() also returns early without setting it when the queue ends up
+    empty, and #queue-count is the one condition that holds for every path
+    through the handler.
     """
     before = page.evaluate(
         "() => ({ state: window.moveManager.currentExpectedInput,"


### PR DESCRIPTION
Fixes #67 and #69 — the two application races found while removing the timed waits from the e2e suite in #65/#68. Both are pre-existing and both are one-liners; the surrounding work is the regression coverage.

## #67 — the move page reported an empty queue for the move it was queueing

`handleDoneCode()` called `finalizeCurrentMove()` without awaiting it. That function pushes to `moveQueue` on the far side of `await fetch('/api/items/{jaId}')`, so the `moveQueue.length === 0` check immediately below still read 0, showed *"No items in move queue. Add some items before finishing."*, and returned early past the three lines that report success. `Done - Ready to Validate` and `Scan completed. N items queued` were unreachable on the most ordinary path through the page.

It self-corrected — when the fetch resolved, `updateUI()` → `updateButtonStates()` re-enabled Validate anyway — which is why the queue row and a clickable button appeared a moment later regardless, and why the existing tests, which assert on the queue table rather than the badge, passed throughout.

The fix is `await`. `handleDoneCode()` becomes `async`; both callers ignore its return value.

The un-awaited finalize at `processInput()` line 235 is left alone — that one is deliberate, letting the next scan start while the previous move is still resolving.

## #69 — the Add Item form overwrote what the user was typing

`autoPopulateJaId()` evaluated *"only auto-populate if the field is empty"* **before** `await fetch('/api/inventory/next-ja-id')` and wrote the result **after** it, so by the time the response landed the guard's answer was stale. Anything typed in between was lost — or concatenated, leaving `JA000123JA000123`, because a programmatic fill selects the field's contents and then inserts, and a write landing between those two steps collapses the selection so the insert appends.

That value fails `pattern="JA[0-9]{6}"`, the browser refuses the submit, and native constraint validation leaves **no trace in the DOM**. The form just appears to do nothing.

The fix re-checks the guard on the far side of the await.

## Tests

Both new assertions were confirmed to fail against the unfixed handlers before being kept:

- `JA000001` overwrote the typed `JA999999`
- the scanner badge sat at `Ready for JA ID` instead of `Done - Ready to Validate`

**#67** — `test_move_no_sub_to_no_sub` already takes this exact path, so it now asserts the two strings the bug made unreachable. No new test, no added runtime.

**#69** — a new test that reproduces the race exactly rather than approximating it with a stalled route. `autoPopulateJaId()` runs synchronously up to its `fetch`, so the guard has already read an empty field by the time the call returns its promise; a value written at that point lands squarely inside the window, and `page.evaluate()` awaits the promise so the assertion runs after the response was handled. Deterministic, 0.33s, and no new interception machinery in the suite.

This needs the instance, so the add page now exposes `window.addItemForm` — mirroring the `window.moveManager` the move page already exposes for the same reason.

## Two judgement calls worth a look

**The e2e workarounds stay.** #69 proposed deleting the pre-fill waits in `AddItemPage.fill_basic_item_data()` and `TestMoveItemsSubLocation.add_test_item()`. The handler fix closes the guard-vs-await race, but Playwright's `fill()` is still select-then-insert, so the page's write can in principle still land between those two CDP steps. Letting the page's one-shot write land first remains the correct state-wait and costs nothing. Their comments are retuned to describe the code as it now is rather than a bug that no longer exists. The three files the issue flags as latently exposed (`test_label_printing.py`, `test_material_selector.py`, `test_material_field_validation.py`) are left unguarded — the handler fix covers them.

**`waits.scan_on_move_page` still waits on `#queue-count` after `>>DONE<<`, not on the badge.** #67 makes `Done - Ready to Validate` reachable on the one-pending-move path, but `handleDoneCode()` still returns early without setting it when the queue ends up empty. `#queue-count` is the one condition that holds for every path through the handler. The docstring's stale rationale is updated.

## Verification

- `nox -s tests` — 807 passed
- `nox -s e2e` — 363 passed in 8m10s, in line with the 8m13s baseline, working tree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhiaBRA2GMdGGVpawqSV4g
