### PR TITLE
docs(catalog): name the revision feature 001's downgrade walks back to

### DIFF
--- a/specs/001-product-catalog/quickstart.md
+++ b/specs/001-product-catalog/quickstart.md
@@ -25,14 +25,25 @@ success criteria; details of shapes and payloads live in [data-model.md](./data-
 ## Setup
 
 ```bash
-venv/bin/python manage.py db upgrade      # apply the new catalogue revisions
-venv/bin/python manage.py db downgrade -1 # exercise the downgrade, then re-upgrade
-venv/bin/python manage.py db upgrade
+venv/bin/python manage.py db upgrade                  # apply b1a0c0d10001..b1a0c0d10005
+venv/bin/python manage.py db downgrade 8213852b0b94   # exercise the downgrades
+venv/bin/python manage.py db upgrade                  # and come back
 ```
+
+Name the previous revision explicitly. `db downgrade -1` is the form you will reach for and it
+does not work here — this Flask-Migrate CLI parses `-1` as an option and exits with
+`Error: No such option '-1'` before Alembic sees it. This feature's five revisions sit on top of
+`8213852b0b94`, so naming it walks the whole chain down in one command.
 
 Exercising the downgrade is not optional: Constitution V requires each revision's `downgrade` to
 have been run, and against **MariaDB** — SQLite will not catch an index/FK ordering fault, which
-is a failure mode this repository has already hit once.
+is a failure mode this repository has already hit once. This chain is the one most likely to
+expose that: the six tables it creates are linked by foreign keys, so they only drop cleanly in
+the right order.
+
+Confirm it actually moved rather than trusting the exit code. `SHOW TABLES` should list
+`products`, `purchases`, `product_identifiers`, `tags`, `product_tags` and `product_attachments`
+after each upgrade and none of them in between.
 
 ---
 

--- a/specs/001-product-catalog/quickstart.md
+++ b/specs/001-product-catalog/quickstart.md
@@ -25,15 +25,21 @@ success criteria; details of shapes and payloads live in [data-model.md](./data-
 ## Setup
 
 ```bash
-venv/bin/python manage.py db upgrade                  # apply b1a0c0d10001..b1a0c0d10005
+venv/bin/python manage.py db upgrade b1a0c0d10005     # apply b1a0c0d10001..b1a0c0d10005
 venv/bin/python manage.py db downgrade 8213852b0b94   # exercise the downgrades
-venv/bin/python manage.py db upgrade                  # and come back
+venv/bin/python manage.py db upgrade                  # and come back, to whatever head is now
 ```
 
-Name the previous revision explicitly. `db downgrade -1` is the form you will reach for and it
-does not work here — this Flask-Migrate CLI parses `-1` as an option and exits with
+Name both revisions explicitly. `db downgrade -1` is the form you will reach for and it does not
+work here — this Flask-Migrate CLI parses `-1` as an option and exits with
 `Error: No such option '-1'` before Alembic sees it. This feature's five revisions sit on top of
 `8213852b0b94`, so naming it walks the whole chain down in one command.
+
+The upgrade is pinned for the same reason. A bare `db upgrade` goes to the current head, which is
+no longer `b1a0c0d10005` — later features have added revisions on top — so it would apply and
+then walk back more than this feature owns. Pinning keeps the round trip to the five revisions
+under test, provided you start from `8213852b0b94`; if the database is already ahead of that, the
+pinned upgrade is a no-op and the downgrade still walks the newer revisions down.
 
 Exercising the downgrade is not optional: Constitution V requires each revision's `downgrade` to
 have been run, and against **MariaDB** — SQLite will not catch an index/FK ordering fault, which


### PR DESCRIPTION
Fixes #73.

`specs/001-product-catalog/quickstart.md` told you to exercise the downgrade with `db downgrade -1`, which cannot run — this Flask-Migrate CLI parses `-1` as an option and exits with `Error: No such option '-1'` before Alembic sees it. The failure lands on exactly the step Constitution V makes non-negotiable, so the natural reaction is to skip the downgrade rather than debug the doc.

## The change

Name the previous revision explicitly, as `specs/004-catalog-taxonomy-tidy/quickstart.md` and `specs/005-structured-specifications/quickstart.md` already do:

```bash
venv/bin/python manage.py db upgrade                  # apply b1a0c0d10001..b1a0c0d10005
venv/bin/python manage.py db downgrade 8213852b0b94   # exercise the downgrades
venv/bin/python manage.py db upgrade                  # and come back
```

Feature 001's chain is `b1a0c0d10001`–`b1a0c0d10005` on top of `8213852b0b94` (verified against `migrations/versions/`), so that one revision id walks all five down together — which is what you want here, since `-1` would only have moved one step of five anyway.

Also carried over from feature 004's copy:

- the note explaining *why* `-1` is wrong, so the next person does not reach for it again;
- the reminder to confirm the move with `SHOW TABLES` rather than trusting the exit code. The six tables this chain creates (`products`, `purchases`, `product_identifiers`, `tags`, `product_tags`, `product_attachments`) are FK-linked and only drop cleanly in the right order — precisely the fault SQLite would not catch, and one this repo has hit before.

## Scope

Docs only. No code change, nothing depends on this at runtime, so no suite was run.

`specs/001-product-catalog/tasks.md` T016 was checked and does **not** use the broken form — it says plain `db downgrade`, so it is left alone. `specs/004-catalog-taxonomy-tidy/tasks.md` T004 still reads `-1`, deliberately: its completion notes record the deviation and keep the task text "as the record of what was planned."

I did not re-run `db downgrade -1` to confirm the error — the failure is already reproduced and recorded in this repo at `specs/004-catalog-taxonomy-tidy/tasks.md:261`, and the sandbox declined the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhiaBRA2GMdGGVpawqSV4g