### PR TITLE
Screenshots: replace an unpassable CI diff with an honest reminder

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -24,7 +24,12 @@ jobs:
   remind:
     runs-on: ubuntu-latest
     permissions:
+      # The comment goes through the issues API (a PR is an issue there), so
+      # grant issues: write alongside pull-requests: write. GitHub's docs do not
+      # settle which of the two that endpoint checks, and the other workflows
+      # here that comment on PRs grant both.
       pull-requests: write
+      issues: write
 
     steps:
       - name: Comment on PR

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,4 +1,15 @@
-name: Screenshot Verification
+name: Screenshot Reminder
+
+# This job used to regenerate the screenshots in CI and diff them against the
+# committed ones. That check could never pass: CI rasterizes fonts differently
+# than the machine the screenshots were committed from, so every glyph on every
+# page differed by a few units and `git diff` reported all twelve files changed
+# on every run. It was informational, so it never blocked anything -- it just
+# posted the same comment on every PR touching the UI.
+#
+# What is left is an honest reminder. It does not claim to know whether the
+# screenshots are stale; it says the PR touched UI files and leaves the judgment
+# to the author. See issue #77.
 
 on:
   pull_request:
@@ -8,147 +19,51 @@ on:
       - 'app/static/js/**'
       - 'tests/e2e/test_screenshot_generation.py'
       - 'tests/e2e/fixtures/screenshot_data.py'
-  workflow_dispatch:  # Allow manual trigger
 
 jobs:
-  verify-screenshots:
+  remind:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write
-      issues: write
-
-    services:
-      mariadb:
-        image: mariadb:11.8
-        env:
-          MYSQL_ROOT_PASSWORD: test_root_password
-          MYSQL_DATABASE: workshop_inventory_test
-          MYSQL_USER: inventory_test_user
-          MYSQL_PASSWORD: test_password
-          MARIADB_CHARACTER_SET_SERVER: utf8mb4
-          MARIADB_COLLATION_SERVER: utf8mb4_unicode_ci
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="healthcheck.sh --connect --innodb_initialized"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 2  # Need history to compare
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-
-      - name: Install system dependencies for pybluez
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            bluetooth libbluetooth-dev
-
-      - name: Cache dependencies
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install nox
-        run: pip install nox
-
-      - name: Wait for MariaDB to be ready
-        run: |
-          for i in {1..30}; do
-            if mysqladmin ping -h127.0.0.1 -P3306 -uinventory_test_user -ptest_password --silent; then
-              echo "MariaDB is ready"
-              break
-            fi
-            echo "Waiting for MariaDB... ($i/30)"
-            sleep 2
-          done
-
-      - name: Set up test database
-        run: |
-          mysql -h127.0.0.1 -P3306 -uinventory_test_user -ptest_password workshop_inventory_test -e "SELECT 1"
-          echo "Database connection verified"
-
-      - name: Regenerate screenshots
-        run: nox -s screenshots_headless
-        env:
-          CI: 'true'
-          PLAYWRIGHT_HEADLESS: true
-          USE_TEST_MARIADB: 1
-          TEST_DB_HOST: 127.0.0.1
-          TEST_DB_PORT: 3306
-          TEST_DB_USER: inventory_test_user
-          TEST_DB_PASSWORD: test_password
-          TEST_DB_NAME: workshop_inventory_test
-
-      - name: Check for screenshot differences
-        id: check_diff
-        run: |
-          if git diff --quiet docs/images/screenshots/; then
-            echo "status=up-to-date" >> $GITHUB_OUTPUT
-            echo "✅ No screenshot differences detected"
-            echo ""
-            echo "This could mean:"
-            echo "  • Screenshots were already regenerated and committed"
-            echo "  • UI changes don't affect screenshot content"
-          else
-            echo "status=outdated" >> $GITHUB_OUTPUT
-            echo "ℹ️  Screenshot differences detected"
-            echo ""
-            echo "Changed screenshot files:"
-            git diff --name-only docs/images/screenshots/
-            echo ""
-            echo "This is expected when UI files change."
-            echo ""
-            echo "If you haven't already, regenerate and commit screenshots:"
-            echo "  1. Run: nox -s screenshots"
-            echo "  2. Review the changes"
-            echo "  3. Commit the updated screenshots with your UI changes"
-            echo ""
-            echo "Updated screenshots are available as artifacts for comparison."
-          fi
-
-      - name: Upload regenerated screenshots
-        if: steps.check_diff.outputs.status == 'outdated'
-        uses: actions/upload-artifact@v7
-        with:
-          name: regenerated-screenshots
-          path: docs/images/screenshots/
-          retention-days: 7
-
-      - name: Comment on PR with screenshot info
-        if: github.event_name == 'pull_request' && steps.check_diff.outputs.status == 'outdated'
+      - name: Comment on PR
         uses: actions/github-script@v9
         with:
           script: |
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '## 📸 Screenshot Update Reminder\n\n' +
-                    'This PR modifies UI files. Screenshot differences were detected when regenerating in CI.\n\n' +
-                    '### Next Steps\n\n' +
-                    'If you haven\'t already, please regenerate and commit screenshots:\n\n' +
-                    '```bash\n' +
-                    'nox -s screenshots\n' +
-                    'git add docs/images/screenshots/\n' +
-                    'git commit -m "Update screenshots for UI changes"\n' +
-                    '```\n\n' +
-                    '### Review\n\n' +
-                    '✅ Updated screenshots are available in the workflow artifacts for comparison\n\n' +
-                    '💡 **Note**: Minor differences in screenshots can occur due to rendering variations. ' +
-                    'The pre-commit hook will also remind you about screenshot updates.\n\n' +
-                    '---\n' +
-                    '*This is an informational message and does not block merging.*'
-            })
+            const marker = '<!-- screenshot-reminder -->'
+            const body = marker + '\n' +
+              '## 📸 Screenshot reminder\n\n' +
+              'This PR touches UI files. If the change is visible in any of the ' +
+              'documentation screenshots, regenerate them:\n\n' +
+              '```bash\n' +
+              'nox -s screenshots\n' +
+              'git add docs/images/screenshots/\n' +
+              '```\n\n' +
+              'Regeneration is not reproducible today — rendered timestamps and ' +
+              'form validation state vary between runs, so expect some files to ' +
+              'change without a real UI difference. Review the diff and keep only ' +
+              'what you meant to change.\n\n' +
+              '---\n' +
+              '*Informational only. Nothing here blocks the merge.*'
+
+            const { owner, repo } = context.repo
+            const issue_number = context.issue.number
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number }
+            )
+            const mine = existing.find(c =>
+              c.user.type === 'Bot' && c.body.includes(marker)
+            )
+
+            if (mine) {
+              await github.rest.issues.updateComment(
+                { owner, repo, comment_id: mine.id, body }
+              )
+            } else {
+              await github.rest.issues.createComment(
+                { owner, repo, issue_number, body }
+              )
+            }

--- a/docs/development-testing-guide.md
+++ b/docs/development-testing-guide.md
@@ -204,9 +204,9 @@ The project includes a pre-commit hook that reminds you to regenerate screenshot
 ❓ Did you update screenshots? (y/n/skip)
 ```
 
-#### CI/CD Verification
+#### CI/CD Reminder
 
-GitHub Actions automatically verifies screenshots on pull requests:
+GitHub Actions posts a reminder on pull requests that touch the UI:
 
 **Workflow**: `.github/workflows/screenshots.yml`
 
@@ -215,16 +215,17 @@ GitHub Actions automatically verifies screenshots on pull requests:
 - CSS/JavaScript
 - Screenshot test files
 
-**Actions**:
-1. Regenerates all screenshots
-2. Compares with committed versions
-3. Fails if screenshots are outdated
-4. Comments on PR with instructions
-5. Provides regenerated screenshots as artifacts
+**Actions**: posts (or updates) a single comment suggesting `nox -s screenshots`.
+
+CI does **not** check whether the screenshots are current — it cannot. It used to
+regenerate them and diff against the committed copies, but CI rasterizes fonts
+differently than the machine the screenshots were committed from, so every file
+differed on every run regardless of whether the UI had changed. Deciding whether
+a change is visible enough to warrant regenerating is the author's call.
 
 **PR Requirements:**
-- If you modify UI files, you must regenerate and commit screenshots
-- CI will block merge if screenshots are out of date
+- If you change the UI in a way the screenshots show, regenerate and commit them
+- Nothing blocks the merge either way
 
 ### Screenshot Test Structure
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -91,12 +91,13 @@ To modify hooks:
 
 ## CI/CD Integration
 
-The pre-commit hook is complemented by CI/CD checks:
+The pre-commit hook is complemented by a CI reminder:
 
 - **GitHub Actions** (`.github/workflows/screenshots.yml`)
   - Runs on PRs that modify UI files
-  - Regenerates screenshots
-  - Fails if screenshots are outdated
-  - Provides download of regenerated screenshots
+  - Posts a single comment suggesting `nox -s screenshots`
 
-This ensures screenshots stay synchronized even if developers skip local hooks.
+CI cannot tell whether the screenshots are stale — it used to regenerate and diff
+them, but font rasterization differs between CI and the machine that committed
+them, so the diff was never empty. Both this hook and the workflow are reminders;
+the judgment is the author's.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -73,7 +73,9 @@ git commit --no-verify
 # Or respond "skip" when prompted by the hook
 ```
 
-**Note:** Use bypass sparingly. CI/CD will still check screenshots on PRs.
+**Note:** Nothing downstream will catch a skipped regeneration. CI posts a
+reminder on PRs that touch UI files, but it cannot tell whether the screenshots
+are stale — see [CI/CD Integration](#cicd-integration) below.
 
 ## Uninstalling
 


### PR DESCRIPTION
Closes #77

The screenshot job regenerated the twelve documentation screenshots in CI and diffed them against the committed copies, on the theory that a difference meant the UI had changed and the screenshots were stale. The check could never pass, so it reported "differences detected" on every run — all 10 most recent included — and taught us to ignore it.

## Why it could never pass

Four independent causes, each sufficient on its own. Confirmed against the artifact from run `31311051929` and a local regeneration, not reasoned about:

1. **`metadata.json` is a timestamp file inside the diffed directory.** `screenshot_generator.py:32` and `:272` stamp `datetime.now()` into `generated_at` and every entry. It is also broken independently — the autouse fixture builds a fresh generator per test and `save_metadata` overwrites, so the committed file records 1 screenshot out of 12.
2. **Screenshots render the wall clock.** `date_added`/`last_modified` go through `toLocaleTimeString()` (`history-viewer.js:222`). `history_view.png` shows `12:47 AM` committed vs `12:03 PM` on a rerun — same data, different clock.
3. **CI rasterizes fonts differently than the machine the screenshots were committed from.** All 12 files differ by **1.2–3.6% of their pixels**, and the diff mask is a ghost outline of every glyph on the page — same words, same positions, different antialiasing. Byte equality across those two environments is not achievable.
4. **Async UI state is unsettled at capture.** A same-machine rerun changed 6 of 12 files; `add_item_form.png`'s diff is every input's *border* and nothing else, because `MaterialValidator` adds `is-valid` after an awaited fetch (`material-validation.js:97`).

A fifth was waiting behind #2: there is no `browser_context_args` fixture, so browser locale and timezone are inherited from the host — `America/New_York` locally, UTC on runners.

## Why not fix the diff instead

That needs all of: pinned locale/timezone; explicit timestamps on every seeded row (they default to `func.now()` — **MariaDB's** NOW(), so `freezegun` cannot reach them); `metadata.json` out of the diff; per-capture async waits across 16 captures; and generation inside a pinned container in both places so rasterization matches. The container is the load-bearing step and is unproven until attempted, with no fallback if it fails — a tolerance comparator cannot work here, because the font noise is the same magnitude as a genuine small UI change.

Options were laid out on the issue and the reminder-only one was chosen.

## What this does

The workflow keeps its path filter and now does one thing: post a comment saying the PR touched UI files and suggesting `nox -s screenshots`. It updates that comment in place on subsequent pushes rather than stacking new ones, and it says outright that regeneration is not currently reproducible — so this reminder does not become the next thing we learn to ignore. The MariaDB service, the Playwright run, the diff and the artifact upload are gone; the job is seconds instead of ~1m50s. Nothing about it blocked a merge before and nothing does now.

`docs/development-testing-guide.md` and `hooks/README.md` both claimed CI verifies screenshots and blocks merges. Neither was true even before this change; both are corrected. The pre-commit hook is unchanged.

## Left open

The four generator bugs are still there. They no longer produce false CI signal, but they do make a manual `nox -s screenshots` touch files whose UI did not change. Worth a follow-up if that friction bites. Separately, `docs/images/screenshots/GENERATION_GUIDE.md:173` still advises `page.wait_for_timeout()`, which contradicts the e2e waiting rules in `CLAUDE.md`.

## Verification

No application code is touched — CI config and docs only. The workflow YAML parses and resolves to a single `remind` job on the `pull_request` trigger; this PR touches no UI paths, so the path filter correctly does not fire on it. Exercising the reminder itself requires a PR that touches `app/templates/**`, `app/static/css/**` or `app/static/js/**`, which the next UI change will do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7LLGYmpXK2Jof2zDfZJRH
