### PR TITLE
feat(catalog): age a hand-set flag, and stop calling a receipt a count

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/007-product-page-capture"
+  "feature_directory": "specs/008-trustworthy-stock-age"
 }

--- a/app/catalog_service.py
+++ b/app/catalog_service.py
@@ -389,6 +389,18 @@ class CatalogService:
         Independent of any count: an untracked product can be flagged low, which
         is the whole point -- the operator knows things the count does not.
 
+        Storing a flag also records **when** it was stored (008 FR-001), and
+        that happens even when the value stored equals the value already there
+        (008 FR-002): re-pressing "Low" on a product already flagged low is the
+        operator saying "I have just looked and it is still low", which is the
+        only way to renew the evidence on a product that has no count. It is
+        also what makes the re-assertion produce an UPDATE at all -- assigning
+        an identical string is no change as far as SQLAlchemy is concerned, so
+        before feature 008 that button press did nothing.
+
+        Clearing the flag discards its date with it (008 FR-003), so a later
+        flag can never inherit an older one's.
+
         Args:
             product_id: The product.
             stock_status: 'low', 'out', or None to clear the flag.
@@ -419,6 +431,9 @@ class CatalogService:
                     f"Product {product_id} not found", item_id=str(product_id)
                 )
             product.stock_status = value
+            # Written unconditionally, including when `value` equals what is
+            # already stored: 008 FR-002 makes a re-assertion a fresh look.
+            product.stock_status_updated_at = datetime.now() if value else None
 
         return self.get_product(product_id)
 
@@ -560,6 +575,11 @@ class CatalogService:
             ItemNotFoundError: If the product does not exist.
             ValidationError: If a supplied field fails validation.
         """
+        # Deliberately excludes quantity, stock_status and both of their dates.
+        # Those are written by set_quantity, set_stock_status, create_product and
+        # receive_purchase, and by nothing else -- which is the whole of why
+        # "what can reset an age" (008 SC-003) is answerable by reading four
+        # functions rather than auditing the codebase. Do not add them here.
         editable = {
             'description', 'manufacturer', 'manufacturer_part_number',
             'specifications', 'category_path', 'location', 'sub_location',
@@ -1246,6 +1266,15 @@ class CatalogService:
         the count changes, but a manually flagged product stays flagged until
         something clears it, and nothing else knows the operator's intent.
 
+        A tracked count goes up by what arrived, and its **age does not move**
+        (008 FR-007, FR-008). Those are two halves of one rule: the number the
+        catalogue reports should account for the delivery, and the date beside it
+        should keep meaning "the last time a person counted". Adding to a count
+        from a packing slip is not counting, and a screen that says otherwise
+        undermines the age display everything else here depends on. What the
+        receipt changed is recorded, with its date and quantity, on the purchase
+        that changed it.
+
         Marking an already-received purchase received again is a no-op, not an
         error.
 
@@ -1313,19 +1342,26 @@ class CatalogService:
 
             if product is not None and not already_received:
                 # A tracked count goes up by what arrived, which clears any
-                # threshold-derived low on its own.
+                # threshold-derived low on its own (008 FR-007).
+                #
+                # The count's age is deliberately *not* touched (008 FR-008).
+                # Arithmetic against a packing slip is not a verification: the
+                # number moved, but nobody has looked in the drawer, and
+                # quantity_updated_at means the last time somebody did.
                 if product.quantity is not None and purchase.quantity:
                     product.quantity = product.quantity + purchase.quantity
-                    product.quantity_updated_at = datetime.now()
 
                 # The manual flag has to be cleared explicitly -- this is the
-                # other half of FR-029, and the half nothing else covers.
+                # other half of FR-029, and the half nothing else covers. Its
+                # date goes with it (008 FR-006), so that a flag set again
+                # later cannot inherit this one's age.
                 if product.stock_status is not None:
                     logger.info(
-                        f"Clearing manual stock flag on product {product.id}: "
-                        f"purchase {purchase_id} received"
+                        f"Clearing manual stock flag and its date on product "
+                        f"{product.id}: purchase {purchase_id} received"
                     )
                     product.stock_status = None
+                    product.stock_status_updated_at = None
 
         return self.get_purchase(purchase_id)
 

--- a/app/database.py
+++ b/app/database.py
@@ -857,6 +857,13 @@ class Product(Base):
     # The operator's manual flag (FR-025): NULL, 'low' or 'out'. Independent of
     # quantity.
     stock_status = Column(String(20), nullable=True)
+    # When the flag was last set; drives its relative age display (008 FR-001).
+    # NULL alongside a flag means the date was never recorded -- every row
+    # predating feature 008 -- and is rendered as unknown, never guessed at.
+    # Must match migration b1a0c0d10010 exactly: the unit suite builds its
+    # schema with create_all and never runs Alembic, so drift between the two
+    # passes `nox -s tests` and fails on the real database.
+    stock_status_updated_at = Column(DateTime, nullable=True)
 
     notes = Column(Text, nullable=True)
 
@@ -942,7 +949,14 @@ class Product(Base):
 
     @property
     def quantity_age(self) -> Optional[timedelta]:
-        """How long ago the quantity was counted (FR-024).
+        """How long ago an operator last counted the quantity (FR-024).
+
+        Not "how long ago the number was last written", and the difference is
+        the point of feature 008: receiving a purchase adds the received
+        quantity here and deliberately leaves this age alone (008 FR-008),
+        because arithmetic against a packing slip is not a verification. Do not
+        restore a timestamp write to ``receive_purchase`` -- it looks like a
+        missing update and it is the bug that feature removed.
 
         None when the quantity is not tracked, and also when it is tracked but
         no timestamp was recorded -- an unknown age is not an error, and the
@@ -951,6 +965,22 @@ class Product(Base):
         if self.quantity is None or self.quantity_updated_at is None:
             return None
         return datetime.now() - self.quantity_updated_at
+
+    @property
+    def stock_status_age(self) -> Optional[timedelta]:
+        """How long ago the manual flag was set (008 FR-001, FR-004).
+
+        A line-for-line mirror of ``quantity_age``, down to the double None
+        guard, on purpose: two properties answering the same question about
+        different evidence should not be two different shapes.
+
+        None when there is no flag, and also when there is one but no date was
+        recorded -- an unknown age is not an error, and the display renders it
+        as unknown rather than raising.
+        """
+        if self.stock_status is None or self.stock_status_updated_at is None:
+            return None
+        return datetime.now() - self.stock_status_updated_at
 
     @property
     def internal_code(self) -> Optional[str]:
@@ -976,6 +1006,10 @@ class Product(Base):
             'quantity_updated_at': self.quantity_updated_at.isoformat() if self.quantity_updated_at else None,
             'reorder_threshold': self.reorder_threshold,
             'stock_status': self.stock_status,
+            'stock_status_updated_at': (
+                self.stock_status_updated_at.isoformat()
+                if self.stock_status_updated_at else None
+            ),
             'notes': self.notes,
             'internal_code': self.internal_code,
             'is_tracked': self.is_tracked,

--- a/app/product/routes.py
+++ b/app/product/routes.py
@@ -723,16 +723,27 @@ def purchase_receive(purchase_id):
 # ---------------------------------------------------------------------------
 
 @bp.app_template_filter('relative_age')
-def relative_age(age) -> str:
+def relative_age(age, unknown: str = 'never counted') -> str:
     """Render a timedelta the way a person would say it (FR-024).
 
     "counted 8 months ago" is a judgement the operator can make. A bare number
     presents a count as currently authoritative when it may be a year stale, and
     a staleness *flag* would need a policy -- how old is stale? -- that nobody has
     measured and the spec does not state.
+
+    A count's age and a manual flag's age are both rendered here, which is 008
+    FR-012 satisfied by construction: two pieces of evidence on one screen
+    cannot drift into different vocabularies if one function renders both. Only
+    the no-date wording differs, hence ``unknown`` -- "never counted" is right
+    for a count and wrong for a flag, which was certainly set; its date simply
+    was not recorded. The flag templates pass 'at an unknown time'.
+
+    Args:
+        age: The timedelta to render, or None.
+        unknown: What to say when there is no age to render.
     """
     if age is None:
-        return 'never counted'
+        return unknown
 
     days = age.days
     if days < 0:

--- a/app/templates/product/detail.html
+++ b/app/templates/product/detail.html
@@ -328,6 +328,15 @@
                     <button type="button" class="btn btn-lg btn-outline-secondary stock-status-btn"
                             data-status="" id="clear-flag-btn">Clear</button>
                 </div>
+                {% if product.stock_status %}
+                {# 008 FR-004: a flag is evidence too, and evidence with no date
+                   on it cannot be judged. Absent -- not empty -- when there is
+                   no flag, so there is nothing to age. #}
+                <div class="text-muted small mt-2" id="flag-age">
+                    Flagged {{ product.stock_status }}
+                    {{ product.stock_status_age | relative_age('at an unknown time') }}
+                </div>
+                {% endif %}
             </div>
         </div>
 

--- a/app/templates/product/reorder.html
+++ b/app/templates/product/reorder.html
@@ -61,6 +61,13 @@
                         <span class="badge text-bg-secondary reason-manual">
                             Flagged {{ product.stock_status }}
                         </span>
+                        {# 008 SC-004: this is the screen where the operator
+                           decides what to buy, so the flag's age has to be
+                           legible without opening the product. A class, not an
+                           id -- there are many rows. #}
+                        <div class="text-muted small flag-age">
+                            {{ product.stock_status_age | relative_age('at an unknown time') }}
+                        </div>
                         {% endif %}
                         {% if entry.is_threshold_low %}
                         <span class="badge text-bg-secondary reason-threshold">At threshold</span>

--- a/docs/product-functionality-gap.md
+++ b/docs/product-functionality-gap.md
@@ -45,16 +45,19 @@ above, and issue #56.
 
 ## Reordering and stock
 
-**A manual low flag has no age.** A counted quantity shows how long ago it was counted, so you can
-judge whether to trust it. A hand-set "low" or "out" flag shows nothing, so a product flagged two
-years ago looks exactly like one flagged this morning.
+**~~A manual low flag has no age.~~** *Built — feature 008.* Setting a flag records when, and both
+the product page and the reorder list show it in the same words a count's age uses — *Flagged low 3
+months ago*. Pressing the same flag again resets the age, which is the only way to renew the
+evidence on something that isn't counted; clearing the flag, or receiving an order, discards the
+date with it. Flags set before the upgrade have no recorded date and read *at an unknown time*:
+nothing was backfilled, because no other stored date is evidence that anybody looked at a shelf.
 
-**Receiving an order changes the count.** This is a difference rather than an absence, and it is the
-one place where the built behaviour actively contradicts the plan. Receiving a purchase adds the
-received quantity to a tracked count and marks the count as freshly updated. The plan was emphatic
-that receiving must never touch a count, on the grounds that a count nobody verified should not
-present itself as verified — an inaccurate number being worse than no number. Both positions are
-defensible; what isn't is showing "counted just now" when nobody counted anything.
+**~~Receiving an order changes the count.~~** *Built — feature 008.* Settled in favour of the third
+position rather than either of the two on offer. Receiving still adds the received quantity to a
+tracked count — a count that ignores a delivery is knowingly wrong from the moment the box is opened
+— but it no longer marks the count as freshly updated. The count's age now means the last time a
+person counted, so nothing claims a verification that never happened, and what the delivery changed
+is evidenced by the purchase that changed it.
 
 ## Grouping products that are the same thing
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -693,7 +693,21 @@ the handful where running out costs you something.
 
 Where a quantity is tracked, it is always shown with its age: *counted 8 months
 ago*. A count nobody has revisited in eight months is not a fact about today, and
-showing the age lets you decide how much to trust it.
+showing the age lets you decide how much to trust it. The age means **the last
+time you counted** -- typing a number, or pressing **+** or **−** at the shelf.
+Receiving an order adds to the count without touching the age, because a packing
+slip is not you looking in the drawer.
+
+A hand-set **Low** or **Out** flag is shown with its age the same way: *Flagged
+low 3 months ago*, on the product page and on the reorder list. Pressing the same
+flag again resets its age -- that is you saying you have just looked and it is
+still low, which is the only way to renew the evidence on something you are not
+counting.
+
+Flags you set before this was added have no recorded date, and read *Flagged low
+at an unknown time*. That is not an error: no date was kept at the time, and
+inventing one from something else would be a guess dressed up as a fact. Press
+the flag again to give it a real date.
 
 **Products → Reorder List** gathers everything that needs buying:
 
@@ -706,7 +720,11 @@ page is stored; it is all derived when you open it, so it cannot drift out of
 step with your purchases.
 
 Receiving an order clears both kinds of low: the count goes up, and a manual flag
-is cleared for you.
+is cleared for you -- along with the flag's age, so a flag you set later never
+inherits an old date. What receiving deliberately leaves alone is the *count's*
+age: the number accounts for the delivery, and the date beside it still tells you
+when you last counted. What the delivery changed is on the purchase that changed
+it.
 
 All of these controls are buttons, not typing, so the whole flow works on a
 handheld with no keyboard.

--- a/migrations/versions/b1a0c0d10010_add_stock_status_updated_at.py
+++ b/migrations/versions/b1a0c0d10010_add_stock_status_updated_at.py
@@ -1,0 +1,53 @@
+"""add products.stock_status_updated_at
+
+Revision ID: b1a0c0d10010
+Revises: b1a0c0d10009
+Create Date: 2026-08-09 18:00:00.000000
+
+When the operator's manual low/out flag was last set. Mirrors
+``products.quantity_updated_at`` in shape and in purpose: the flag is evidence of
+somebody looking at a shelf, and evidence with no date attached cannot be judged.
+
+**Nothing is backfilled** (008 FR-005, SC-006). ``products.last_modified`` is the
+only candidate and it is not evidence -- it moves when a description is
+corrected or a receipt clears an unrelated field, none of which is somebody
+looking at a shelf. Inventing a date here would reproduce inside the flag the
+exact error feature 008 removes from the count, and it would be worse, because
+afterwards a fabricated date is indistinguishable from a real one. So every
+product already flagged reads "flagged at an unknown time" after this upgrade.
+That is correct, and it is the thing most likely to be reported as a bug.
+
+No CHECK constraint pairs the flag with its date. The identical invariant for
+``quantity`` / ``quantity_updated_at`` has been enforced in code alone since
+feature 001, and constraining the new pair but not the old one would leave the
+table saying that one of two matching rules matters; see the feature's
+``research.md``. The constraint could not have been symmetric in any case,
+because a flag with no date is a legal row -- it is every row predating this.
+
+The reverse loses every flag date and nothing else. Flags themselves, counts,
+count ages and purchases are untouched, so downgrading returns the catalogue to
+its previous behaviour: flags with no age.
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1a0c0d10010'
+down_revision: Union[str, None] = 'b1a0c0d10009'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'products',
+        sa.Column('stock_status_updated_at', sa.DateTime(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('products', 'stock_status_updated_at')

--- a/specs/008-trustworthy-stock-age/checklists/requirements.md
+++ b/specs/008-trustworthy-stock-age/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Trustworthy Stock Age
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The specification is ready for `/speckit-plan`.
+- The one open question — whether a count adjusted by a receipt should additionally
+  advertise that it changed since it was last verified — was resolved in favour of the
+  narrowest fix: one age per count, meaning the last time a person counted, with no
+  second "last changed" date. Recorded as FR-015, SC-007, and the first Edge Case.
+- Issue #59's third possibility, that receiving should stop touching the count entirely,
+  was considered and not taken; the reasoning is in Assumptions.

--- a/specs/008-trustworthy-stock-age/contracts/catalog-service.md
+++ b/specs/008-trustworthy-stock-age/contracts/catalog-service.md
@@ -1,0 +1,62 @@
+# Contract: service surface
+
+No signature changes. Two methods change what they do, and the change to the second one is a deletion. Everything a caller passes and everything it gets back is the same type it was.
+
+---
+
+## `CatalogService.set_stock_status(product_id, stock_status)` — now dates the flag
+
+```python
+def set_stock_status(self, product_id: int, stock_status: Optional[str]) -> Product
+```
+
+| `stock_status` argument | `product.stock_status` | `product.stock_status_updated_at` |
+|---|---|---|
+| `'low'` or `'out'` (any case) | that value | **now** |
+| the value it already holds | unchanged | **now** — FR-002, a re-assertion is a fresh look |
+| `None` or `''` | `NULL` | `NULL` — FR-003 |
+| anything else | unchanged | unchanged; raises `ValidationError` |
+
+Validation is unchanged and still happens before the session opens, so a refused value leaves both fields alone. `ItemNotFoundError` for an unknown product, as before.
+
+**The re-assertion row is the one to test.** Assigning a string equal to the stored one produces no `UPDATE`; the timestamp write is what makes the round trip real.
+
+---
+
+## `CatalogService.receive_purchase(...)` — stops dating the count
+
+```python
+def receive_purchase(self, purchase_id, received_date=None, quantity=None,
+                     unit_price=None, notes=None, description=None) -> Purchase
+```
+
+Signature unchanged. Inside the `if not already_received` block, on the product the purchase belongs to:
+
+| Field | Before | After |
+|---|---|---|
+| `quantity` | `+= purchase.quantity`, when tracked and the purchase has a quantity | **unchanged behaviour** (FR-007) |
+| `quantity_updated_at` | set to now, in the same branch | **not written** (FR-008) |
+| `stock_status` | cleared, and logged | unchanged behaviour |
+| `stock_status_updated_at` | — | cleared with the flag (FR-006) |
+
+Everything outside that block — the received date, the amended quantity, price and notes, and the description correction that deliberately applies even on a repeat receive — is untouched by this feature.
+
+**Consequences a caller can rely on:**
+
+- Receiving never decreases the reported age of a count (SC-001).
+- Receiving against a product with `quantity IS NULL` writes no count and no date (FR-009). This already held; it now holds for a second reason, since the only writer in that branch is gone.
+- Receiving an already-received purchase remains a no-op for all four fields above.
+
+---
+
+## `CatalogService.set_quantity(product_id, quantity)` — unchanged
+
+Listed because FR-010 depends on it and it is easy to break by accident while implementing FR-008. A number stamps `quantity_updated_at`; `None` clears the count, the date and the threshold. The `+` and `−` buttons on the product page reach this method through `PATCH /api/products/<id>/quantity` — they are not a separate path and must not become one.
+
+## `CatalogService.create_product(...)` — unchanged
+
+Stamps `quantity_updated_at` when created with a quantity, which is the operator entering a count. Does not accept `stock_status`, so there is no creation-time flag to date.
+
+## `CatalogService.update_product(product_id, **fields)` — unchanged
+
+Its `editable` set excludes `quantity`, `stock_status` and both dates, and raises `ValidationError` for anything outside it. **Do not add the new column to that set.** The dates are written by the two methods above and by nothing else; that is what makes SC-003 checkable by reading four functions.

--- a/specs/008-trustworthy-stock-age/contracts/presentation.md
+++ b/specs/008-trustworthy-stock-age/contracts/presentation.md
@@ -1,0 +1,76 @@
+# Contract: what the operator sees
+
+Two templates and one Jinja filter. No JavaScript: `product-stock.js` already reloads the page after every successful PATCH, so both age lines are server-rendered like the count's age beside them.
+
+---
+
+## The filter: `relative_age(age, unknown='never counted')`
+
+Registered in `app/product/routes.py` as an `app_template_filter`. One optional parameter is added; the positional behaviour and every existing call site are unchanged.
+
+```python
+@bp.app_template_filter('relative_age')
+def relative_age(age, unknown: str = 'never counted') -> str:
+```
+
+| `age` | Renders |
+|---|---|
+| `None` | the `unknown` argument — `'never counted'` for a count, `'at an unknown time'` for a flag |
+| negative, or under an hour | `just now` |
+| under a day | `3 hours ago` |
+| one day | `yesterday` |
+| under 31 days | `9 days ago` |
+| under a year | `8 months ago` |
+| a year or more | `2 years ago` |
+
+Every row but the first is shared between a count and a flag, which is FR-012 satisfied by construction rather than by discipline: two pieces of evidence on one screen cannot drift into different vocabularies if one function renders both.
+
+**Why a parameter and not a second filter**: `'never counted'` is right for a count and wrong for a flag — a flag with no date was certainly set, its date simply was not recorded. See `research.md`.
+
+---
+
+## `product/detail.html` — the stock card
+
+Under the three flag buttons, rendered only when a flag is set:
+
+```jinja
+{% if product.stock_status %}
+<div class="text-muted small mt-2" id="flag-age">
+    Flagged {{ product.stock_status }}
+    {{ product.stock_status_age | relative_age('at an unknown time') }}
+</div>
+{% endif %}
+```
+
+Reads as *Flagged low 3 months ago*, *Flagged out just now*, *Flagged low at an unknown time*.
+
+`id="flag-age"` is the E2E hook. The element is absent — not empty — when there is no flag, so a test asserting its absence is asserting something real.
+
+The count's age line above it (`id="quantity-age"`) is unchanged in markup. Its *meaning* changes, because the writer that was not a person has stopped writing.
+
+---
+
+## `product/reorder.html` — the "Why" column
+
+Under the existing `Flagged low` badge:
+
+```jinja
+{% if entry.is_manually_low %}
+<span class="badge text-bg-secondary reason-manual">
+    Flagged {{ product.stock_status }}
+</span>
+<div class="text-muted small flag-age">
+    {{ product.stock_status_age | relative_age('at an unknown time') }}
+</div>
+{% endif %}
+```
+
+A class rather than an id, because the reorder list has many rows. Scoped by the row's `data-product-id` in tests.
+
+This is the screen SC-004 is measured on: two flagged products, and the operator can tell which was flagged more recently without opening either.
+
+## What does not change
+
+- **Reorder list membership and ordering.** FR-013 and FR-014: no age is classified as stale, nothing is withheld, warned about, coloured differently or re-sorted. The age is text in the muted style the count's age already uses.
+- **No new screen, no new control.** Both lines are read-only text next to controls that already exist.
+- **No screenshots.** `tests/e2e/screenshot_config.yaml` covers the metal-stock screens; no committed image shows a product page. See the deviation note in `plan.md`.

--- a/specs/008-trustworthy-stock-age/contracts/product-json.md
+++ b/specs/008-trustworthy-stock-age/contracts/product-json.md
@@ -1,0 +1,40 @@
+# Contract: the product JSON
+
+`Product.to_dict()` gains one field. Purely additive: no field is renamed, removed or given a new meaning, and every existing consumer keeps working without knowing the field exists.
+
+## The addition
+
+```diff
+   "quantity": 12,
+   "quantity_updated_at": "2026-05-02T09:14:03",
+   "reorder_threshold": 5,
+   "stock_status": "low",
++  "stock_status_updated_at": "2026-08-09T18:22:41",
+   "notes": null,
+```
+
+ISO 8601, or `null` — the same shaping as `quantity_updated_at` immediately above it, and it sits next to `stock_status` for the same reason that one sits next to `quantity`.
+
+`null` carries two meanings, distinguished by `stock_status`:
+
+| `stock_status` | `stock_status_updated_at` | Meaning |
+|---|---|---|
+| `null` | `null` | No flag |
+| `"low"` / `"out"` | a timestamp | Flagged, and when |
+| `"low"` / `"out"` | `null` | Flagged before this feature; the date was never recorded |
+
+## Where it appears
+
+Everywhere `to_dict()` already goes, with no route change:
+
+- `GET /api/products/<id>` (via `include_related=True`)
+- `PATCH /api/products/<id>/quantity`
+- `PATCH /api/products/<id>/stock-status`
+- and anywhere else a product is serialized, since the field is on the model method rather than on a route.
+
+## What does not change
+
+- **No new endpoint.** The two PATCH endpoints already accept exactly what this feature needs; the flag's date is derived from the act, never supplied by the caller. There is no way to set `stock_status_updated_at` over HTTP and there should not be — a client-supplied date for "when somebody looked" is the same lie in a different place.
+- **No request body changes.** `PATCH /api/products/<id>/stock-status` still takes `{"stock_status": "low" | "out" | null}` and still 400s on a missing key or an unknown value.
+- **`app/api_client.py` is untouched.** It is the standalone inventory-item client and knows nothing about products; its `__all__` surface is unaffected.
+- **No JavaScript consumes the new field.** `product-stock.js` reloads the page on success and reads nothing out of the response body but `success` and `error`.

--- a/specs/008-trustworthy-stock-age/data-model.md
+++ b/specs/008-trustworthy-stock-age/data-model.md
@@ -1,0 +1,83 @@
+# Phase 1 Data Model: Trustworthy Stock Age
+
+## One column
+
+```
+products.stock_status_updated_at   DATETIME  NULL
+```
+
+When the operator's manual flag was last set. `NULL` means one of two things, and the template already distinguishes them because it only renders the age inside a `{% if product.stock_status %}` guard:
+
+| `stock_status` | `stock_status_updated_at` | Means | Shown as |
+|---|---|---|---|
+| `NULL` | `NULL` | No flag | nothing |
+| `'low'` / `'out'` | a date | Flagged, and this is when | *Flagged low 3 months ago* |
+| `'low'` / `'out'` | `NULL` | Flagged before this feature shipped | *Flagged low at an unknown time* |
+| `NULL` | a date | **Cannot occur.** `set_stock_status` and `receive_purchase` clear both together | — |
+
+This is deliberately the same shape as `quantity` / `quantity_updated_at`, including the part where the fourth row is prevented in code rather than by a constraint. `research.md` records why no CHECK constraint was added.
+
+### Revision `b1a0c0d10010` — add the flag's date
+
+`down_revision = 'b1a0c0d10009'`, the current head.
+
+- **upgrade**: `op.add_column('products', sa.Column('stock_status_updated_at', sa.DateTime(), nullable=True))`. Nullable, no server default, **no backfill** — FR-005 and SC-006 require an unrecorded age to stay unrecorded, and `research.md` says why `last_modified` is not a substitute.
+- **downgrade**: `op.drop_column('products', 'stock_status_updated_at')`.
+
+### Reversibility
+
+The downgrade loses every flag date and nothing else. Flags themselves, counts, count ages and purchases are untouched, so downgrading returns the catalogue to exactly today's behaviour: flags with no age. That is the whole of the data loss and it is inherent to reversing an added column; there is no guard worth writing for it, unlike `b1a0c0d10009`'s narrowing, where reversing could have truncated text.
+
+Exercise the pair against a disposable MariaDB container, never against the database named in `.env` — neither test suite runs migrations, so `upgrade` and `downgrade` are otherwise unexercised code.
+
+## Two properties on `Product`
+
+### `stock_status_age -> Optional[timedelta]`
+
+```python
+@property
+def stock_status_age(self) -> Optional[timedelta]:
+    """How long ago the manual flag was set (008 FR-001, FR-004).
+
+    None when there is no flag, and also when there is one but no date was
+    recorded -- an unknown age is not an error, and the display renders it as
+    unknown rather than raising.
+    """
+    if self.stock_status is None or self.stock_status_updated_at is None:
+        return None
+    return datetime.now() - self.stock_status_updated_at
+```
+
+Deliberately a line-for-line mirror of the existing `quantity_age`, down to the double `None` guard and the reason for it. Two properties that answer the same question about different evidence should not be two different shapes.
+
+### `quantity_age` — unchanged
+
+Its meaning changes without its code changing. Before this feature it answered "when was this number last written?"; after it, it answers "when did somebody last count?", because the one writer that was not a person has stopped writing. That is the point of the feature, and it is worth saying in the docstring so the next reader does not restore the deleted line as a bug fix.
+
+## Field addition to `Product.to_dict()`
+
+`'stock_status_updated_at': self.stock_status_updated_at.isoformat() if self.stock_status_updated_at else None`, placed next to `stock_status`, matching the `quantity_updated_at` line four rows above it. Additive; see `contracts/product-json.md`.
+
+## Service rules
+
+Stated as behaviour; signatures are in `contracts/catalog-service.md`.
+
+**`set_stock_status(product_id, stock_status)`**
+
+- Setting to `'low'` or `'out'` writes the value *and* `stock_status_updated_at = datetime.now()` — including when the value equals what is already stored (FR-002). The timestamp write is what makes a re-assertion produce an `UPDATE` at all; see `research.md`.
+- Clearing writes `NULL` to both (FR-003).
+
+**`receive_purchase(...)`**
+
+- The line `product.quantity_updated_at = datetime.now()` is **deleted** (FR-008). The increment on the line above it stays (FR-007).
+- Where the flag is cleared, `stock_status_updated_at` is cleared with it (FR-006).
+- Both are already inside the `if not already_received` guard, so receiving twice remains a no-op for stock.
+
+**`set_quantity`, `create_product`** — unchanged. They are the operator entering a count, which is what FR-010 says should stamp the age.
+
+## What is not modelled
+
+- **No history table.** One operator, one current fact. A flag transition log is a schema, a relationship, a cascade and a query in exchange for a date.
+- **No second timestamp on the count** (FR-015). A change the operator did not make is evidenced by the purchase that made it.
+- **No `stock_status_age` on the reorder query.** `get_reorder_products` returns the `Product` itself inside each entry, so the template reaches the property directly. Nothing is added to the entry dict.
+- **No index.** Nothing filters or sorts on the new column (FR-013, FR-014), and adding one for a column only ever read through an already-loaded row would be indexing beyond the obvious.

--- a/specs/008-trustworthy-stock-age/plan.md
+++ b/specs/008-trustworthy-stock-age/plan.md
@@ -1,0 +1,122 @@
+# Implementation Plan: Trustworthy Stock Age
+
+**Branch**: `issues/59` | **Date**: 2026-08-09 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/008-trustworthy-stock-age/spec.md`
+
+## Summary
+
+Two changes to what the catalogue is allowed to assert about stock, and both are small.
+
+**One column.** `products.stock_status_updated_at`, nullable, no backfill. `set_stock_status` stamps it when a flag is set and clears it when the flag is cleared; a `stock_status_age` property mirrors the `quantity_age` that already exists; two templates render it through the `relative_age` filter that already exists.
+
+**One deleted line.** `receive_purchase` currently writes `product.quantity_updated_at = datetime.now()` alongside the increment. That line is the whole of FR-008: with it gone, a count's age means the last time a person counted, the increment still happens, and the screen stops claiming a verification that never occurred.
+
+The shape of the work is set by two properties of the code as it stands. The stock write surface is tiny — `create_product`, `set_quantity`, `set_stock_status` and `receive_purchase` are the only four places that touch `quantity_updated_at` or `stock_status`, and `update_product` explicitly refuses both fields — so "what resets the age" (SC-003) is a claim that can be read off four functions rather than argued about. And `product-stock.js` responds to every successful PATCH with `window.location.reload()`, so the new age lines are server-rendered like everything else and this feature ships **no JavaScript at all**.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+
+**Primary Dependencies**: Flask 3.1.x, SQLAlchemy 2.0.x (legacy `Query` API, per the surrounding file), Alembic, Jinja2 + Bootstrap 5.3.2. No new dependency.
+
+**Storage**: MariaDB via PyMySQL. One Alembic revision, `b1a0c0d10010`, on top of the current head `b1a0c0d10009`.
+
+**Testing**: `nox -s tests` (pytest against SQLite through `test_storage`), `nox -s e2e` (Playwright against MariaDB, 15-minute tool timeout).
+
+**Target Platform**: Flask app on a home LAN, reached from a desktop and a handheld.
+
+**Project Type**: Server-rendered web application.
+
+**Performance Goals**: None. This feature adds one nullable column, one property, and two lines of Jinja; it removes a write. There is nothing here to measure.
+
+**Constraints**: No backfill of the new column (FR-005, SC-006). Reversible migration. No new screen and no JavaScript.
+
+**Scale/Scope**: ~4 production files, 1 migration, 2 templates, 2 test files, 1 documentation section.
+
+## Constitution Check
+
+*GATE: passed before Phase 0, re-checked after Phase 1.*
+
+| Principle | Assessment |
+|---|---|
+| **I. Simplicity First** | The feature adds one column and deletes one statement. Three simpler-looking options were considered and rejected in `research.md` — a second "last changed" timestamp, a CHECK constraint pairing the flag with its date, and a second Jinja filter — and each was rejected for adding a moving part the requirement does not need. Nothing here is speculative: every artifact traces to an FR. |
+| **II. Layered Architecture Boundaries** | The column goes on the ORM model, the rules go in `CatalogService`, the routes are untouched, and the templates read properties. `relative_age` stays where it is, in `app/product/routes.py`, because that is where the filter is registered and moving it would be churn. No new layer, no repository, no DTO. |
+| **III. Exact Numerics** | Not engaged. No measured quantity is involved; the counts here are `int` piece counts, as they already are, and the new column is a `DateTime`. |
+| **IV. Test Discipline Through Nox** | Behaviour changes, so tests land with it. Unit tests carry FR-007 through FR-011 because they can backdate a timestamp; E2E carries the two display requirements and the one end-to-end path (receive through the UI, age unchanged). No new pytest marker. Every new wait is an `expect()` on a server-rendered element. |
+| **V. MariaDB Is the Source of Truth** | One Alembic revision, `upgrade` adds the column and `downgrade` drops it. The downgrade loses the flag ages and nothing else; that is inherent to reversing an added column and is stated in `data-model.md`. Exercised against a disposable MariaDB container, not against `.env`. |
+| **VI. Item Lifecycle and History Invariants** | Not engaged. This feature does not touch `inventory_items`, JA IDs, active rows or shortening history. The product catalogue is a separate table with no history semantics. |
+
+**Deviation to record, not to fix here.** The Development Workflow section requires regenerating documentation screenshots for any change under `app/templates/**`. This change touches `product/detail.html` and `product/reorder.html`, and **no committed screenshot shows either page** — `tests/e2e/screenshot_config.yaml` covers the metal-stock screens only. Regenerating would rewrite eleven unrelated PNGs with rasterization noise, which `.github/workflows/screenshots.yml` documents as non-reproducible (issue #77) and which the constitution's own "no mass reformatting, it destroys review signal" rationale argues against. Screenshots are therefore not regenerated. Separately, the constitution says CI blocks on stale screenshots and the workflow says it is informational; the two disagree and one of them should be corrected, but not by this feature.
+
+No violations requiring justification, so there is no Complexity Tracking table.
+
+### Why one age and not two
+
+Recorded fully in `research.md`; the short form is that FR-015 was a decision, not an omission. A second `quantity_changed_at` beside `quantity_counted_at` would buy one line of display and cost a rule that every future write of a count has to get right — and the change it would advertise is already recorded, with its date, vendor and quantity, on the purchase that caused it. The count's age answers "should I trust this number?"; the purchase list answers "why did it move?". Splitting the first question across two dates makes it harder to answer, not easier.
+
+### Why the flag's age is a plain column and not an event
+
+The obvious "proper" design is a small history of flag transitions. It is refused under Principle I: nothing in the spec asks who flagged what when — there is one operator — and FR-001 needs exactly one date. A table would be a schema, a relationship, a cascade and a query in exchange for a fact one column holds.
+
+### Post-design re-check (after Phase 1)
+
+Nothing in Phase 1 introduced a new dependency, layer, table, endpoint, JavaScript file or configuration knob. The design got *smaller* than the first pass in two places: the CHECK constraint was dropped in favour of matching the existing `quantity` / `quantity_updated_at` precedent exactly, and the planned second Jinja filter became one optional parameter on the existing one. Gate still passes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-trustworthy-stock-age/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── catalog-service.md   # Service method semantics
+│   ├── product-json.md      # The to_dict field addition
+│   └── presentation.md      # The relative_age filter and what each template renders
+├── checklists/
+│   └── requirements.md  # From /speckit-specify, 16/16
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+app/
+├── database.py                      # +stock_status_updated_at column
+│                                    # +stock_status_age property
+│                                    # +field in to_dict
+├── catalog_service.py               # set_stock_status: stamp / clear the date
+│                                    # receive_purchase: delete the quantity_updated_at
+│                                    #   write; clear the flag's date with the flag
+├── product/
+│   └── routes.py                    # relative_age gains one optional parameter
+└── templates/product/
+    ├── detail.html                  # flag age line under the flag buttons
+    └── reorder.html                 # flag age line under the "Flagged low" badge
+
+migrations/versions/
+└── b1a0c0d10010_add_stock_status_updated_at.py
+
+tests/
+├── unit/
+│   └── test_stock_status.py         # extended: the age rules and the receive path
+└── e2e/
+    ├── test_reorder_view.py         # extended: flag age on the reorder row
+    └── test_stock_age.py            # new: the aged/unknown/receive display cases
+
+docs/
+└── user-manual.md                   # the two sentences that are now wrong
+```
+
+**Structure Decision**: The existing layout, unchanged. The catalogue already has its `product` blueprint, its `CatalogService`, and its two stock templates; this feature adds no file to `app/` at all and one file to `tests/e2e/`.
+
+## Phase 0 / Phase 1 outputs
+
+- `research.md` — the decisions and what was rejected: one age versus two, no CHECK constraint, no backfill, one filter parameter instead of a second filter, and how a test backdates a timestamp when the UI can only write "now".
+- `data-model.md` — the column, the migration and its reverse, the two properties, and what deliberately is not modelled.
+- `contracts/` — the three surfaces this touches: `CatalogService` methods, the product JSON, and the template-facing filter.
+- `quickstart.md` — how to run the suites, and the four things to check by hand against a real database, including the legacy-row case a fresh database cannot produce.

--- a/specs/008-trustworthy-stock-age/quickstart.md
+++ b/specs/008-trustworthy-stock-age/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart: validating Trustworthy Stock Age
+
+## Prerequisites
+
+```bash
+cd /home/jantman/scratch/rm_me/workshop-inventory-tracking
+source venv/bin/activate
+```
+
+`nox` sessions pin Python 3.13; put pyenv's 3.13 ahead of the system Python on `PATH` if `nox` reports a missing interpreter.
+
+## The suites
+
+```bash
+nox -s tests      # unit; sub-second, network blocked, SQLite via test_storage
+nox -s e2e        # Playwright against MariaDB -- allow a 15-minute tool timeout
+```
+
+Both must pass. `nox -s e2e` selects `-m "e2e and not screenshot"` and must leave the working tree clean.
+
+## What the unit suite proves
+
+`tests/unit/test_stock_status.py`, extended. These carry the requirements that need a clock the UI cannot provide — a test backdates the field through `service.Session()` and then exercises the service (see `research.md`).
+
+| Behaviour | Requirement |
+|---|---|
+| Setting a flag records the moment | FR-001 |
+| Setting the flag to the value it already holds moves the date forward | FR-002 |
+| Clearing the flag clears the date | FR-003 |
+| `stock_status_age` is `None` with no flag, and `None` with a flag and no date | FR-005 |
+| Receiving adds the received quantity to a tracked count | FR-007 |
+| Receiving leaves a backdated `quantity_updated_at` **exactly** where it was | FR-008, SC-001 |
+| Receiving against an untracked product writes no count and no date | FR-009 |
+| Receiving clears the flag *and* its date | FR-006 |
+| Receiving twice changes neither the count nor either date | FR-008 |
+| Setting a count, and stepping it, stamp the date | FR-010 |
+| Stopping tracking clears the date; starting again writes a fresh one | FR-011 |
+| `relative_age(None)` still says `never counted`; `relative_age(None, 'at an unknown time')` says that instead | FR-012 |
+| `to_dict()` carries `stock_status_updated_at` | contract |
+
+The FR-008 test is the one that matters. Backdate `quantity_updated_at`, receive, and assert the stored value is **unchanged** — not "older than now", which passes against a bug that moves it by a second.
+
+## What the E2E suite proves
+
+`tests/e2e/test_stock_age.py` (new) and `tests/e2e/test_reorder_view.py` (extended). Seed through `CatalogService(live_server.storage)` and backdate through `sessionmaker(bind=live_server.engine)`; drive the browser only for the parts under test.
+
+| Scenario | Requirement |
+|---|---|
+| Flag a product from the detail page → `#flag-age` reads *Flagged low just now* | FR-004 |
+| Two products flagged at different seeded dates → the reorder rows show different ages | FR-004, SC-004 |
+| A product with a flag and a `NULL` date → *at an unknown time* | FR-005, SC-006 |
+| Clear the flag → `#flag-age` is absent | FR-003 |
+| A backdated count, receive through the reorder list's **Receive** button → the count rises and `#quantity-age` still reads the old age | FR-007, FR-008, SC-001 |
+| The received product's flag and flag age are both gone | FR-006 |
+
+Waiting rules for the new assertions, per `CLAUDE.md`: every one is `expect(locator)` on server-rendered HTML. The existing `wait_for_stock_flag()` helper in `test_reorder_view.py` is the right wait after a flag button click — the button PATCHes and reloads, so the reloaded button's own styling is the proof the round trip finished. Reuse it rather than writing a second one.
+
+## The migration
+
+Neither suite runs migrations, so `b1a0c0d10010` is otherwise unexercised. Run it against a **disposable MariaDB container**, never against the database named in `.env`:
+
+```bash
+python manage.py db upgrade      # column appears, nullable, all NULL
+python manage.py db downgrade    # column gone, flags and counts intact
+python manage.py db upgrade      # back again
+```
+
+Check after the upgrade that no row has a non-`NULL` `stock_status_updated_at`: nothing is backfilled, by design.
+
+## The four things to check by hand
+
+A fresh database cannot produce the first of these, and the others are judgements about wording rather than assertions.
+
+1. **The legacy row.** On a copy of the real database, upgrade and open the reorder list. Every product flagged before today reads **Flagged low at an unknown time**. This is correct and it is the thing most likely to be reported as a bug — confirm it reads as an honest gap rather than an error.
+2. **The receive path, watched.** Find a product with a tracked count and an outstanding order. Note the age line. Receive. The number goes up, the age line does not move. This is the entire point of the feature and it takes ten seconds to see.
+3. **Re-affirming a flag.** Open a product flagged some time ago and press **Low** again. The age resets to *just now*. Before this feature that button press did nothing at all.
+4. **The two ages side by side.** A product with both a count and a flag shows two age lines in the same words. Read them together and confirm they cannot be confused for one another — that is FR-012 as a judgement, not as a test.
+
+## Documentation
+
+`docs/user-manual.md` has two sentences that this feature falsifies, around line 694 and line 708: the stock section describes the count's age without mentioning the flag's, and says receiving "clears both kinds of low" without saying what it now leaves alone. Both need updating in the same change, along with a note that flags set before the upgrade have no recorded age.

--- a/specs/008-trustworthy-stock-age/research.md
+++ b/specs/008-trustworthy-stock-age/research.md
@@ -1,0 +1,88 @@
+# Phase 0 Research: Trustworthy Stock Age
+
+Everything here is a decision taken with its alternatives, or a fact about the existing code that changed what the plan says. There were no unknowns in the Technical Context to resolve — the stack, storage and test strategy are all fixed by the constitution — so this document is entirely about *which* small change, not *whether* one is possible.
+
+## The write surface is four functions, and that is the whole safety argument
+
+SC-003 says the only things that reset a count's age are an operator entering a count and an operator adjusting one at the shelf. That is a universal claim, and universal claims are usually expensive to verify. Here it is cheap, because the places that write these fields are enumerable:
+
+| Writer | Touches | After this feature |
+|---|---|---|
+| `CatalogService.create_product` (`catalog_service.py:167`) | `quantity_updated_at` when a quantity is supplied | Unchanged — creating a product *with* a count is the operator entering one |
+| `CatalogService.set_quantity` (`:377`, `:382`) | `quantity_updated_at`, set or cleared | Unchanged — this is both the typed count and the +/- buttons (`product-stock.js` calls the same endpoint) |
+| `CatalogService.set_stock_status` (`:421`) | `stock_status` | Gains the date, set and cleared with the flag |
+| `CatalogService.receive_purchase` (`:1319`, `:1328`) | `quantity`, `quantity_updated_at`, `stock_status` | Loses the `quantity_updated_at` write; clears the flag's date with the flag |
+
+`update_product` cannot reach either field: it validates `fields` against an explicit `editable` set and raises `ValidationError` for anything else (`catalog_service.py:563-573`). So the product edit form, which is the one place an operator might expect to be able to type a count, cannot silently restamp an age. Nothing else in `app/` assigns `quantity_updated_at` or `stock_status`.
+
+**Consequence for the plan:** FR-008 is a deletion, not a redesign. There is no "audit every path" task, because the audit is the table above.
+
+## One age per count, not two
+
+**Decision**: a count carries exactly one date, meaning the last time an operator counted it. A receipt changes the number and leaves the date alone. (FR-015.)
+
+**Rationale**: the alternative — `quantity_counted_at` beside `quantity_changed_at`, rendered as "counted 3 months ago, adjusted yesterday" — buys one line of display and costs a permanent rule. Every future write of a count would have to decide which of the two dates it moves, and getting that wrong reintroduces exactly the bug this feature removes, only harder to see because now there are two dates to disbelieve instead of one. The information it would surface is not lost: the product's purchases already record what arrived, when, from whom and how many, and that list is on the same page.
+
+**Alternatives considered**:
+
+- *Two timestamps.* Rejected above. Its real appeal is that it makes the number self-explaining, and the honest answer is that the purchase list already does that better.
+- *Receiving stops touching the count entirely*, which was the archived plan's position and is the third reading of issue #59. Rejected: a count that ignores a delivery is knowingly wrong from the moment the box is opened until the operator next counts, which is a worse trade than a correct number whose age is honest about who last verified it. The spec records this in Assumptions so the reasoning survives.
+- *Show the count as provisional* (an asterisk, an italic, a "since last count" note) when a receipt has moved it since it was counted. Rejected as the two-timestamp option wearing a hat: it needs the same second date to know when to show itself.
+
+## No CHECK constraint pairing the flag with its date
+
+**Decision**: the invariant "no flag means no flag date" is enforced in `set_stock_status` and `receive_purchase` and covered by unit tests, not by a database constraint.
+
+**Rationale**: the first draft of this plan added `CHECK (stock_status IS NOT NULL OR stock_status_updated_at IS NULL)`, on the grounds that a stale date surviving a cleared flag is precisely the class of lie this feature exists to remove, and that `products` already carries three CHECK constraints in that spirit. It was dropped because of the asymmetry it would create: the identical invariant for `quantity` / `quantity_updated_at` has been enforced in code alone since feature 001, and adding a constraint for the new pair and not the old one leaves the table saying that one of two matching rules is important. The two ways out — constrain both, or constrain neither — are a migration touching an existing column for no observed problem, or Principle I. Principle I wins.
+
+Note that the constraint could not have been symmetric in any case: FR-005 requires a flag with *no* date to be a legal row, because that is every row that predates this feature.
+
+## Nothing is backfilled
+
+**Decision**: the migration adds the column and writes nothing into it. Products already flagged read as an unknown age until they are flagged again.
+
+**Rationale**: `products.last_modified` is the only candidate and it is not evidence. It moves when a description is corrected, when a specification is added, when a receipt clears an unrelated field — none of which is somebody looking at a shelf. Backfilling from it would reproduce inside the flag the exact error being removed from the count, and it would be worse there, because a fabricated date is indistinguishable from a real one afterwards.
+
+**Consequence**: on the operator's live database, every currently flagged product will read "Flagged low at an unknown time" after the upgrade. That is correct and it will look like a bug. It is called out in `quickstart.md`, in the user manual change, and in the plan.
+
+## One filter parameter, not a second filter
+
+**Decision**: `relative_age(age, unknown='never counted')` — the existing filter gains one optional keyword, and the flag templates pass `'at an unknown time'`.
+
+**Rationale**: the filter's `None` branch returns the string `'never counted'` (`app/product/routes.py:734-735`), which is right for a count and wrong for a flag — a flag with no date was certainly set, its date just was not recorded. The three ways to get the right words were a second filter (`flag_age`), a wrapper, or a parameter. A second filter duplicates twenty lines of date arithmetic to change one string. The parameter changes one line, leaves all four existing call sites reading exactly as they do today, and keeps FR-012 true by construction: a flag and a count on the same screen are rendered by the same code, so they cannot drift into different vocabularies.
+
+## The feature ships no JavaScript
+
+**Fact that changed the plan.** `product-stock.js:76-79` handles every successful PATCH with `window.location.reload()`, with a comment saying why: "the age line and the badge both change", so re-rendering from the server was already chosen over patching the DOM in two places. That decision, made for the count's age, pays for the flag's age for free. There is no client-side render of stock state anywhere, so:
+
+- no JS file is touched;
+- the new lines are ordinary Jinja;
+- and the E2E tests are asserting against server-rendered HTML, which means the "never snapshot a JavaScript-rendered region" hazard in `CLAUDE.md` does not apply to the new assertions. It still applies to the existing `reorder_rows()` helper, which is fine as written for the same reason.
+
+## Re-asserting a flag is currently a silent no-op
+
+**Fact that made FR-002 worth stating.** `set_stock_status` assigns `product.stock_status = value` and nothing else. When the value equals what is already stored, SQLAlchemy detects no change and emits no `UPDATE` — so today, pressing **Low** on a product already flagged low does nothing at all, and the page reloads to the identical state.
+
+FR-002 makes that press meaningful: the assignment of a fresh timestamp is a real change, so the `UPDATE` happens and the age resets. This is not incidental. Re-affirming a flag is the operator saying "I have just looked and it is still low", which is the only way, short of clearing and re-setting, to renew evidence on a product that has no count.
+
+## How a test backdates a timestamp
+
+**Problem**: every path that writes an age writes `datetime.now()`. A test that needs "counted three months ago" cannot get there through the UI or the service.
+
+**Decision**: write the field directly through a session, in the test.
+
+- **Unit** (`tests/unit/test_stock_status.py`): `CatalogService` exposes `self.Session`, a `sessionmaker` bound to the storage engine. The test opens one, sets the field, commits, and then exercises the service. The file already reaches into the model for property tests (`:105-109` mutates `quantity_updated_at` on a detached object), so this is the same move one step deeper.
+- **E2E** (`tests/e2e/test_stock_age.py`): `sessionmaker(bind=live_server.engine)` is established practice in this suite — `test_toggle_item_status.py`, `test_edit_item_deactivation.py`, `test_move_items.py` and four others all do it — and `CatalogService(live_server.storage)` is used directly by `test_tag_rename.py:184`. Seeding this way is also what `CLAUDE.md` asks for: direct seeding over driving forms, because the form is not what is under test.
+
+**Alternative rejected**: freezing or patching the clock. The E2E server runs in a thread in the same process, so monkeypatching `datetime` would in fact reach it — and would reach every other request in flight at the same time. A direct write to one column is smaller, local, and cannot affect anything it did not name.
+
+## What this feature is not
+
+- **Not a staleness policy** (FR-013). No threshold, no warning colour, no re-sort, no notification. The existing filter's docstring already refused this once — "a staleness *flag* would need a policy that nobody has measured" — and adding the flag's age does not license inventing the policy now.
+- **Not a change to who appears on the reorder list** (FR-014). Membership is derived from `is_effectively_low`, which this feature does not touch. A two-year-old flag still means "low", because nothing has been told otherwise.
+- **Not a history of flag transitions.** One operator, one current fact, one column. See the plan.
+- **Not a change to receiving's effect on the flag.** Receiving still clears it (feature 001's FR-029). Only the date now travels with it.
+
+## The risk that is not mitigated
+
+An operator who never re-affirms a flag gets an ever-growing age on a product that may genuinely still be low, and nothing prompts them. That is the intended behaviour — FR-013 forbids the prompt — but it means the flag's age is only as useful as the operator's habit of pressing the button again when they check. There is no way to distinguish "flagged two years ago and still low" from "flagged two years ago and forgotten", and this feature does not try to; it makes the ambiguity visible instead of hiding it, which is the whole of what issue #59 asked for.

--- a/specs/008-trustworthy-stock-age/spec.md
+++ b/specs/008-trustworthy-stock-age/spec.md
@@ -1,0 +1,146 @@
+# Feature Specification: Trustworthy Stock Age
+
+**Feature Branch**: `issues/59`
+
+**Created**: 2026-08-09
+
+**Status**: Draft
+
+**Input**: GitHub issue #59 — "Stock information should be trustworthy: age a manual low flag, and don't call a count verified when nobody counted", and the "Reordering and stock" section of `docs/product-functionality-gap.md`.
+
+## Overview
+
+The catalogue already knows that a bare number is not trustworthy. It never shows a count without saying how old it is — "12, counted 8 months ago" — precisely so the operator can decide whether to believe it. That display is the whole trust mechanism, and it has two holes in it.
+
+The first is an absence. A hand-set "low" or "out" flag carries no age at all. A product flagged two years ago and a product flagged this morning look identical on the reorder list, which is the one screen where the operator is deciding what to buy. The manual flag is the mechanism for everything the count cannot express — an untracked consumable, a judgement about a part that is technically in stock but not enough of it — and it is the half of the reorder list with no evidence attached.
+
+The second is worse, because it is not a gap but a false statement. Receiving a purchase adds the received quantity to a tracked count *and* stamps the count as freshly updated, so the screen can read "counted just now" when nobody counted anything — the number went up by what the packing slip claimed, sight unseen. That is the one place where the shipped behaviour actively contradicts the plan, which held that receiving must never touch a count because an inaccurate number is worse than no number. The increment itself is defensible and this feature keeps it. What is not defensible is that an arithmetic adjustment presents itself as a physical verification, because that undermines the age display the rest of the catalogue depends on.
+
+So the feature is one idea in two places: **an assertion about stock displays the age of the evidence behind it, and nothing claims evidence it does not have.**
+
+This is deliberately not a staleness policy. Nothing here decides how old is too old, flags anything as expired, or nags. The existing display renders an age in the words a person would use and lets the operator judge; this extends that treatment to the flag and stops the count's version of it from lying.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The reorder list stops claiming a count nobody made (Priority: P1)
+
+The operator tracks a count of 4 M3 standoffs, counted properly in January. In August a box of 100 arrives and they receive the purchase. The catalogue now says 104 — and says it was counted in January, because it was. Nothing on the screen claims anyone has looked in the drawer since.
+
+**Why this priority**: It is the only part of this feature where the application currently states something untrue, and the untruth attacks the mechanism the whole trust story rests on. Every other improvement here is worth less while the age display can be reset by a delivery.
+
+**Independent Test**: Seed a product with a tracked count and a counted-age of several months, receive an outstanding purchase against it, and verify the count has risen by the received quantity while the displayed counted-age has not moved backwards.
+
+**Acceptance Scenarios**:
+
+1. **Given** a product with a tracked count last counted three months ago, **When** an outstanding purchase for it is received, **Then** the count rises by the received quantity and the screen still reports the count as three months old.
+2. **Given** that same product, **When** the operator afterwards counts the drawer and enters the number they found, **Then** the screen reports the count as counted just now.
+3. **Given** a product whose count is not tracked, **When** a purchase for it is received, **Then** no count appears and no age is claimed — receiving does not start tracking a count.
+4. **Given** a purchase recorded with no quantity, **When** it is received against a product with a tracked count, **Then** the count is unchanged and its age is unchanged.
+5. **Given** an already-received purchase, **When** it is received a second time, **Then** neither the count nor its age changes.
+6. **Given** a product whose count has never been counted, **When** a purchase for it is received, **Then** the screen does not begin claiming a counted age.
+7. **Given** a product whose count has risen by a receipt since it was last counted, **When** the operator views it, **Then** exactly one age is shown for the count, it is the age of the count, and no second date is offered claiming the number changed more recently.
+
+---
+
+### User Story 2 - A hand-set flag shows how old it is (Priority: P2)
+
+The operator opens the reorder list. Two products are flagged low by hand. One says "flagged low yesterday" and one says "flagged low 2 years ago". They order the first and open the second to check whether it is still true.
+
+**Why this priority**: It closes the gap that made the reorder list half-evidenced, and it is what makes the manual flag usable as something other than a permanent shout. It ranks below Story 1 because a missing age misleads less than a false one.
+
+**Independent Test**: Flag one product low, seed another as flagged at an older date, and verify the reorder list and the product page each show the two ages distinctly and in the same words used for a count's age.
+
+**Acceptance Scenarios**:
+
+1. **Given** a product with no manual flag, **When** the operator flags it low, **Then** the flag's age is recorded and shown as just set.
+2. **Given** a product flagged low some time ago, **When** the operator views the reorder list, **Then** the row shows how long ago it was flagged.
+3. **Given** a product flagged low some time ago, **When** the operator views the product page, **Then** the flag's age is shown next to the flag.
+4. **Given** a product flagged low, **When** the operator changes the flag to out, **Then** the age resets to that moment, because "out" is a new assertion and not the old one.
+5. **Given** a product flagged low, **When** the operator presses "low" again, **Then** the age resets to that moment, because re-asserting a flag means the operator has just looked.
+6. **Given** a product flagged low, **When** the operator clears the flag, **Then** no flag and no flag age are shown.
+7. **Given** a product flagged low, **When** an outstanding purchase for it is received and the flag is cleared as a result, **Then** no stale flag age survives to be shown if it is flagged again later.
+8. **Given** a product that was already flagged before this feature existed, **When** it is shown, **Then** the flag is shown with its age stated as unknown, and no age is invented for it.
+
+---
+
+### User Story 3 - Adjusting a count at the shelf still counts as counting (Priority: P3)
+
+The operator takes two standoffs out of the drawer and presses the minus button twice on their phone, standing at the shelf. The count drops by two and its age resets, because they were holding the things.
+
+**Why this priority**: It is the boundary that makes Story 1 coherent rather than over-broad. Without it stated, "receiving must not refresh the age" could reasonably be read as "no arithmetic refreshes the age", which would break the quick adjust buttons that are the most common way a count is kept honest.
+
+**Independent Test**: Adjust a tracked count from the product page using the increment and decrement controls and verify the displayed counted-age resets to just now.
+
+**Acceptance Scenarios**:
+
+1. **Given** a product with a tracked count last counted months ago, **When** the operator increments or decrements it from the product page, **Then** the count changes and its age resets to just now.
+2. **Given** a product with a tracked count, **When** the operator stops tracking the count, **Then** neither a count nor a counted age is shown.
+3. **Given** a product whose count tracking was stopped, **When** the operator starts counting it again with a number, **Then** the age is that moment and carries nothing over from before.
+
+---
+
+### Edge Cases
+
+- **A count changed by a receipt, then never counted again.** The number is not the number anybody counted, and the age refers to the count that was. This is intended and is not further annotated: a count has exactly one age, meaning the last time a person counted, and the screen says so. That the number has moved since is recoverable from the product's purchases, which is where it belongs; a second date shown beside the first would buy one line of display at the cost of a rule every future write path has to get right.
+- **A receipt against a product with no count tracked.** Nothing to increment; nothing changes. Receiving never begins tracking a count.
+- **A flag set on a product that also has a tracked count.** Both ages are shown, independently, because they are evidence of two different acts.
+- **A flagged product with no count at all.** The flag's age is the only evidence the reorder row has, which is exactly the case this feature exists for.
+- **A flag that predates this feature.** No age exists and none is fabricated; the display says so.
+- **A count that predates this feature and has no recorded age.** Already handled — it reads as never counted — and this feature does not change it.
+- **Receiving a purchase whose received quantity was amended at receipt time.** The count moves by what actually arrived, not by what was ordered.
+- **Clearing a flag that was never set.** A no-op; nothing to age.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**The manual flag's age**
+
+- **FR-001**: The system MUST record when the operator's manual low/out flag was last set.
+- **FR-002**: Setting the flag to any value MUST record that moment as the flag's age, including when the value set is the value it already had.
+- **FR-003**: Clearing the flag MUST discard its age, so that a later flag never inherits an older one's date.
+- **FR-004**: Every screen that shows a manual flag MUST show how long ago it was set, in the same human terms already used for a count's age.
+- **FR-005**: A flag whose age was never recorded MUST be shown with its age stated as unknown; the system MUST NOT substitute any other date for it.
+- **FR-006**: Anything that clears the flag as a side effect — receiving an outstanding purchase does — MUST discard the flag's age with it.
+
+**What counts as a verified count**
+
+- **FR-007**: Receiving a purchase MUST continue to add the received quantity to a product's tracked count.
+- **FR-008**: Receiving a purchase MUST NOT cause the product's count to present itself as more recently counted than it was.
+- **FR-009**: Receiving a purchase against a product with no tracked count MUST NOT begin tracking one, and MUST NOT record a counted age.
+- **FR-010**: An operator setting or adjusting a count directly — entering a number, or using the increment and decrement controls — MUST record that moment as the count's age.
+- **FR-011**: Stopping count tracking MUST discard the counted age, and starting it again MUST record a fresh one.
+- **FR-012**: The words used to express an age MUST be the same for a flag and for a count, so that two pieces of evidence on one screen can be compared at a glance.
+
+**Boundaries**
+
+- **FR-013**: The system MUST NOT classify any age as stale, expired or overdue, and MUST NOT withhold, warn about or re-sort an entry on account of its age. The judgement is the operator's.
+- **FR-014**: An entry's membership of the reorder list MUST be unchanged by this feature: a flagged product appears however old its flag is.
+- **FR-015**: A count MUST carry exactly one age, meaning the last time an operator counted. The system MUST NOT record or display a separate "last changed" date beside it; a change the operator did not make is evidenced by the purchase that made it, not by a second date on the count.
+
+### Key Entities
+
+- **Product**: Gains the date its manual flag was last set, alongside the date its count was last taken. Both are evidence of an operator's act, both are absent when there is nothing to be evidence of, and neither is written by machinery acting on the operator's behalf.
+- **Purchase**: Unchanged in what it stores. What changes is what receiving one is allowed to assert about the product it belongs to.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Receiving a purchase never reduces the reported age of a count. Measured by comparing the displayed age immediately before and after a receipt on a product with a tracked count.
+- **SC-002**: 100% of manual flags displayed anywhere in the application are accompanied by their age or by an explicit statement that the age is unknown.
+- **SC-003**: The only actions that reset a count's age are an operator entering a count and an operator adjusting one at the shelf. Every other path that can change stored stock data leaves the age alone.
+- **SC-004**: On the reorder list, an operator can tell which of two flagged products was flagged more recently without opening either one.
+- **SC-005**: No product that was previously reachable through the reorder list becomes unreachable, and no product joins or leaves it as a result of this feature.
+- **SC-006**: Products carrying flags set before this feature shipped continue to display and behave correctly, with no invented dates.
+- **SC-007**: A stock assertion shown to the operator carries at most one date: a count shows when it was counted, a flag shows when it was set. No screen presents two competing ages for the same assertion.
+
+## Assumptions
+
+- The age of a flag is rendered in the same relative, human phrasing already used for a count's age ("yesterday", "3 months ago") rather than an absolute date. Absolute timestamps were rejected for counts for the same reason they are rejected here: the operator's question is "should I trust this?", not "what was the date?".
+- Existing flagged products are not backfilled with a date derived from any other field. A record's last-modified date is not evidence that anybody looked at a shelf, and inventing one would repeat in the flag the exact error this feature removes from the count.
+- Receiving continues to clear the manual flag, as it does today. That behaviour is not in question here; only the age travelling with it.
+- Receiving continues to increment a tracked count, as it does today. Issue #59 offered stopping that as well — the original plan's position — and it was not taken: a count that ignores a delivery is knowingly wrong until the operator counts, which is a worse trade than a correct number whose age is honest about who last verified it.
+- No new screen is introduced. The two ages appear on the screens that already show a count and a flag: the product page and the reorder list.
+- The reorder list's ordering is unchanged. Sorting by evidence age is a plausible follow-on and is not part of this feature.
+- The counted age remains absent — rendered as never counted — for a tracked count that has never been set by an operator, which is the behaviour today.

--- a/specs/008-trustworthy-stock-age/tasks.md
+++ b/specs/008-trustworthy-stock-age/tasks.md
@@ -23,8 +23,8 @@ Repository root is `/home/jantman/scratch/rm_me/workshop-inventory-tracking`. Pa
 
 **Purpose**: confirm the ground the change stands on before touching anything.
 
-- [ ] T001 Confirm the current Alembic head is `b1a0c0d10009` by checking `down_revision` across `migrations/versions/*.py`; the new revision in T008 must chain from whatever this reports, not from what the plan assumed
-- [ ] T002 Run `nox -s tests` and record it green, so that any failure after this point belongs to this feature
+- [X] T001 Confirm the current Alembic head is `b1a0c0d10009` by checking `down_revision` across `migrations/versions/*.py`; the new revision in T008 must chain from whatever this reports, not from what the plan assumed
+- [X] T002 Run `nox -s tests` and record it green, so that any failure after this point belongs to this feature
 
 **Checkpoint**: baseline established.
 
@@ -50,13 +50,13 @@ User Story 1 is a deleted line in `app/catalog_service.py` and needs no schema c
 
 ### Tests for User Story 1
 
-- [ ] T003 [US1] Add a `TestReceivingDoesNotVerifyACount` class to `tests/unit/test_stock_status.py` with a module-level helper that backdates a product's `quantity_updated_at` through `service.Session()`, covering: the count rises by the received quantity (FR-007); the stored timestamp is **unchanged** — assert equality against the seeded value, not `>=` or "older than now", because the weaker assertion passes against a bug that moves it by a second (FR-008, SC-001); receiving against a product with `quantity IS NULL` leaves both `quantity` and `quantity_updated_at` NULL (FR-009); a purchase with no quantity changes neither; and receiving an already-received purchase changes neither
-- [ ] T004 [P] [US1] Add `test_receiving_does_not_reset_a_counted_age` to a new `tests/e2e/test_stock_age.py`: seed a product and an outstanding purchase through `CatalogService(live_server.storage)`, backdate the count through `sessionmaker(bind=live_server.engine)`, receive through the reorder list's **Receive** button, and `expect(page.locator("#quantity-age"))` to still read the aged text while `#quantity-value` shows the increased count
+- [X] T003 [US1] Add a `TestReceivingDoesNotVerifyACount` class to `tests/unit/test_stock_status.py` with a module-level helper that backdates a product's `quantity_updated_at` through `service.Session()`, covering: the count rises by the received quantity (FR-007); the stored timestamp is **unchanged** — assert equality against the seeded value, not `>=` or "older than now", because the weaker assertion passes against a bug that moves it by a second (FR-008, SC-001); receiving against a product with `quantity IS NULL` leaves both `quantity` and `quantity_updated_at` NULL (FR-009); a purchase with no quantity changes neither; and receiving an already-received purchase changes neither
+- [X] T004 [P] [US1] Add `test_receiving_does_not_reset_a_counted_age` to a new `tests/e2e/test_stock_age.py`: seed a product and an outstanding purchase through `CatalogService(live_server.storage)`, backdate the count through `sessionmaker(bind=live_server.engine)`, receive through the reorder list's **Receive** button, and `expect(page.locator("#quantity-age"))` to still read the aged text while `#quantity-value` shows the increased count
 
 ### Implementation for User Story 1
 
-- [ ] T005 [US1] In `app/catalog_service.py`, delete the `product.quantity_updated_at = datetime.now()` line inside `receive_purchase`'s `if not already_received` block (currently line 1319), keeping the increment above it; rewrite the surrounding comment and the method docstring's receiving paragraph to say that the count moves and its age does not, citing `008 FR-007`/`008 FR-008`
-- [ ] T006 [P] [US1] In `app/database.py`, update the `quantity_age` property docstring: the value now means "how long ago an operator counted", not "how long ago the number was written", and the difference is the point of the change — say so, so the deleted line is not restored later as a bug fix
+- [X] T005 [US1] In `app/catalog_service.py`, delete the `product.quantity_updated_at = datetime.now()` line inside `receive_purchase`'s `if not already_received` block (currently line 1319), keeping the increment above it; rewrite the surrounding comment and the method docstring's receiving paragraph to say that the count moves and its age does not, citing `008 FR-007`/`008 FR-008`
+- [X] T006 [P] [US1] In `app/database.py`, update the `quantity_age` property docstring: the value now means "how long ago an operator counted", not "how long ago the number was written", and the difference is the point of the change — say so, so the deleted line is not restored later as a bug fix
 
 **Checkpoint**: `nox -s tests` and the new E2E test pass. Receiving is honest. This is a shippable increment on its own.
 
@@ -72,28 +72,28 @@ User Story 1 is a deleted line in `app/catalog_service.py` and needs no schema c
 
 ### Schema and model
 
-- [ ] T007 [US2] Create `migrations/versions/b1a0c0d10010_add_stock_status_updated_at.py` chaining from the head confirmed in T001: `upgrade` adds `products.stock_status_updated_at` as a nullable `sa.DateTime()` with no server default and **no backfill**; `downgrade` drops it. Document in the revision docstring that the reverse loses only flag ages, and that not backfilling from `last_modified` is deliberate (008 FR-005, SC-006)
-- [ ] T008 [US2] In `app/database.py`, add the `stock_status_updated_at` column to `Product` beside `stock_status`, matching the migration's type and nullability exactly — the unit suite builds its schema with `create_all` and never runs the migration, so drift between the two is invisible to `nox -s tests`. Add no CHECK constraint; `research.md` records why
-- [ ] T009 [US2] In `app/database.py`, add the `stock_status_age` property as a line-for-line mirror of `quantity_age` — `None` when there is no flag and `None` when there is a flag with no recorded date — and add `stock_status_updated_at` to `to_dict()` next to `stock_status`, ISO-formatted or `None`, per `contracts/product-json.md`
+- [X] T007 [US2] Create `migrations/versions/b1a0c0d10010_add_stock_status_updated_at.py` chaining from the head confirmed in T001: `upgrade` adds `products.stock_status_updated_at` as a nullable `sa.DateTime()` with no server default and **no backfill**; `downgrade` drops it. Document in the revision docstring that the reverse loses only flag ages, and that not backfilling from `last_modified` is deliberate (008 FR-005, SC-006)
+- [X] T008 [US2] In `app/database.py`, add the `stock_status_updated_at` column to `Product` beside `stock_status`, matching the migration's type and nullability exactly — the unit suite builds its schema with `create_all` and never runs the migration, so drift between the two is invisible to `nox -s tests`. Add no CHECK constraint; `research.md` records why
+- [X] T009 [US2] In `app/database.py`, add the `stock_status_age` property as a line-for-line mirror of `quantity_age` — `None` when there is no flag and `None` when there is a flag with no recorded date — and add `stock_status_updated_at` to `to_dict()` next to `stock_status`, ISO-formatted or `None`, per `contracts/product-json.md`
 
 ### Service rules
 
-- [ ] T010 [US2] In `app/catalog_service.py`, make `set_stock_status` write `stock_status_updated_at = datetime.now()` whenever a flag value is stored — including when the stored value equals the incoming one, which is what makes a re-assertion produce an `UPDATE` at all (008 FR-002) — and write `None` to it when the flag is cleared (008 FR-003); extend the docstring to state both
-- [ ] T011 [US2] In `app/catalog_service.py`, clear `stock_status_updated_at` alongside `stock_status` in `receive_purchase`, inside the existing flag-clearing branch and its log line (008 FR-006)
-- [ ] T012 [US2] Confirm `update_product`'s `editable` set in `app/catalog_service.py` still excludes `stock_status`, `stock_status_updated_at`, `quantity` and `quantity_updated_at`, and do not add any of them; SC-003 is checkable only because these fields have exactly four writers
+- [X] T010 [US2] In `app/catalog_service.py`, make `set_stock_status` write `stock_status_updated_at = datetime.now()` whenever a flag value is stored — including when the stored value equals the incoming one, which is what makes a re-assertion produce an `UPDATE` at all (008 FR-002) — and write `None` to it when the flag is cleared (008 FR-003); extend the docstring to state both
+- [X] T011 [US2] In `app/catalog_service.py`, clear `stock_status_updated_at` alongside `stock_status` in `receive_purchase`, inside the existing flag-clearing branch and its log line (008 FR-006)
+- [X] T012 [US2] Confirm `update_product`'s `editable` set in `app/catalog_service.py` still excludes `stock_status`, `stock_status_updated_at`, `quantity` and `quantity_updated_at`, and do not add any of them; SC-003 is checkable only because these fields have exactly four writers
 
 ### Presentation
 
-- [ ] T013 [P] [US2] In `app/product/routes.py`, give `relative_age` an optional second parameter — `def relative_age(age, unknown: str = 'never counted') -> str` — returned in place of the hardcoded string in the `None` branch, leaving all existing call sites unchanged; note in the docstring that a count and a flag share this function so their wording cannot drift (008 FR-012)
-- [ ] T014 [P] [US2] In `app/templates/product/detail.html`, add a muted line with `id="flag-age"` under the three flag buttons, rendered only inside `{% if product.stock_status %}`, reading `Flagged {{ product.stock_status }} {{ product.stock_status_age | relative_age('at an unknown time') }}`
-- [ ] T015 [P] [US2] In `app/templates/product/reorder.html`, add a muted `<div class="flag-age">` under the existing `reason-manual` badge, inside the same `{% if entry.is_manually_low %}` guard, rendering `{{ product.stock_status_age | relative_age('at an unknown time') }}`
+- [X] T013 [P] [US2] In `app/product/routes.py`, give `relative_age` an optional second parameter — `def relative_age(age, unknown: str = 'never counted') -> str` — returned in place of the hardcoded string in the `None` branch, leaving all existing call sites unchanged; note in the docstring that a count and a flag share this function so their wording cannot drift (008 FR-012)
+- [X] T014 [P] [US2] In `app/templates/product/detail.html`, add a muted line with `id="flag-age"` under the three flag buttons, rendered only inside `{% if product.stock_status %}`, reading `Flagged {{ product.stock_status }} {{ product.stock_status_age | relative_age('at an unknown time') }}`
+- [X] T015 [P] [US2] In `app/templates/product/reorder.html`, add a muted `<div class="flag-age">` under the existing `reason-manual` badge, inside the same `{% if entry.is_manually_low %}` guard, rendering `{{ product.stock_status_age | relative_age('at an unknown time') }}`
 
 ### Tests for User Story 2
 
-- [ ] T016 [US2] Extend `tests/unit/test_stock_status.py`: setting a flag records the moment (FR-001); setting a flag to the value it already holds moves the stored date forward, verified by backdating first (FR-002); clearing writes `None` to both (FR-003); `stock_status_age` is `None` with no flag and `None` with a flag and no date (FR-005); receiving clears the flag and its date together (FR-006); `to_dict()` carries the ISO field; and `relative_age(None)` still returns `never counted` while `relative_age(None, 'at an unknown time')` returns the override (FR-012)
-- [ ] T017 [P] [US2] Extend `tests/e2e/test_stock_age.py`: flagging from the detail page leaves `#flag-age` reading *Flagged low just now*, reusing `test_reorder_view.py`'s `wait_for_stock_flag` pattern for the post-click reload; a seeded flag with a `NULL` date reads *at an unknown time*; clearing the flag makes `#flag-age` absent rather than empty; and a received purchase leaves neither flag nor flag age
-- [ ] T018 [P] [US2] Extend `tests/e2e/test_reorder_view.py` with a test seeding two flagged products at different backdated times and asserting their `.flag-age` cells, scoped by each row's `data-product-id`, read different ages (SC-004)
-- [ ] T019 [US2] Exercise `b1a0c0d10010` up, down and up again against a **disposable MariaDB container** — never the database named in `.env`, since neither suite runs migrations — and confirm after the upgrade that every `stock_status_updated_at` is `NULL`
+- [X] T016 [US2] Extend `tests/unit/test_stock_status.py`: setting a flag records the moment (FR-001); setting a flag to the value it already holds moves the stored date forward, verified by backdating first (FR-002); clearing writes `None` to both (FR-003); `stock_status_age` is `None` with no flag and `None` with a flag and no date (FR-005); receiving clears the flag and its date together (FR-006); `to_dict()` carries the ISO field; and `relative_age(None)` still returns `never counted` while `relative_age(None, 'at an unknown time')` returns the override (FR-012)
+- [X] T017 [P] [US2] Extend `tests/e2e/test_stock_age.py`: flagging from the detail page leaves `#flag-age` reading *Flagged low just now*, reusing `test_reorder_view.py`'s `wait_for_stock_flag` pattern for the post-click reload; a seeded flag with a `NULL` date reads *at an unknown time*; clearing the flag makes `#flag-age` absent rather than empty; and a received purchase leaves neither flag nor flag age
+- [X] T018 [P] [US2] Extend `tests/e2e/test_reorder_view.py` with a test seeding two flagged products at different backdated times and asserting their `.flag-age` cells, scoped by each row's `data-product-id`, read different ages (SC-004)
+- [X] T019 [US2] Exercise `b1a0c0d10010` up, down and up again against a **disposable MariaDB container** — never the database named in `.env`, since neither suite runs migrations — and confirm after the upgrade that every `stock_status_updated_at` is `NULL`
 
 **Checkpoint**: both suites pass, and the reorder list distinguishes a flag set today from one set two years ago.
 
@@ -109,8 +109,8 @@ User Story 1 is a deleted line in `app/catalog_service.py` and needs no schema c
 
 ### Tests for User Story 3
 
-- [ ] T020 [US3] Extend `tests/unit/test_stock_status.py`: a typed count stamps the age (FR-010); `set_quantity(None)` clears the count, the age and the threshold, and setting a count afterwards writes a fresh age carrying nothing over (FR-011); and `create_product(quantity=...)` stamps the age, since creating a product with a count is an operator entering one
-- [ ] T021 [US3] Extend `tests/e2e/test_stock_age.py`: seed a product with a backdated count, press `#quantity-increment` on the detail page, and `expect(page.locator("#quantity-age"))` to read *counted just now* after the reload — the `+`/`−` buttons reach `PATCH /api/products/<id>/quantity` and must not become a separate path
+- [X] T020 [US3] Extend `tests/unit/test_stock_status.py`: a typed count stamps the age (FR-010); `set_quantity(None)` clears the count, the age and the threshold, and setting a count afterwards writes a fresh age carrying nothing over (FR-011); and `create_product(quantity=...)` stamps the age, since creating a product with a count is an operator entering one
+- [X] T021 [US3] Extend `tests/e2e/test_stock_age.py`: seed a product with a backdated count, press `#quantity-increment` on the detail page, and `expect(page.locator("#quantity-age"))` to read *counted just now* after the reload — the `+`/`−` buttons reach `PATCH /api/products/<id>/quantity` and must not become a separate path
 
 **Checkpoint**: the distinction the feature rests on is pinned by tests in both suites.
 
@@ -118,10 +118,10 @@ User Story 1 is a deleted line in `app/catalog_service.py` and needs no schema c
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T022 [P] Update `docs/user-manual.md`: the stock section around line 694 gains the flag's age beside the count's, and the sentence at line 708 ("Receiving an order clears both kinds of low") gains what receiving now leaves alone — the count's age. Add a short note that flags set before this upgrade have no recorded age and will read *at an unknown time* until flagged again
-- [ ] T023 [P] Update `docs/product-functionality-gap.md`: strike through the two "Reordering and stock" bullets and mark them *Built — feature 008*, matching how the Order capture section records feature 006
-- [ ] T024 Run `nox -s tests` and `nox -s e2e` (allow a 15-minute tool timeout) and confirm both pass and the working tree is left clean
-- [ ] T025 Work through the four hand-checks in `quickstart.md`, in particular the legacy-row check against a copy of the real database — every product flagged before today reading *at an unknown time* is correct behaviour and the single most likely thing to be reported as a bug
+- [X] T022 [P] Update `docs/user-manual.md`: the stock section around line 694 gains the flag's age beside the count's, and the sentence at line 708 ("Receiving an order clears both kinds of low") gains what receiving now leaves alone — the count's age. Add a short note that flags set before this upgrade have no recorded age and will read *at an unknown time* until flagged again
+- [X] T023 [P] Update `docs/product-functionality-gap.md`: strike through the two "Reordering and stock" bullets and mark them *Built — feature 008*, matching how the Order capture section records feature 006
+- [X] T024 Run `nox -s tests` and `nox -s e2e` (allow a 15-minute tool timeout) and confirm both pass and the working tree is left clean
+- [X] T025 Work through the four hand-checks in `quickstart.md`, in particular the legacy-row check against a copy of the real database — every product flagged before today reading *at an unknown time* is correct behaviour and the single most likely thing to be reported as a bug
 
 **Not a task: screenshots.** No committed screenshot shows a product page — `tests/e2e/screenshot_config.yaml` covers the metal-stock screens only — so regenerating would rewrite eleven unrelated PNGs with rasterization noise. The deviation and its reasoning are recorded in `plan.md`; the CI reminder that fires on `app/templates/**` is informational (issue #77) and blocks nothing.
 

--- a/specs/008-trustworthy-stock-age/tasks.md
+++ b/specs/008-trustworthy-stock-age/tasks.md
@@ -1,0 +1,181 @@
+# Tasks: Trustworthy Stock Age
+
+**Feature**: `specs/008-trustworthy-stock-age/` | **Branch**: `issues/59`
+
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]** — parallelizable: a different file from every other task running with it, and no dependency on incomplete work.
+- **[US1] / [US2] / [US3]** — the user story from `spec.md` the task serves. Setup, Foundational and Polish tasks carry no story label.
+
+## Path Conventions
+
+Repository root is `/home/jantman/scratch/rm_me/workshop-inventory-tracking`. Paths below are relative to it. Source the virtualenv (`venv/`) before running anything, and run tests through `nox`, never `pytest` directly.
+
+**Tests are not optional here.** Constitution IV requires that a change altering behaviour lands with tests covering that behaviour. Every story below therefore carries its tests as ordinary tasks, not as an opt-in.
+
+**Two FR namespaces.** Code in `app/` already cites feature 001's FR numbers (FR-024, FR-025, FR-029) in docstrings and comments. This feature has its own FR-001…FR-015. Where a new comment cites one, qualify it — `008 FR-008` — so the next reader is not sent to the wrong spec.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: confirm the ground the change stands on before touching anything.
+
+- [ ] T001 Confirm the current Alembic head is `b1a0c0d10009` by checking `down_revision` across `migrations/versions/*.py`; the new revision in T008 must chain from whatever this reports, not from what the plan assumed
+- [ ] T002 Run `nox -s tests` and record it green, so that any failure after this point belongs to this feature
+
+**Checkpoint**: baseline established.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**None.** This is a finding, not an omission.
+
+User Story 1 is a deleted line in `app/catalog_service.py` and needs no schema change, no new column and no new property — it can ship on its own, ahead of everything else. User Story 2 owns the migration and the new column outright; nothing else depends on them. There is no shared scaffolding for the two to wait on, so introducing a foundational phase would only serialize work that is genuinely independent.
+
+**Checkpoint**: proceed directly to Phase 3.
+
+---
+
+## Phase 3: User Story 1 - The reorder list stops claiming a count nobody made (Priority: P1) 🎯 MVP
+
+**Goal**: receiving a purchase adds the received quantity to a tracked count and leaves the count's age exactly where it was, so the screen stops reporting a verification that never happened.
+
+**Independent test**: seed a product with a tracked count, backdate `quantity_updated_at` by three months, receive an outstanding purchase against it, and confirm the count rose by the received quantity while the stored timestamp is byte-for-byte unchanged.
+
+**Why it stands alone**: no schema change and no display change. The age line already exists; this makes it tell the truth.
+
+### Tests for User Story 1
+
+- [ ] T003 [US1] Add a `TestReceivingDoesNotVerifyACount` class to `tests/unit/test_stock_status.py` with a module-level helper that backdates a product's `quantity_updated_at` through `service.Session()`, covering: the count rises by the received quantity (FR-007); the stored timestamp is **unchanged** — assert equality against the seeded value, not `>=` or "older than now", because the weaker assertion passes against a bug that moves it by a second (FR-008, SC-001); receiving against a product with `quantity IS NULL` leaves both `quantity` and `quantity_updated_at` NULL (FR-009); a purchase with no quantity changes neither; and receiving an already-received purchase changes neither
+- [ ] T004 [P] [US1] Add `test_receiving_does_not_reset_a_counted_age` to a new `tests/e2e/test_stock_age.py`: seed a product and an outstanding purchase through `CatalogService(live_server.storage)`, backdate the count through `sessionmaker(bind=live_server.engine)`, receive through the reorder list's **Receive** button, and `expect(page.locator("#quantity-age"))` to still read the aged text while `#quantity-value` shows the increased count
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] In `app/catalog_service.py`, delete the `product.quantity_updated_at = datetime.now()` line inside `receive_purchase`'s `if not already_received` block (currently line 1319), keeping the increment above it; rewrite the surrounding comment and the method docstring's receiving paragraph to say that the count moves and its age does not, citing `008 FR-007`/`008 FR-008`
+- [ ] T006 [P] [US1] In `app/database.py`, update the `quantity_age` property docstring: the value now means "how long ago an operator counted", not "how long ago the number was written", and the difference is the point of the change — say so, so the deleted line is not restored later as a bug fix
+
+**Checkpoint**: `nox -s tests` and the new E2E test pass. Receiving is honest. This is a shippable increment on its own.
+
+---
+
+## Phase 4: User Story 2 - A hand-set flag shows how old it is (Priority: P2)
+
+**Goal**: a manual low/out flag records when it was set and displays that age wherever the flag appears, in the same words a count's age uses.
+
+**Independent test**: flag one product now, seed another as flagged two years ago and a third as flagged with no recorded date, then open the reorder list and read three distinct ages — *just now*, *2 years ago*, *at an unknown time* — without opening any of them.
+
+**Depends on**: nothing in Phase 3. It can be built and shipped independently; T012's flag-date clearing touches the same method as T005, so if both phases are in flight, sequence those two edits.
+
+### Schema and model
+
+- [ ] T007 [US2] Create `migrations/versions/b1a0c0d10010_add_stock_status_updated_at.py` chaining from the head confirmed in T001: `upgrade` adds `products.stock_status_updated_at` as a nullable `sa.DateTime()` with no server default and **no backfill**; `downgrade` drops it. Document in the revision docstring that the reverse loses only flag ages, and that not backfilling from `last_modified` is deliberate (008 FR-005, SC-006)
+- [ ] T008 [US2] In `app/database.py`, add the `stock_status_updated_at` column to `Product` beside `stock_status`, matching the migration's type and nullability exactly — the unit suite builds its schema with `create_all` and never runs the migration, so drift between the two is invisible to `nox -s tests`. Add no CHECK constraint; `research.md` records why
+- [ ] T009 [US2] In `app/database.py`, add the `stock_status_age` property as a line-for-line mirror of `quantity_age` — `None` when there is no flag and `None` when there is a flag with no recorded date — and add `stock_status_updated_at` to `to_dict()` next to `stock_status`, ISO-formatted or `None`, per `contracts/product-json.md`
+
+### Service rules
+
+- [ ] T010 [US2] In `app/catalog_service.py`, make `set_stock_status` write `stock_status_updated_at = datetime.now()` whenever a flag value is stored — including when the stored value equals the incoming one, which is what makes a re-assertion produce an `UPDATE` at all (008 FR-002) — and write `None` to it when the flag is cleared (008 FR-003); extend the docstring to state both
+- [ ] T011 [US2] In `app/catalog_service.py`, clear `stock_status_updated_at` alongside `stock_status` in `receive_purchase`, inside the existing flag-clearing branch and its log line (008 FR-006)
+- [ ] T012 [US2] Confirm `update_product`'s `editable` set in `app/catalog_service.py` still excludes `stock_status`, `stock_status_updated_at`, `quantity` and `quantity_updated_at`, and do not add any of them; SC-003 is checkable only because these fields have exactly four writers
+
+### Presentation
+
+- [ ] T013 [P] [US2] In `app/product/routes.py`, give `relative_age` an optional second parameter — `def relative_age(age, unknown: str = 'never counted') -> str` — returned in place of the hardcoded string in the `None` branch, leaving all existing call sites unchanged; note in the docstring that a count and a flag share this function so their wording cannot drift (008 FR-012)
+- [ ] T014 [P] [US2] In `app/templates/product/detail.html`, add a muted line with `id="flag-age"` under the three flag buttons, rendered only inside `{% if product.stock_status %}`, reading `Flagged {{ product.stock_status }} {{ product.stock_status_age | relative_age('at an unknown time') }}`
+- [ ] T015 [P] [US2] In `app/templates/product/reorder.html`, add a muted `<div class="flag-age">` under the existing `reason-manual` badge, inside the same `{% if entry.is_manually_low %}` guard, rendering `{{ product.stock_status_age | relative_age('at an unknown time') }}`
+
+### Tests for User Story 2
+
+- [ ] T016 [US2] Extend `tests/unit/test_stock_status.py`: setting a flag records the moment (FR-001); setting a flag to the value it already holds moves the stored date forward, verified by backdating first (FR-002); clearing writes `None` to both (FR-003); `stock_status_age` is `None` with no flag and `None` with a flag and no date (FR-005); receiving clears the flag and its date together (FR-006); `to_dict()` carries the ISO field; and `relative_age(None)` still returns `never counted` while `relative_age(None, 'at an unknown time')` returns the override (FR-012)
+- [ ] T017 [P] [US2] Extend `tests/e2e/test_stock_age.py`: flagging from the detail page leaves `#flag-age` reading *Flagged low just now*, reusing `test_reorder_view.py`'s `wait_for_stock_flag` pattern for the post-click reload; a seeded flag with a `NULL` date reads *at an unknown time*; clearing the flag makes `#flag-age` absent rather than empty; and a received purchase leaves neither flag nor flag age
+- [ ] T018 [P] [US2] Extend `tests/e2e/test_reorder_view.py` with a test seeding two flagged products at different backdated times and asserting their `.flag-age` cells, scoped by each row's `data-product-id`, read different ages (SC-004)
+- [ ] T019 [US2] Exercise `b1a0c0d10010` up, down and up again against a **disposable MariaDB container** — never the database named in `.env`, since neither suite runs migrations — and confirm after the upgrade that every `stock_status_updated_at` is `NULL`
+
+**Checkpoint**: both suites pass, and the reorder list distinguishes a flag set today from one set two years ago.
+
+---
+
+## Phase 5: User Story 3 - Adjusting a count at the shelf still counts as counting (Priority: P3)
+
+**Goal**: prove the boundary US1 draws is the right one — an operator's own adjustment still resets the count's age, and only receiving stopped doing so.
+
+**Independent test**: press the `−` button on a product whose count was last taken months ago and confirm the age line resets to *just now*.
+
+**No production code.** This story is entirely tests. That is intentional: without them, "receiving must not refresh the age" is one careless edit away from becoming "nothing refreshes the age", which would silently break the most common way a count is kept honest.
+
+### Tests for User Story 3
+
+- [ ] T020 [US3] Extend `tests/unit/test_stock_status.py`: a typed count stamps the age (FR-010); `set_quantity(None)` clears the count, the age and the threshold, and setting a count afterwards writes a fresh age carrying nothing over (FR-011); and `create_product(quantity=...)` stamps the age, since creating a product with a count is an operator entering one
+- [ ] T021 [US3] Extend `tests/e2e/test_stock_age.py`: seed a product with a backdated count, press `#quantity-increment` on the detail page, and `expect(page.locator("#quantity-age"))` to read *counted just now* after the reload — the `+`/`−` buttons reach `PATCH /api/products/<id>/quantity` and must not become a separate path
+
+**Checkpoint**: the distinction the feature rests on is pinned by tests in both suites.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T022 [P] Update `docs/user-manual.md`: the stock section around line 694 gains the flag's age beside the count's, and the sentence at line 708 ("Receiving an order clears both kinds of low") gains what receiving now leaves alone — the count's age. Add a short note that flags set before this upgrade have no recorded age and will read *at an unknown time* until flagged again
+- [ ] T023 [P] Update `docs/product-functionality-gap.md`: strike through the two "Reordering and stock" bullets and mark them *Built — feature 008*, matching how the Order capture section records feature 006
+- [ ] T024 Run `nox -s tests` and `nox -s e2e` (allow a 15-minute tool timeout) and confirm both pass and the working tree is left clean
+- [ ] T025 Work through the four hand-checks in `quickstart.md`, in particular the legacy-row check against a copy of the real database — every product flagged before today reading *at an unknown time* is correct behaviour and the single most likely thing to be reported as a bug
+
+**Not a task: screenshots.** No committed screenshot shows a product page — `tests/e2e/screenshot_config.yaml` covers the metal-stock screens only — so regenerating would rewrite eleven unrelated PNGs with rasterization noise. The deviation and its reasoning are recorded in `plan.md`; the CI reminder that fires on `app/templates/**` is informational (issue #77) and blocks nothing.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Phase 1 (Setup)** → everything. T001's answer determines the migration's `down_revision`.
+- **Phase 2 (Foundational)** → empty; nothing blocks.
+- **Phase 3 (US1)** and **Phase 4 (US2)** are independent of each other and may be built in either order or in parallel, with one exception: T005 and T011 both edit `receive_purchase`, so sequence those two.
+- **Phase 5 (US3)** is best done after Phase 3, since it exists to guard the boundary Phase 3 draws — but its tests pass before and after, so it does not block.
+- **Phase 6 (Polish)** → after the stories whose behaviour it documents.
+
+### Within User Story 2
+
+```
+T007 (migration) ─┐
+T008 (column) ────┴─→ T009 (property, to_dict) ─→ T016 (unit tests)
+                                                 ↘
+T010, T011, T012 (service) ──────────────────────→ T017, T018 (E2E)
+T013 (filter) ─→ T014, T015 (templates) ─────────↗
+T019 (migration up/down) — independent of the rest; do it before merging
+```
+
+T014 and T015 need T009's property and T013's parameter to exist at render time. Editing them earlier is harmless; running the E2E tests before those land is not.
+
+### Parallel opportunities
+
+- **T004 with T003** — different files (`tests/e2e/test_stock_age.py`, `tests/unit/test_stock_status.py`).
+- **T006 with T005** — different files (`app/database.py`, `app/catalog_service.py`).
+- **T013, T014, T015** — three different files, once T009 exists.
+- **T017 with T018** — different E2E files.
+- **T022 with T023** — different documents.
+
+Everything touching `tests/unit/test_stock_status.py` (T003, T016, T020) is one file and runs sequentially, as does everything touching `app/catalog_service.py` (T005, T010, T011, T012).
+
+---
+
+## Implementation Strategy
+
+### MVP: User Story 1 alone
+
+T001–T006. Six tasks, one deleted line of production code, two docstrings and two tests. It removes the only place the application currently states something untrue, needs no migration, and can be merged without any of the rest. If the feature were cut short here it would still have paid for itself.
+
+### Incremental delivery
+
+1. **US1** — receiving stops claiming a verification. Ship.
+2. **US2** — the flag gets an age. This is the larger half: the migration, the column, the property, the service rules and both templates. Ship.
+3. **US3** — pin the boundary. Tests only.
+4. **Polish** — the two documents, the full suites, the hand-checks.
+
+### The two things most likely to go wrong
+
+- **An FR-008 test that asserts too weakly.** `assert product.quantity_updated_at >= seeded` passes against the exact bug being removed. Assert equality with the seeded value.
+- **Model/migration drift.** `nox -s tests` builds its schema from the model with `create_all` and never runs Alembic, so a column that differs between `app/database.py` and `b1a0c0d10010` passes the unit suite and fails on the real database. T019 is the only thing that catches it.

--- a/tests/e2e/test_reorder_view.py
+++ b/tests/e2e/test_reorder_view.py
@@ -10,33 +10,13 @@ and impossible to notice from the UI afterwards:
   count, and clears a manual flag only because the receive path says so.
 """
 
-import re
+from datetime import datetime, timedelta
 
 import pytest
 from playwright.sync_api import expect
 
-
-def wait_for_stock_flag(page, status):
-    """Wait for a stock-status button click to have taken effect.
-
-    The buttons are type="button": they PATCH the API and then reload the page,
-    so nothing has happened yet at the moment the click returns. Waiting on the
-    reloaded button's own styling is the only observable proof the round trip
-    finished -- and without it the next goto() aborts the in-flight PATCH.
-    """
-    if status:
-        colour = 'btn-warning' if status == 'low' else 'btn-danger'
-        expect(page.locator(f"#flag-{status}-btn")).to_have_class(
-            re.compile(rf"\b{colour}\b")
-        )
-    else:
-        # Cleared: every status button is back to its outline variant.
-        expect(page.locator("#flag-low-btn")).to_have_class(
-            re.compile(r"\bbtn-outline-warning\b")
-        )
-        expect(page.locator("#flag-out-btn")).to_have_class(
-            re.compile(r"\bbtn-outline-danger\b")
-        )
+from app.catalog_service import CatalogService
+from tests.e2e.waits import wait_for_stock_flag
 
 
 def create_product(page, base_url, description):
@@ -235,3 +215,34 @@ def test_the_manual_flag_is_set_and_cleared_by_button(page, live_server):
     page.click("#clear-flag-btn")
     wait_for_stock_flag(page, None)
     assert reorder_rows(page, live_server.url) == []
+
+
+@pytest.mark.e2e
+def test_two_flagged_products_show_when_each_was_flagged(page, live_server):
+    """008 SC-004 -- the whole point of dating the flag.
+
+    This is the screen where the operator decides what to buy. Before feature
+    008 these two rows were indistinguishable, so a flag set this morning and
+    one set two years ago and forgotten looked like equally good evidence.
+    Seeded rather than driven: the flag buttons are covered above, and an age
+    cannot be set through them anyway.
+    """
+    service = CatalogService(live_server.storage)
+    recent = service.create_product(description='Flagged recently')
+    stale = service.create_product(description='Flagged long ago')
+    for product in (recent, stale):
+        service.set_stock_status(product.id, 'low')
+    live_server.backdate_product(
+        recent.id, stock_status_updated_at=datetime.now() - timedelta(days=9)
+    )
+    live_server.backdate_product(
+        stale.id, stock_status_updated_at=datetime.now() - timedelta(days=800)
+    )
+
+    page.goto(f"{live_server.url}/products/reorder")
+    expect(page.locator(f"tr[data-product-id='{recent.id}'] .flag-age")).to_have_text(
+        "9 days ago"
+    )
+    expect(page.locator(f"tr[data-product-id='{stale.id}'] .flag-age")).to_have_text(
+        "2 years ago"
+    )

--- a/tests/e2e/test_server.py
+++ b/tests/e2e/test_server.py
@@ -214,6 +214,36 @@ class E2ETestServer:
         print(f"Added {len(products)} test products directly to database")
         return products
 
+    def backdate_product(self, product_id, **fields):
+        """Write a product column directly, bypassing CatalogService.
+
+        For the stock timestamps specifically. Every service path that records
+        one writes ``datetime.now()``, so a count taken three months ago or a
+        flag set two years ago is unreachable through the UI or the service --
+        and those are exactly the states the age display exists for.
+
+        A direct write to one named column is smaller and more local than
+        patching the clock, which would reach every other request the
+        in-process server has in flight.
+
+        Args:
+            product_id: The product to write to.
+            **fields: Column names and values, e.g.
+                ``quantity_updated_at=datetime(2026, 1, 14)``.
+        """
+        if not self.storage:
+            raise RuntimeError("Server not started")
+
+        Session = sessionmaker(bind=self.engine)
+        session = Session()
+        try:
+            product = session.query(Product).filter(Product.id == product_id).one()
+            for name, value in fields.items():
+                setattr(product, name, value)
+            session.commit()
+        finally:
+            session.close()
+
     def add_material_taxonomy(self, taxonomy_data, clear_existing=True):
         """Add custom material taxonomy data for testing
 

--- a/tests/e2e/test_stock_age.py
+++ b/tests/e2e/test_stock_age.py
@@ -1,0 +1,153 @@
+"""
+E2E tests for the age shown beside a stock assertion (feature 008).
+
+The feature is one claim in two places: an assertion about stock displays the age
+of the evidence behind it, and nothing claims evidence it does not have. These
+tests drive the two screens where that shows -- the product detail page and the
+reorder list -- and seed everything else directly, because the seeding is not
+what is under test.
+
+Every age is server-rendered: `product-stock.js` reloads the page after each
+successful PATCH rather than patching the DOM, so nothing here is asserting
+against a JavaScript-rendered region.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from playwright.sync_api import expect
+
+from app.catalog_service import CatalogService
+from tests.e2e.waits import wait_for_stock_flag
+
+
+def days_ago(days):
+    """An age is unreachable through the UI -- every write path stamps now()"""
+    return datetime.now() - timedelta(days=days)
+
+
+@pytest.mark.e2e
+def test_receiving_does_not_reset_a_counted_age(page, live_server):
+    """008 FR-007, FR-008, SC-001: the number moves and the age does not.
+
+    Receiving used to stamp the count as freshly updated, so the screen read
+    "counted just now" when nobody had counted anything.
+    """
+    service = CatalogService(live_server.storage)
+    product = service.create_product(
+        description='M3 standoff', quantity=4, reorder_threshold=5
+    )
+    service.record_purchase(
+        product.id, vendor='Amazon', order_date=datetime(2026, 1, 14), quantity=100
+    )
+    live_server.backdate_product(product.id, quantity_updated_at=days_ago(100))
+
+    page.goto(f"{live_server.url}/products/reorder")
+    receive = page.locator(f"tr[data-product-id='{product.id}'] .receive-btn")
+    expect(receive).to_be_visible()
+    receive.click()
+
+    expect(page.locator("#confirm-receive-btn")).to_be_visible()
+    page.click("#confirm-receive-btn")
+
+    # Receiving redirects to the product page. The increased count is the proof
+    # the round trip landed, so it is also the wait for the age assertion below.
+    expect(page.locator("#quantity-value")).to_contain_text("104")
+    expect(page.locator("#quantity-age")).to_contain_text("3 months ago")
+
+
+@pytest.mark.e2e
+def test_flagging_a_product_shows_the_flag_as_just_set(page, live_server):
+    """008 FR-001, FR-004 -- the flag arrives with its age attached"""
+    product = CatalogService(live_server.storage).create_product(description='Blue tape')
+
+    page.goto(f"{live_server.url}/products/{product.id}")
+    expect(page.locator("#flag-age")).to_have_count(0)
+
+    page.click("#flag-low-btn")
+    wait_for_stock_flag(page, 'low')
+
+    expect(page.locator("#flag-age")).to_have_text("Flagged low just now")
+
+
+@pytest.mark.e2e
+def test_a_flag_with_no_recorded_date_says_so(page, live_server):
+    """008 FR-005, SC-006 -- every row that predates this feature.
+
+    Nothing is backfilled, so the honest answer is that the date is unknown. No
+    other date is substituted, and this is not an error state.
+    """
+    service = CatalogService(live_server.storage)
+    product = service.create_product(description='Legacy flagged thing')
+    service.set_stock_status(product.id, 'low')
+    live_server.backdate_product(product.id, stock_status_updated_at=None)
+
+    page.goto(f"{live_server.url}/products/{product.id}")
+    expect(page.locator("#flag-age")).to_have_text("Flagged low at an unknown time")
+
+
+@pytest.mark.e2e
+def test_clearing_a_flag_removes_the_age_line_entirely(page, live_server):
+    """008 FR-003 -- absent, not blank: there is no flag to date"""
+    service = CatalogService(live_server.storage)
+    product = service.create_product(description='Blue tape')
+    service.set_stock_status(product.id, 'low')
+
+    page.goto(f"{live_server.url}/products/{product.id}")
+    expect(page.locator("#flag-age")).to_be_visible()
+
+    page.click("#clear-flag-btn")
+    wait_for_stock_flag(page, None)
+
+    expect(page.locator("#flag-age")).to_have_count(0)
+
+
+@pytest.mark.e2e
+def test_receiving_leaves_neither_a_flag_nor_a_flag_age(page, live_server):
+    """008 FR-006 -- no stale age survives to be shown if it is flagged again"""
+    service = CatalogService(live_server.storage)
+    product = service.create_product(description='Flagged by hand')
+    service.set_stock_status(product.id, 'low')
+    service.record_purchase(
+        product.id, vendor='Amazon', order_date=datetime(2026, 1, 14), quantity=10
+    )
+    live_server.backdate_product(product.id, stock_status_updated_at=days_ago(400))
+
+    page.goto(f"{live_server.url}/products/reorder")
+    expect(page.locator(f"tr[data-product-id='{product.id}'] .flag-age")).to_have_text(
+        "1 year ago"
+    )
+    page.click(f"tr[data-product-id='{product.id}'] .receive-btn")
+
+    expect(page.locator("#confirm-receive-btn")).to_be_visible()
+    page.click("#confirm-receive-btn")
+
+    # Redirected to the product page: the flag buttons are back to their outline
+    # variants, which is the proof the receipt landed.
+    wait_for_stock_flag(page, None)
+    expect(page.locator("#flag-age")).to_have_count(0)
+
+
+@pytest.mark.e2e
+def test_adjusting_a_count_at_the_shelf_resets_its_age(page, live_server):
+    """008 FR-010 -- the boundary that keeps FR-008 from over-reaching.
+
+    The operator pressing + or - is holding the things, so that *is* a count.
+    The buttons reach PATCH /api/products/<id>/quantity, the same endpoint the
+    typed count uses; they must not become a separate path that forgets to
+    stamp the age.
+    """
+    product = CatalogService(live_server.storage).create_product(
+        description='M3 standoff', quantity=4
+    )
+    live_server.backdate_product(product.id, quantity_updated_at=days_ago(100))
+
+    page.goto(f"{live_server.url}/products/{product.id}")
+    expect(page.locator("#quantity-age")).to_contain_text("3 months ago")
+
+    page.click("#quantity-increment")
+
+    # The button PATCHes and then reloads; the new count is the proof the round
+    # trip finished, and the age line is re-rendered by that same reload.
+    expect(page.locator("#quantity-value")).to_contain_text("5")
+    expect(page.locator("#quantity-age")).to_have_text("counted just now")

--- a/tests/e2e/waits.py
+++ b/tests/e2e/waits.py
@@ -221,6 +221,33 @@ def wait_for_material_suggestions(page: Page, query: str) -> None:
     )
 
 
+def wait_for_stock_flag(page: Page, status) -> None:
+    """Wait for a stock-status button click to have taken effect.
+
+    The buttons are type="button": they PATCH the API and then reload the page,
+    so nothing has happened yet at the moment the click returns. Waiting on the
+    reloaded button's own styling is the only observable proof the round trip
+    finished -- and without it the next goto() aborts the in-flight PATCH.
+
+    Args:
+        page: The page showing the product detail view.
+        status: 'low', 'out', or None for a cleared flag.
+    """
+    if status:
+        colour = 'btn-warning' if status == 'low' else 'btn-danger'
+        expect(page.locator(f"#flag-{status}-btn")).to_have_class(
+            re.compile(rf"\b{colour}\b")
+        )
+    else:
+        # Cleared: every status button is back to its outline variant.
+        expect(page.locator("#flag-low-btn")).to_have_class(
+            re.compile(r"\bbtn-outline-warning\b")
+        )
+        expect(page.locator("#flag-out-btn")).to_have_class(
+            re.compile(r"\bbtn-outline-danger\b")
+        )
+
+
 def wait_for_select_populated(page: Page, select_id: str) -> None:
     """Wait for a select that is filled from an API call after render.
 

--- a/tests/e2e/waits.py
+++ b/tests/e2e/waits.py
@@ -221,7 +221,13 @@ def wait_for_material_suggestions(page: Page, query: str) -> None:
     )
 
 
-def wait_for_stock_flag(page: Page, status) -> None:
+# The flag values the product page has buttons for, and the class each button
+# carries once it is the active one. A value outside this mapping has no button
+# to wait on, so it is rejected rather than turned into a selector.
+_STOCK_FLAG_ACTIVE_CLASS = {'low': 'btn-warning', 'out': 'btn-danger'}
+
+
+def wait_for_stock_flag(page: Page, status: str | None) -> None:
     """Wait for a stock-status button click to have taken effect.
 
     The buttons are type="button": they PATCH the API and then reload the page,
@@ -232,9 +238,19 @@ def wait_for_stock_flag(page: Page, status) -> None:
     Args:
         page: The page showing the product detail view.
         status: 'low', 'out', or None for a cleared flag.
+
+    Raises:
+        ValueError: If status is not one of those three. Interpolating an
+            unknown value into `#flag-{status}-btn` would instead wait out
+            Playwright's full timeout against an element that never existed,
+            and report it as a flaky UI rather than as the typo it is.
     """
+    if status is not None and status not in _STOCK_FLAG_ACTIVE_CLASS:
+        valid = ', '.join(repr(s) for s in _STOCK_FLAG_ACTIVE_CLASS)
+        raise ValueError(f"Unknown stock flag {status!r}. Expected {valid}, or None")
+
     if status:
-        colour = 'btn-warning' if status == 'low' else 'btn-danger'
+        colour = _STOCK_FLAG_ACTIVE_CLASS[status]
         expect(page.locator(f"#flag-{status}-btn")).to_have_class(
             re.compile(rf"\b{colour}\b")
         )

--- a/tests/unit/test_stock_status.py
+++ b/tests/unit/test_stock_status.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta
 import pytest
 
 from app.catalog_service import CatalogService
+from app.database import Product
 from app.exceptions import ItemNotFoundError, ValidationError
 from app.product.routes import relative_age
 
@@ -22,6 +23,25 @@ from app.product.routes import relative_age
 @pytest.fixture
 def service(test_storage):
     return CatalogService(test_storage)
+
+
+def backdate(service, product_id, **fields):
+    """Write a timestamp column directly, bypassing the service.
+
+    Every path that records an age writes ``datetime.now()``, so "counted three
+    months ago" and "flagged two years ago" are unreachable through the service
+    or the UI. The tests that need one write the column through a session and
+    then exercise the service against it (research.md, "How a test backdates a
+    timestamp").
+    """
+    session = service.Session()
+    try:
+        product = session.query(Product).filter(Product.id == product_id).one()
+        for name, value in fields.items():
+            setattr(product, name, value)
+        session.commit()
+    finally:
+        session.close()
 
 
 class TestThreeQuantityStates:
@@ -119,6 +139,18 @@ class TestRelativeAgeRendering:
 
     def test_no_age_reads_as_never_counted(self):
         assert relative_age(None) == 'never counted'
+
+    def test_the_no_age_wording_can_be_overridden(self):
+        """008 FR-012 -- one function renders both kinds of evidence.
+
+        'never counted' is right for a count and wrong for a flag, which was
+        certainly set; only its date was not recorded. Everything below the None
+        branch is shared, so the two cannot drift into different vocabularies.
+        """
+        assert relative_age(None, 'at an unknown time') == 'at an unknown time'
+
+    def test_the_override_does_not_reach_an_age_that_exists(self):
+        assert relative_age(timedelta(days=240), 'at an unknown time') == '8 months ago'
 
     def test_minutes_read_as_just_now(self):
         assert relative_age(timedelta(minutes=5)) == 'just now'
@@ -303,3 +335,289 @@ class TestFr029BothHalves:
         service.receive_purchase(purchase.id)
 
         assert service.get_product(product.id).quantity is None
+
+
+COUNTED_IN_JANUARY = datetime(2026, 1, 14, 9, 30, 0)
+
+
+class TestReceivingDoesNotVerifyACount:
+    """008 FR-007 and FR-008: the number moves, the age stays where it was.
+
+    Receiving used to stamp ``quantity_updated_at`` alongside the increment, so
+    a delivery made the screen read "counted just now" when nobody had counted
+    anything. Every assertion below compares the stored timestamp for
+    **equality** with the seeded value, never ``>=`` and never "older than an
+    hour": the weaker forms pass against exactly the bug being removed.
+    """
+
+    def _tracked_with_an_outstanding_order(self, service, quantity=4, ordered=100):
+        product = service.create_product(description='M3 standoff', quantity=quantity)
+        backdate(service, product.id, quantity_updated_at=COUNTED_IN_JANUARY)
+        purchase = service.record_purchase(
+            product.id, vendor='Amazon', order_date=datetime(2026, 1, 14), quantity=ordered
+        )
+        return product, purchase
+
+    def test_the_count_rises_by_the_received_quantity(self, service):
+        """008 FR-007 -- the increment is kept; only its dishonest half went"""
+        product, purchase = self._tracked_with_an_outstanding_order(service)
+        service.receive_purchase(purchase.id)
+
+        assert service.get_product(product.id).quantity == 104
+
+    def test_the_counted_age_does_not_move(self, service):
+        """008 FR-008, SC-001 -- equality, because >= passes against the bug"""
+        product, purchase = self._tracked_with_an_outstanding_order(service)
+        service.receive_purchase(purchase.id)
+
+        assert service.get_product(product.id).quantity_updated_at == COUNTED_IN_JANUARY
+
+    def test_an_untracked_product_gains_neither_a_count_nor_an_age(self, service):
+        """008 FR-009 -- receiving never begins tracking a count"""
+        product = service.create_product(description='untracked')
+        purchase = service.record_purchase(
+            product.id, vendor='Amazon', order_date=datetime(2026, 1, 14), quantity=10
+        )
+        service.receive_purchase(purchase.id)
+
+        after = service.get_product(product.id)
+        assert after.quantity is None
+        assert after.quantity_updated_at is None
+
+    def test_a_purchase_with_no_quantity_moves_neither(self, service):
+        """Nothing arrived that anyone counted, so nothing about the count changes"""
+        product = service.create_product(description='M3 standoff', quantity=4)
+        backdate(service, product.id, quantity_updated_at=COUNTED_IN_JANUARY)
+        purchase = service.record_purchase(
+            product.id, vendor='Amazon', order_date=datetime(2026, 1, 14)
+        )
+        service.receive_purchase(purchase.id)
+
+        after = service.get_product(product.id)
+        assert after.quantity == 4
+        assert after.quantity_updated_at == COUNTED_IN_JANUARY
+
+    def test_receiving_an_already_received_purchase_moves_neither(self, service):
+        """008 FR-008 -- the second receipt is a no-op for stock, as before"""
+        product, purchase = self._tracked_with_an_outstanding_order(service)
+        service.receive_purchase(purchase.id)
+        service.receive_purchase(purchase.id)
+
+        after = service.get_product(product.id)
+        assert after.quantity == 104
+        assert after.quantity_updated_at == COUNTED_IN_JANUARY
+
+
+FLAGGED_TWO_YEARS_AGO = datetime(2024, 3, 5, 11, 0, 0)
+
+
+class TestFlagIsDated:
+    """008 FR-001 to FR-003, FR-006: the flag carries when it was set"""
+
+    def test_flagging_records_the_moment(self, service):
+        """008 FR-001"""
+        product = service.create_product(description='x')
+        flagged = service.set_stock_status(product.id, 'low')
+
+        assert flagged.stock_status_updated_at is not None
+        assert datetime.now() - flagged.stock_status_updated_at < timedelta(minutes=1)
+
+    def test_an_unflagged_product_has_no_flag_date(self, service):
+        product = service.create_product(description='x')
+        assert product.stock_status_updated_at is None
+
+    def test_changing_the_flag_moves_the_date(self, service):
+        """008 FR-002 -- 'out' is a new assertion, not the old one"""
+        product = service.create_product(description='x')
+        service.set_stock_status(product.id, 'low')
+        backdate(service, product.id, stock_status_updated_at=FLAGGED_TWO_YEARS_AGO)
+
+        changed = service.set_stock_status(product.id, 'out')
+        assert changed.stock_status == 'out'
+        assert changed.stock_status_updated_at > FLAGGED_TWO_YEARS_AGO
+
+    def test_re_asserting_the_same_flag_moves_the_date(self, service):
+        """008 FR-002 -- and before this feature the press did nothing at all.
+
+        Assigning a string equal to the stored one is no change as far as
+        SQLAlchemy is concerned, so no UPDATE was emitted. The timestamp write
+        is what makes re-affirming a flag -- "I have just looked, still low" --
+        a real act, and it is the only way to renew evidence on a product that
+        has no count to re-count.
+        """
+        product = service.create_product(description='x')
+        service.set_stock_status(product.id, 'low')
+        backdate(service, product.id, stock_status_updated_at=FLAGGED_TWO_YEARS_AGO)
+
+        reasserted = service.set_stock_status(product.id, 'low')
+        assert reasserted.stock_status == 'low'
+        assert reasserted.stock_status_updated_at > FLAGGED_TWO_YEARS_AGO
+
+    def test_clearing_the_flag_clears_its_date(self, service):
+        """008 FR-003 -- a later flag must not inherit an older one's date"""
+        product = service.create_product(description='x')
+        service.set_stock_status(product.id, 'low')
+
+        cleared = service.set_stock_status(product.id, None)
+        assert cleared.stock_status is None
+        assert cleared.stock_status_updated_at is None
+
+    def test_flagging_again_after_a_clear_starts_a_fresh_date(self, service):
+        product = service.create_product(description='x')
+        service.set_stock_status(product.id, 'low')
+        backdate(service, product.id, stock_status_updated_at=FLAGGED_TWO_YEARS_AGO)
+        service.set_stock_status(product.id, None)
+
+        reflagged = service.set_stock_status(product.id, 'low')
+        assert reflagged.stock_status_updated_at > FLAGGED_TWO_YEARS_AGO
+
+    def test_a_refused_value_leaves_both_fields_alone(self, service):
+        """Validation happens before the session opens, as it always did"""
+        product = service.create_product(description='x')
+        service.set_stock_status(product.id, 'low')
+        backdate(service, product.id, stock_status_updated_at=FLAGGED_TWO_YEARS_AGO)
+
+        with pytest.raises(ValidationError):
+            service.set_stock_status(product.id, 'quite low really')
+
+        after = service.get_product(product.id)
+        assert after.stock_status == 'low'
+        assert after.stock_status_updated_at == FLAGGED_TWO_YEARS_AGO
+
+    def test_receiving_clears_the_flag_and_its_date_together(self, service):
+        """008 FR-006 -- no stale flag age survives to be shown later"""
+        product = service.create_product(description='x')
+        service.set_stock_status(product.id, 'low')
+        purchase = service.record_purchase(
+            product.id, vendor='Amazon', order_date=datetime(2026, 1, 14), quantity=10
+        )
+        service.receive_purchase(purchase.id)
+
+        after = service.get_product(product.id)
+        assert after.stock_status is None
+        assert after.stock_status_updated_at is None
+
+
+class TestStockStatusAge:
+    """008 FR-005 -- a mirror of TestQuantityAge, because it is a mirror"""
+
+    def test_an_unflagged_product_has_no_flag_age(self, service):
+        product = service.create_product(description='x')
+        assert product.stock_status_age is None
+
+    def test_a_flagged_product_has_a_flag_age(self, service):
+        product = service.create_product(description='x')
+        flagged = service.set_stock_status(product.id, 'low')
+
+        assert flagged.stock_status_age is not None
+        assert flagged.stock_status_age < timedelta(minutes=1)
+
+    def test_a_flag_with_no_date_yields_no_age_rather_than_an_error(self, service):
+        """008 FR-005, SC-006 -- every row that predates this feature.
+
+        An unrecorded age stays unrecorded and is rendered as unknown; no other
+        date is substituted for it.
+        """
+        product = service.create_product(description='x')
+        service.set_stock_status(product.id, 'low')
+        backdate(service, product.id, stock_status_updated_at=None)
+
+        assert service.get_product(product.id).stock_status_age is None
+
+    def test_a_backdated_flag_reports_its_real_age(self, service):
+        product = service.create_product(description='x')
+        service.set_stock_status(product.id, 'low')
+        backdate(service, product.id, stock_status_updated_at=datetime.now() - timedelta(days=800))
+
+        assert relative_age(service.get_product(product.id).stock_status_age) == '2 years ago'
+
+    def test_a_count_and_a_flag_are_aged_independently(self, service):
+        """Two acts, two pieces of evidence, two dates"""
+        product = service.create_product(description='x', quantity=5)
+        service.set_stock_status(product.id, 'low')
+        backdate(service, product.id, quantity_updated_at=COUNTED_IN_JANUARY)
+
+        after = service.get_product(product.id)
+        assert after.quantity_updated_at == COUNTED_IN_JANUARY
+        assert after.stock_status_updated_at > COUNTED_IN_JANUARY
+
+
+class TestProductJsonCarriesTheFlagDate:
+    """contracts/product-json.md -- additive, shaped like quantity_updated_at"""
+
+    def test_a_flagged_product_serializes_an_iso_date(self, service):
+        product = service.create_product(description='x')
+        service.set_stock_status(product.id, 'low')
+        backdate(service, product.id, stock_status_updated_at=FLAGGED_TWO_YEARS_AGO)
+
+        payload = service.get_product(product.id).to_dict()
+        assert payload['stock_status'] == 'low'
+        assert payload['stock_status_updated_at'] == FLAGGED_TWO_YEARS_AGO.isoformat()
+
+    def test_an_unflagged_product_serializes_null(self, service):
+        product = service.create_product(description='x')
+        assert product.to_dict()['stock_status_updated_at'] is None
+
+
+class TestCountingStillCountsAsCounting:
+    """008 FR-010, FR-011: the boundary that makes FR-008 coherent.
+
+    Without these, "receiving must not refresh the count's age" is one careless
+    edit away from "nothing refreshes the count's age", which would silently
+    break the most common way a count is kept honest -- the operator standing at
+    the shelf with the things in their hand.
+    """
+
+    def test_a_typed_count_stamps_the_age(self, service):
+        """008 FR-010 -- an operator entering a number is a verification"""
+        product = service.create_product(description='x', quantity=4)
+        backdate(service, product.id, quantity_updated_at=COUNTED_IN_JANUARY)
+
+        counted = service.set_quantity(product.id, 6)
+        assert counted.quantity == 6
+        assert counted.quantity_updated_at > COUNTED_IN_JANUARY
+
+    def test_stepping_a_count_stamps_the_age(self, service):
+        """008 FR-010 -- the +/- buttons reach set_quantity and must keep doing so.
+
+        `product-stock.js` sends them to PATCH /api/products/<id>/quantity, the
+        same endpoint the typed count uses. They are not a separate path and
+        must not become one.
+        """
+        product = service.create_product(description='x', quantity=4)
+        backdate(service, product.id, quantity_updated_at=COUNTED_IN_JANUARY)
+
+        stepped = service.set_quantity(product.id, 3)
+        assert stepped.quantity == 3
+        assert stepped.quantity_updated_at > COUNTED_IN_JANUARY
+
+    def test_stopping_tracking_clears_the_count_the_age_and_the_threshold(self, service):
+        """008 FR-011"""
+        product = service.create_product(description='x', quantity=4, reorder_threshold=2)
+        stopped = service.set_quantity(product.id, None)
+
+        assert stopped.quantity is None
+        assert stopped.quantity_updated_at is None
+        assert stopped.reorder_threshold is None
+
+    def test_counting_again_afterwards_carries_nothing_over(self, service):
+        """008 FR-011 -- a fresh age, not the one from before tracking stopped"""
+        product = service.create_product(description='x', quantity=4)
+        backdate(service, product.id, quantity_updated_at=COUNTED_IN_JANUARY)
+        service.set_quantity(product.id, None)
+
+        restarted = service.set_quantity(product.id, 9)
+        assert restarted.quantity == 9
+        assert restarted.quantity_updated_at > COUNTED_IN_JANUARY
+        assert datetime.now() - restarted.quantity_updated_at < timedelta(minutes=1)
+
+    def test_creating_a_product_with_a_count_stamps_the_age(self, service):
+        """Creating a product *with* a count is the operator entering one"""
+        product = service.create_product(description='x', quantity=4)
+
+        assert product.quantity_updated_at is not None
+        assert datetime.now() - product.quantity_updated_at < timedelta(minutes=1)
+
+    def test_creating_a_product_without_a_count_stamps_nothing(self, service):
+        product = service.create_product(description='x')
+        assert product.quantity_updated_at is None


### PR DESCRIPTION
Closes #59. Spec, plan and tasks: [`specs/008-trustworthy-stock-age/`](specs/008-trustworthy-stock-age/).

The catalogue already knows a bare number is not trustworthy — it never shows a count without saying how old it is. That mechanism had two holes. This closes both: **a stock assertion displays the age of the evidence behind it, and nothing claims evidence it does not have.**

## One deleted line

`receive_purchase` wrote `quantity_updated_at = datetime.now()` alongside the increment, so a delivery could make the screen read *counted just now* when nobody counted anything — the number rose by what the packing slip claimed, sight unseen. That was the one place the application stated something untrue.

The increment stays. A count that ignores a delivery is knowingly wrong from the moment the box is opened, which is a worse trade than a correct number whose age is honest about who last verified it. Issue #59's third option — receiving stops touching the count entirely — was considered and not taken; the reasoning is in the spec's Assumptions.

No second "last changed" date was added beside the count's age. What a receipt changed is already recorded, with its date and quantity, on the purchase that changed it.

## One column

`products.stock_status_updated_at`, nullable, written when the manual low/out flag is set and cleared with it. Before this, a product flagged two years ago and one flagged this morning were indistinguishable on the reorder list — the one screen where the operator decides what to buy.

Re-pressing a flag it already holds now moves the date. That press previously did **nothing at all**: assigning an identical string is no change to SQLAlchemy, so no `UPDATE` was emitted. Re-affirming is the operator saying they have just looked, and on something that isn't counted it is the only way to renew the evidence.

## ⚠️ Nothing is backfilled — expect "at an unknown time"

After the upgrade, **every product you have already flagged will read *Flagged low at an unknown time***. That is correct behaviour, and it is the single most likely thing to be mistaken for a bug.

`last_modified` is the only candidate date and it is not evidence — it moves when a description is corrected or a receipt clears an unrelated field. Inventing a date would reproduce inside the flag the exact error being removed from the count, and worse, because afterwards a fabrication is indistinguishable from a real date. Press the flag again to give it a real one.

## Design notes

- `relative_age` gained one optional parameter rather than a sibling filter, so a count and a flag on one screen are rendered by the same code and cannot drift into different vocabularies.
- **No CHECK constraint** pairing the flag with its date. The identical invariant for `quantity`/`quantity_updated_at` has been enforced in code alone since feature 001; constraining one and not the other would leave the table saying that one of two matching rules matters.
- **No JavaScript.** `product-stock.js` already reloads after a successful PATCH, so both age lines are server-rendered.
- `wait_for_stock_flag` moved from `test_reorder_view.py` to `tests/e2e/waits.py`, and a `backdate_product` seeding helper joined `add_test_products` on the test server — both are now used by two modules.

## Testing

| | Result |
|---|---|
| `nox -s tests` | **1080 passed** (baseline 1052) |
| `nox -s e2e` | **449 passed**, 10m26s, clean tree |

The FR-008 assertions compare the stored timestamp for **equality** with a seeded value rather than `>=`, because the weaker form passes against exactly the bug being removed. Both were confirmed red before the fix.

A third of the diff is tests pinning the boundary: "receiving must not refresh the count's age" is one careless edit away from "nothing refreshes the count's age", which would silently break the +/− buttons.

## Migration `b1a0c0d10010`

Neither suite runs Alembic, so it was exercised by hand — up, down, up — against a disposable MariaDB 11.8 container, never the database in `.env`. Confirmed: the column is nullable `datetime` matching the model, pre-existing flagged rows come through `NULL`, and the downgrade costs only the flag dates.

**The deployment still needs `manage.py db upgrade` run at deploy time.**

## Not done

- **Screenshots are not regenerated.** No committed image shows a product page — `screenshot_config.yaml` covers the metal-stock screens only — so regenerating would rewrite eleven unrelated PNGs with rasterization noise. Recorded in the plan.
- **The legacy-row check against a copy of the real database** is still yours to run. I reproduced the exact post-upgrade state on a container and confirmed the wording; what your data adds is seeing it at real volume.
- `nox -s lint` fails, identically at baseline `main`, on files this branch never touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7LLGYmpXK2Jof2zDfZJRH
