### PR TITLE
fix(add): make Add & Continue work with quantity greater than one (#52)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/009-find-by-code-or-note"
+  "feature_directory": "specs/010-fix-bulk-add-continue"
 }

--- a/app/static/js/inventory-add.js
+++ b/app/static/js/inventory-add.js
@@ -72,14 +72,26 @@ class InventoryAddForm {
     }
     
     setupEventListeners() {
-        // Form submission
+        // Form submission. Both submit buttons go through this one listener --
+        // which one was pressed is read from event.submitter inside the handler.
+        // A second listener on the continue button would be a second entry point
+        // for one user action, which is what this replaced.
         this.form.addEventListener('submit', (e) => this.handleSubmit(e));
-        
-        // Submit and continue button
-        document.getElementById('submit-and-continue-btn').addEventListener('click', () => {
-            this.handleSubmit(null, true);
-        });
-        
+
+        // Honour "continue" on the bulk path. Bulk creation answers with JSON
+        // consumed by fetch(), so the server cannot redirect the way it does for
+        // a single item -- the client owns this navigation. Re-rendering the
+        // form is what makes the end state identical to the single-item path
+        // rather than merely similar. Registered once, not per submission.
+        const bulkModal = document.getElementById('bulkLabelPrintingModal');
+        if (bulkModal) {
+            bulkModal.addEventListener('hidden.bs.modal', () => {
+                if (this.continueAfterBulk) {
+                    window.location.href = '/inventory/add';
+                }
+            });
+        }
+
         // Type and shape changes
         document.getElementById('item_type').addEventListener('change', () => {
             this.updateDimensionRequirements();
@@ -651,11 +663,11 @@ class InventoryAddForm {
         }
     }
     
-    async handleSubmit(event, continueAdding = false) {
+    async handleSubmit(event) {
         if (event) {
             event.preventDefault();
         }
-        
+
         // Validate form
         if (!this.form.checkValidity()) {
             event?.stopPropagation();
@@ -663,16 +675,26 @@ class InventoryAddForm {
             this.showValidationErrors();
             return;
         }
-        
-        // Set submit type for continue functionality
-        if (continueAdding) {
-            const submitTypeInput = document.createElement('input');
-            submitTypeInput.type = 'hidden';
-            submitTypeInput.name = 'submit_type';
-            submitTypeInput.value = 'continue';
-            this.form.appendChild(submitTypeInput);
+
+        // One submission per user action. The buttons are disabled below while a
+        // request is in flight, but Enter still reaches the form even when they
+        // are, so the flag is what actually guarantees it.
+        if (this.submitting) {
+            console.log('Submit: Ignoring submission, one is already in flight');
+            return;
         }
-        
+        this.submitting = true;
+
+        // Which control was pressed. Implicit submission (Enter) reports the
+        // form's first submit button, which is #submit-btn -- so Enter means
+        // Add, matching the previous behavior.
+        const continueAdding = event?.submitter?.value === 'continue';
+
+        // Carry the choice in the form's own hidden field rather than appending
+        // one per submission: form.submit() sends no submitter, and appended
+        // inputs outlive a bulk submission that never navigates away.
+        document.getElementById('submit-type').value = continueAdding ? 'continue' : 'add';
+
         // Show loading state
         const submitBtn = document.getElementById('submit-btn');
         const continueBtn = document.getElementById('submit-and-continue-btn');
@@ -706,6 +728,9 @@ class InventoryAddForm {
 
         if (quantity > 1) {
             console.log(`Submit: Using AJAX for bulk creation (quantity=${quantity})`);
+            // Set on every bulk submission, not only the continue ones, so a
+            // failed continue cannot leave the flag set for a later plain Add.
+            this.continueAfterBulk = continueAdding;
             // Use AJAX for bulk creation to handle JSON response
             try {
                 const formData = new FormData(this.form);
@@ -717,12 +742,6 @@ class InventoryAddForm {
 
                 const data = await response.json();
                 console.log(`Submit: Parsed JSON response:`, data);
-
-                // Reset button states
-                submitBtn.innerHTML = originalSubmitHTML;
-                continueBtn.innerHTML = originalContinueHTML;
-                submitBtn.disabled = false;
-                continueBtn.disabled = false;
 
                 if (data.success) {
                     console.log(`Submit: Success! Created ${data.count} items, showing modal...`);
@@ -743,15 +762,20 @@ class InventoryAddForm {
             } catch (error) {
                 console.error('Error during bulk creation:', error);
                 WorkshopInventory.utils.showToast('An error occurred. Please try again.', 'error');
-
-                // Reset button states
+            } finally {
+                // One restore for success, failure and error alike (FR-005).
+                // Two copies of this drifting apart is how a disabled button
+                // gets stranded.
                 submitBtn.innerHTML = originalSubmitHTML;
                 continueBtn.innerHTML = originalContinueHTML;
                 submitBtn.disabled = false;
                 continueBtn.disabled = false;
+                this.submitting = false;
             }
         } else {
-            // Submit form normally for single item creation
+            // Submit form normally for single item creation. The page is being
+            // replaced, so the loading state stays up and `submitting` stays set
+            // until the new document loads.
             this.form.submit();
         }
     }
@@ -818,31 +842,6 @@ class InventoryAddForm {
         data.active = formData.has('active');
         
         return data;
-    }
-    
-    clearFormForContinue() {
-        // Clear specific fields but keep others for carry-forward
-        const clearFields = [
-            'ja_id', 'length', 'width', 'thickness', 'wall_thickness', 
-            'weight', 'thread_size', 'notes', 'vendor_part_number',
-            'purchase_date', 'purchase_price'
-        ];
-        
-        clearFields.forEach(field => {
-            const input = document.getElementById(field);
-            if (input) {
-                input.value = '';
-            }
-        });
-        
-        // Clear validation states
-        this.form.classList.remove('was-validated');
-        this.form.querySelectorAll('.is-invalid').forEach(el => {
-            el.classList.remove('is-invalid');
-        });
-        
-        // Focus on JA ID for next item
-        document.getElementById('ja_id').focus();
     }
     
     showValidationErrors() {

--- a/app/templates/inventory/add.html
+++ b/app/templates/inventory/add.html
@@ -29,7 +29,12 @@
 
 <form id="add-item-form" class="needs-validation" novalidate method="POST">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-    
+    {# Which submit control was used. The single-item path submits with
+       form.submit(), which is programmatic and therefore carries no submitter,
+       so the buttons' own name/value never reach the server on that path. The
+       submit handler assigns this field instead. #}
+    <input type="hidden" name="submit_type" id="submit-type" value="add"/>
+
     <!-- Alert for messages -->
     <div id="form-alerts"></div>
     

--- a/app/templates/inventory/add.html
+++ b/app/templates/inventory/add.html
@@ -348,10 +348,14 @@
                 </div>
                 
                 <div class="btn-group">
-                    <button type="submit" name="submit_type" value="add" class="btn btn-primary" id="submit-btn">
+                    {# These carry `value` but deliberately not `name`: the
+                       handler reads event.submitter.value, and a name here
+                       would put a second `submit_type` in the payload on a
+                       native submission, competing with the hidden field. #}
+                    <button type="submit" value="add" class="btn btn-primary" id="submit-btn">
                         <i class="bi bi-check-circle"></i> Add Item
                     </button>
-                    <button type="submit" name="submit_type" value="continue" class="btn btn-success" id="submit-and-continue-btn">
+                    <button type="submit" value="continue" class="btn btn-success" id="submit-and-continue-btn">
                         <i class="bi bi-plus-circle"></i> Add & Continue
                     </button>
                     <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary">

--- a/specs/010-fix-bulk-add-continue/checklists/requirements.md
+++ b/specs/010-fix-bulk-add-continue/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Specification Quality Checklist: Fix Add & Continue With Quantity Greater Than One
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Iteration 1 flagged SC-006 for naming the project's test runner by command. Reworded to a
+  technology-agnostic outcome ("all existing automated checks continue to pass"); the runner
+  itself is a governance constraint recorded in the constitution, not a success criterion.
+- Iteration 1 flagged the absence of a stated regression boundary. FR-011 was confirmed to cover
+  it: the three working combinations (Add/quantity 1, Add & Continue/quantity 1, Add/quantity > 1)
+  are named explicitly as must-not-change.
+- One open decision was raised with the user and resolved rather than left as a
+  [NEEDS CLARIFICATION] marker: what **Add & Continue** should do *after* a successful bulk
+  creation. Answer given 2026-08-10 — reset the form for the next entry once the bulk
+  label-printing dialog is dismissed, rather than leaving it filled or disabling the button for
+  quantities above 1. Recorded as User Story 2 and FR-006/FR-007.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/010-fix-bulk-add-continue/contracts/add-item-submission.md
+++ b/specs/010-fix-bulk-add-continue/contracts/add-item-submission.md
@@ -1,0 +1,85 @@
+# Contract: `POST /inventory/add`
+
+**Status for this feature: unchanged.** This document records the existing contract so the client
+change can be checked against it, and so the one genuinely surprising property — the response type
+depends on a *request field* — is written down somewhere. No field is added, removed, or
+reinterpreted by feature 010.
+
+Handler: `inventory_add()`, `app/main/routes.py:550`.
+
+## Request
+
+`Content-Type: application/x-www-form-urlencoded`, submitted by `#add-item-form`
+(`app/templates/inventory/add.html:30`).
+
+### Fields that govern control flow
+
+| Field | Required | Values | Meaning |
+|-------|----------|--------|---------|
+| `quantity_to_create` | no (defaults to `"1"`) | integer 1–100 | Selects the response type. `1` → redirect; `> 1` → JSON. Outside the range → 400. |
+| `submit_type` | no | `add` \| `continue` | Where to send the user after a **single-item** success. **Consulted only when `quantity_to_create == 1`** (`routes.py:601`); the bulk branch returns at `routes.py:577` before reading it. Absent or any other value is treated as `add`. |
+
+`submit_type` reaches the server through a hidden field rather than the pressed button's
+`name`/`value`, because the quantity-1 path submits via `form.submit()`, which is programmatic and
+carries no submitter. Feature 010 changes that hidden field from one created per submission to one
+declared in the template — the wire format is identical.
+
+### Item fields
+
+Required: `ja_id` (`JA######`), `item_type`, `shape`, `material`, `location`. `material` must
+match the taxonomy case-insensitively.
+
+Optional: `sub_location`, `notes`, `vendor`, `vendor_part_number`, `purchase_location`,
+`purchase_date`, `purchase_price`, `length`, `width`, `thickness`, `wall_thickness`, `weight`,
+`thread_series`, `thread_handedness`, `thread_size`, `active`, `precision`.
+
+Also carried: `csrf_token` (a hidden field inside the form, so it rides along in the `FormData`
+built for the AJAX path without special handling).
+
+For `quantity_to_create > 1`, the submitted `ja_id` acts as a **floor**, not as the literal first
+ID: the server allocates from `max(get_max_ja_id_number() + 1, int(ja_id[2:]))` and assigns
+sequentially (`routes.py:314-329`).
+
+## Responses
+
+### `quantity_to_create == 1` — redirect
+
+| Outcome | Status | Location | Flash |
+|---------|--------|----------|-------|
+| Success, `submit_type == "continue"` | 302 | `/inventory/add` | `Item added successfully!` |
+| Success, otherwise | 302 | `/inventory` | `Item added successfully!` |
+| Validation failure | 400 | — | JSON body `{"success": false, "error": "..."}` |
+| Persistence failure | 302 | `/inventory/add` | `Failed to add item. Please try again.` |
+
+### `quantity_to_create > 1` — JSON
+
+| Outcome | Status | Body |
+|---------|--------|------|
+| All created | 200 | `{"success": true, "count": N, "ja_ids": [...], "message": "Successfully created N items: JA000101 - JA000106"}` |
+| Some created | 500 | `{"success": false, "count": M, "ja_ids": [...], "error": "Created M of N items. Some items failed."}` |
+| None created | 500 | `{"success": false, "error": "Failed to create any items"}` |
+| Validation failure | 400 | `{"success": false, "error": "..."}` |
+
+Note the partial case returns **500 with a populated `ja_ids`**. Callers must read `ja_ids`
+even on a non-2xx response; treating any error status as "nothing happened" would understate what
+was recorded. This is what FR-009's "the count stated matches the inventory" depends on.
+
+## Consumer obligations (what feature 010 must honor)
+
+1. **One request per user action.** The contract is not idempotent — it has no request key and no
+   deduplication. Two identical submissions mean two batches, or a JA-ID collision, depending on
+   interleaving. Safety lives entirely on the client. This is the obligation the current code
+   breaks and FR-001 restores.
+2. **Read the response type from the quantity you sent.** A client that sends
+   `quantity_to_create > 1` and expects a redirect will hang; one that sends `1` and calls
+   `response.json()` will get the redirect target's HTML.
+3. **`submit_type` is inert above quantity 1.** A client wanting continue-like behavior after a
+   bulk creation must implement it itself. Feature 010 does, via navigation after the label dialog
+   closes (research.md D4).
+
+## Related: `POST /api/inventory/items`
+
+`app/main/routes.py:470` exposes the same `_process_item_creation` to JSON callers, allocating the
+JA ID server-side and mapping status to 200/207/400/500. Used by `app/api_client.py` and covered by
+`tests/e2e/test_api_client.py`. **Out of scope** — it does not go through the form's submit
+controls and does not exhibit the defect.

--- a/specs/010-fix-bulk-add-continue/data-model.md
+++ b/specs/010-fix-bulk-add-continue/data-model.md
@@ -1,0 +1,102 @@
+# Phase 1 Data Model: Fix Add & Continue With Quantity Greater Than One
+
+## Persistent model: unchanged
+
+**No entity, column, index, constraint, or relationship changes.** No Alembic revision is created,
+and Constitution V's migration requirements are not engaged.
+
+The two entities the spec names already exist and are not modified:
+
+| Spec entity | Where it lives | Change |
+|-------------|----------------|--------|
+| **Inventory item** | `Item` (`app/models.py`) ↔ `InventoryItem` (`app/database.py`) | None. Bulk creation already produces N ordinary items differing only in `ja_id`. |
+| **Add submission** | Not persisted. It is one HTTP request built from the form. | None to its shape; see the contract in [contracts/add-item-submission.md](./contracts/add-item-submission.md). |
+
+The defect is that one **Add submission** was being constructed twice from a single user action.
+That is a client-side lifecycle problem, not a data-shape problem — which is why this file is
+short.
+
+## Invariant this feature restores
+
+Constitution VI requires exactly one active row per JA ID and consistent item history. Bulk
+creation with **Add & Continue** could violate the *intent* of that invariant in a way the schema
+cannot catch: each of the 2N rows is individually well-formed and uniquely keyed, so the database
+is internally consistent while the inventory is wrong. Nothing in the data model can detect
+"the user asked for 6 and the system recorded 12" — only the count assertion in the new e2e
+coverage can.
+
+Stated as the property under test:
+
+> For one press of a submit control on the Add Item form with **Quantity to Create** = *N*,
+> the number of `InventoryItem` rows created is exactly *N*.
+
+## Client-side state (the part that does change)
+
+`InventoryAdd` (`app/static/js/inventory-add.js`) gains and loses state as follows. This is
+in-memory browser state within a single page load; none of it is persisted server-side.
+
+| Field | Status | Purpose |
+|-------|--------|---------|
+| `submitting` | **new** — boolean, default `false` | Re-entrancy guard (D2). Set after `preventDefault()`, cleared in `finally`. Prevents a second submission from a repeated press or an Enter keypress while the first is in flight. |
+| `continueAfterBulk` | **new** — boolean, default `false` | Records that the in-flight bulk submission came from **Add & Continue**, so the `hidden.bs.modal` handler knows whether to navigate (D4). Set from `event.submitter` at submit time. |
+| `createdJaIds` | existing | JA IDs returned by a bulk creation; drives the label-printing dialog. Unchanged. |
+| `bulkCreationCount` | existing | Count returned by a bulk creation. Unchanged. |
+| `lastItemData` | existing | Carry-forward values, mirrored into `sessionStorage` under `workshop_inventory_last_item`. Unchanged — it already survives a page load, which is what makes D4's navigation safe for FR-008. |
+
+### Removed
+
+- The per-submission `<input type="hidden" name="submit_type">` created by
+  `document.createElement` is replaced by a static field in the template (D3). Beyond being
+  clearer, this removes a latent defect: a failed bulk submission does not navigate away, so its
+  appended input survived and a later press appended a second one. `request.form.get('submit_type')`
+  returns the *first* value, so a subsequent plain **Add** would have been read as a `continue`.
+- `clearFormForContinue()` — dead code, called from nowhere in `app/` or `tests/` (D7).
+
+## State transitions
+
+One press of a submit control on the Add Item form:
+
+```
+                        ┌─────────────────────────────────────────┐
+                        │ idle  (submitting = false)              │
+                        └────────────────┬────────────────────────┘
+                                         │ submit event
+                                         │ (from either button, or Enter)
+                                         ▼
+                         ┌───────────────────────────────┐
+      invalid form ◄─────┤ preventDefault()              │
+      (report, no        │ guard: submitting? → return   │
+       request sent,     │ checkValidity()               │
+       FR-010)           │ submitting = true             │
+                         │ submit_type ← submitter value │
+                         │ stash carry-forward data      │
+                         └───────────┬───────────────────┘
+                                     │
+                  quantity == 1 ─────┴───── quantity > 1
+                         │                        │
+                         ▼                        ▼
+              form.submit()              ONE fetch POST
+              (native, navigates)        (buttons disabled)
+                         │                        │
+                         ▼                        ▼
+              server redirect            JSON response
+              /inventory/add             │
+              (continue) or              ├─ ok      → toast + label dialog
+              /inventory (add)           ├─ partial → count message (FR-009)
+                                         └─ error   → error message
+                                                    │
+                                    buttons restored in `finally` (FR-005)
+                                                    │
+                                         dialog dismissed
+                                                    │
+                        continueAfterBulk ──────────┴────────── else
+                                │                                 │
+                                ▼                                 ▼
+                    navigate to /inventory/add           stay on page, form
+                    (FR-006, matches the                  intact (FR-007 — the
+                     quantity-1 continue path)            two buttons stay
+                                                          distinguishable)
+```
+
+The property that makes this correct is that there is exactly **one** arrow out of `idle`. Today
+there are two, and above quantity 1 both fire.

--- a/specs/010-fix-bulk-add-continue/plan.md
+++ b/specs/010-fix-bulk-add-continue/plan.md
@@ -1,0 +1,145 @@
+# Implementation Plan: Fix Add & Continue With Quantity Greater Than One
+
+**Branch**: `issues/52` (spec directory `010-fix-bulk-add-continue`) | **Date**: 2026-08-10 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/010-fix-bulk-add-continue/spec.md`
+
+## Summary
+
+The Add Item form submits twice for one press of **Add & Continue**. The button is
+`type="submit"` inside the form *and* carries a click listener that calls
+`handleSubmit(null, true)` — with a null event, so nothing calls `preventDefault()`. The click
+handler runs, then the click's default action submits the form, firing the `submit` listener and
+running the same handler a second time. At quantity 1 the duplication is invisible and
+load-bearing. At quantity > 1 both passes take the `await fetch(...)` branch, so two concurrent
+bulk creations race — they either collide on JA IDs (error beside the success dialog) or
+serialize and record twice the requested items.
+
+The fix collapses the two entry points into one: delete the click listener, derive which button
+was pressed from `event.submitter` on the single `submit` listener, and carry that through a
+persistent hidden field instead of an appended one. A re-entrancy guard covers repeated presses
+and Enter-key submission. Finally, the bulk path learns to honor "continue": when the bulk
+label-printing dialog closes after a continue submission, the page navigates back to the Add
+form, which is exactly what the single-item path already does via a server redirect.
+
+This is entirely client-side. No route, service, storage, schema, or migration change is needed
+or made.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (unchanged by this work); browser JavaScript (ES2017+, no build
+step)
+
+**Primary Dependencies**: Flask 3.1.x, Jinja2 templates, Bootstrap 5.3.2 — all existing. No new
+dependency.
+
+**Storage**: MariaDB via the existing `Storage`/`InventoryService` layers. **Untouched** — no
+schema change, no Alembic revision.
+
+**Testing**: pytest via `nox` sessions (`tests`, `e2e`). New coverage is end-to-end
+(Playwright), because the defect lives in browser event wiring that unit tests cannot reach.
+
+**Target Platform**: Server-rendered Flask app on a home LAN, single user, modern desktop Chrome.
+
+**Project Type**: Web application, server-rendered HTML with progressive-enhancement JavaScript.
+
+**Performance Goals**: None specific. The relevant budget is the e2e suite: it runs in ~8m13s and
+must not regress by more than the cost of the new scenarios (target: under 30s added).
+
+**Constraints**:
+- E2E tests must wait on observable state, never elapsed time (Constitution IV, `CLAUDE.md`).
+- `event.submitter` is required. Baseline across all current browsers; the app targets one
+  desktop Chrome on a LAN, and Playwright's bundled Chromium supports it.
+- The existing quantity-1 behavior of **Add**, **Add & Continue**, and the quantity > 1 behavior
+  of **Add** are all currently correct and covered — they are a regression surface, not a
+  target (FR-011).
+
+**Scale/Scope**: Three files changed (`app/static/js/inventory-add.js`,
+`app/templates/inventory/add.html`, `tests/e2e/test_bulk_creation.py`). Roughly 40 lines of
+production change, most of it deletion.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design — see the bottom of
+this section.*
+
+| Principle | Assessment |
+|-----------|------------|
+| **I. Simplicity First (NON-NEGOTIABLE)** | **PASS.** The change is net-negative in moving parts: one event listener deleted, one runtime DOM append replaced by a static field, one dead method removed. No submission framework, no request-deduplication layer, no queue. The one addition is a boolean re-entrancy flag. |
+| **II. Layered Architecture Boundaries** | **PASS (not engaged).** No route, service, or storage code changes. `app/main/routes.py` is read during planning and left alone. |
+| **III. Exact Numerics** | **PASS (not engaged).** No measurement parsing, formatting, or comparison is touched. |
+| **IV. Test Discipline Through Nox** | **PASS, with obligations.** New tests go in `tests/e2e/test_bulk_creation.py` under the existing `e2e` marker — no new marker to register. Every new wait is an `expect()` or a `wait_for_function` on page state; no `wait_for_timeout`, no `time.sleep`, no `networkidle`. Both `nox -s tests` and `nox -s e2e` must pass. The e2e session gets a 15-minute tool timeout. |
+| **V. MariaDB Is the Source of Truth** | **PASS (not engaged).** No schema change, therefore no Alembic revision and no `downgrade` to exercise. |
+| **VI. Item Lifecycle and History Invariants** | **PASS, and directly served.** This *is* an add-path integrity fix: today one user action can produce twice the intended active rows. FR-002 and FR-004 encode the invariant. Because the add path changes, the full e2e suite — including the active-status and history tests — must pass, not just the new file. |
+| **Operating Context / Threat Model** | **PASS.** CSRF stays as-is: the token is a hidden field inside the form, so it rides along in the `FormData` for the AJAX path unchanged. No hardening added. |
+| **Development Workflow / Screenshots** | **PASS with a documented judgment.** The change touches `app/templates/**` and `app/static/js/**`, which triggers `.github/workflows/screenshots.yml`. That workflow is an informational reminder — it stopped diffing in CI because font rasterization differs per machine (issue #77) — and it explicitly blocks nothing. This change alters a `type` attribute and adds a hidden input; neither renders. Screenshots are **not** regenerated, because regeneration would produce byte-different PNGs for zero visual difference. See [research.md](./research.md) D6. |
+
+**Note on a stale constitution claim** (no action taken here, flagged for the author): Constitution
+§ Development Workflow states "CI blocks merge on stale screenshots." `.github/workflows/screenshots.yml`
+says the opposite in its own header comment and in the body of the comment it posts. The workflow is
+the current truth. Correcting the constitution is a governance change outside this feature's scope.
+
+**Post-Phase-1 re-check**: No gate moved. Phase 1 produced no new entities, no contract change
+(the existing form and JSON contract are *documented*, not altered), and no new dependency. The
+design is smaller than the problem allowed for, which is the outcome Principle I asks for.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-fix-bulk-add-continue/
+├── spec.md                          # Feature specification
+├── plan.md                          # This file
+├── research.md                      # Phase 0: the seven decisions behind the fix
+├── data-model.md                    # Phase 1: why no persistent model changes; client state
+├── quickstart.md                    # Phase 1: how to reproduce, verify, and validate
+├── contracts/
+│   └── add-item-submission.md       # Phase 1: the POST /inventory/add contract as it stands
+├── checklists/
+│   └── requirements.md              # Spec quality checklist (from /speckit-specify)
+└── tasks.md                         # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+app/
+├── static/js/
+│   └── inventory-add.js             # CHANGED: single submit path, submitter detection,
+│                                    #          re-entrancy guard, continue-after-bulk,
+│                                    #          delete dead clearFormForContinue()
+├── templates/inventory/
+│   └── add.html                     # CHANGED: persistent hidden submit_type field
+└── main/
+    └── routes.py                    # UNCHANGED (read only; see research.md D5)
+
+tests/
+├── e2e/
+│   ├── test_bulk_creation.py        # CHANGED: submit-via-continue helper + 4 new tests
+│   ├── test_add_item.py             # UNCHANGED (regression surface for quantity-1 continue)
+│   ├── pages/add_item_page.py       # UNCHANGED (submit_and_continue keeps working)
+│   └── waits.py                     # UNCHANGED (wait_for_modal_shown/hidden already exist)
+└── unit/
+    └── test_routes.py               # UNCHANGED (regression surface; server behavior is stable)
+```
+
+**Structure Decision**: No new modules, directories, or layers. The defect is in existing browser
+event wiring, so the change lands in the two files that own that wiring plus the e2e file that
+already covers bulk creation through the form (`tests/e2e/test_bulk_creation.py`). Placing the new
+tests beside the existing bulk tests keeps the whole quantity-to-create behavior in one file and
+lets them reuse `BulkCreationPage`.
+
+## Correction to the record
+
+The `/speckit-specify` commit message (`c8b18a5`) and my summary of it stated that no e2e test
+drives the Add form with a quantity above 1. That is wrong: `tests/e2e/test_bulk_creation.py`
+has driven bulk creation through the form since the feature landed — eight tests, all clicking
+`#submit-btn`. The accurate gap, and the one FR-012 actually names, is narrower: no test uses
+**Add & Continue** with a quantity above 1, which is why the button-specific double-submission
+was never exercised. FR-012 in the spec is correct as written; only the commit narrative
+overstated it.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Table intentionally empty.

--- a/specs/010-fix-bulk-add-continue/quickstart.md
+++ b/specs/010-fix-bulk-add-continue/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: Validating the Add & Continue Bulk Fix
+
+How to see the defect, then prove it is gone. Everything here runs against the repository
+virtualenv (Constitution, Development Workflow).
+
+```bash
+source venv/bin/activate
+```
+
+`nox` sessions pin Python 3.13; if the system Python is newer, put pyenv's 3.13 on `PATH` first.
+
+## 1. Reproduce it by hand (before the fix)
+
+```bash
+python manage.py run      # or however the app is normally started locally
+```
+
+1. Open `/inventory/add` with the browser console visible.
+2. Fill the required fields: JA ID (pre-filled), Type, Shape, Material, Location, and whatever
+   dimensions the type/shape combination demands.
+3. Set **Quantity to Create** to `3`.
+4. Press **Add & Continue**.
+
+What you should see today, and what tells you which interleaving you hit:
+
+- The console logs `Submit: Submitting form with type: continue` **and**
+  `Submit: Submitting form with type: add` — two runs of the same handler from one press. This
+  line is the clearest single piece of evidence.
+- Then either:
+  - a red error toast (`Failed to create any items`) beside the green "3 Items Created
+    Successfully" dialog — the JA-ID collision; or
+  - no error at all, and `/inventory` now lists **six** new items — the silent doubling, which is
+    the outcome that matters.
+- Either way, dismissing the dialog leaves you on the same filled-in form. The "continue" never
+  happens.
+
+Compare against **Add** with the same quantity: one handler run, three items, no error.
+
+## 2. Automated validation
+
+```bash
+nox -s tests      # unit suite; must stay green and unchanged
+nox -s e2e        # allow a 15-minute tool timeout (Constitution IV)
+```
+
+Targeting just this feature's coverage while iterating:
+
+```bash
+nox -s e2e -- tests/e2e/test_bulk_creation.py
+```
+
+The full `e2e` run is not optional before merge. The add path is named in Constitution VI, so the
+active-status and history suites are part of this change's regression surface, not adjacent
+scenery. `nox -s e2e` selects `-m "e2e and not screenshot"`, so a run must leave the working tree
+clean — if `git status` is dirty afterwards, something ran that should not have.
+
+### The two assertions that carry the fix
+
+| Requirement | How it is checked | Before | After |
+|-------------|-------------------|--------|-------|
+| FR-001 — one request per action | `page.on("request", ...)` counts `POST /inventory/add` | 2 | 1 |
+| FR-002 — exactly N items | `len(InventoryService(live_server.storage).get_all_items())` delta | 3 or 6, nondeterministic | 3 |
+
+Confirm the request-count test genuinely bites before trusting it: stash the fix, run that test
+alone, and watch it fail with 2. A regression test that has never been seen red is not yet a
+regression test (SC-005).
+
+## 3. Manual acceptance walkthrough (after the fix)
+
+Each step maps to a requirement so a failure names what broke.
+
+| # | Action | Expected | Covers |
+|---|--------|----------|--------|
+| 1 | Quantity `6`, press **Add & Continue** | Console logs the handler once. Dialog: "6 Items Created Successfully". No error toast. | FR-001, FR-003 |
+| 2 | Dismiss the dialog | Lands on a fresh `/inventory/add`; JA ID auto-populated to the next free ID; per-item fields cleared | FR-006 |
+| 3 | Press **Carry Forward** | Success toast; type, shape, material, location, notes restored from the batch just created | FR-008 |
+| 4 | Check `/inventory` | Exactly 6 new items, sequential JA IDs, no duplicates | FR-002, FR-004 |
+| 5 | Quantity `3`, press **Add** (not continue) | 3 items, dialog appears; after dismissing, **still on the filled-in form** — no navigation | FR-007, FR-011 |
+| 6 | Quantity `1`, press **Add & Continue** | Unchanged from today: item created, returned to an empty Add form | FR-011 |
+| 7 | Quantity `1`, press **Add** | Unchanged from today: item created, redirected to the inventory list | FR-011 |
+| 8 | Clear a required field, quantity `4`, press **Add & Continue** | Validation reported; **nothing created** — verify the item count did not move | FR-010 |
+| 9 | Quantity `4`, press **Add & Continue** twice in quick succession | One batch of 4, not two. Buttons return to their normal labels and enabled state | FR-005, Edge Cases |
+| 10 | Quantity `4`, press Enter in a text field | Behaves as **Add** (Enter's submitter is the first submit button), one submission | Edge Cases |
+
+Step 5 is the one most easily lost: if **Add** starts navigating too, the two buttons have
+collapsed into one and FR-007 is broken even though every count is right.
+
+## 4. Before opening the PR
+
+- `nox -s tests` and `nox -s e2e` both green; working tree clean after the e2e run.
+- Screenshots **not** regenerated. The change is a `type` attribute, a hidden input, and event
+  wiring — none of it renders. `.github/workflows/screenshots.yml` will still post its reminder
+  comment on any PR touching `app/templates/**` or `app/static/js/**`; it blocks nothing and its
+  own text says regeneration is not reproducible. Say so in the PR description rather than
+  committing byte-different PNGs for zero visual change. (research.md D6.)
+- `nox -s lint` is advisory and is red at baseline on pre-existing E501 failures. New lines should
+  satisfy it; do not reformat surrounding code.

--- a/specs/010-fix-bulk-add-continue/research.md
+++ b/specs/010-fix-bulk-add-continue/research.md
@@ -3,6 +3,36 @@
 The spec deliberately says nothing about mechanism. This file records what the code actually does
 today and the seven decisions that follow from it.
 
+> **Correction from implementation (2026-08-10).** The double-submission root
+> cause described immediately below was **not reproducible**. Measured with
+> `page.on("request", ...)` against the unmodified code, one press of
+> **Add & Continue** at quantity 3 dispatched **one** POST, logged
+> `Submit: Submitting form with type: continue` exactly once, created exactly 3
+> items, raised no error toast and no page error. The reason is that
+> `handleSubmit` sets `continueBtn.disabled = true` synchronously, before its
+> first `await`; per the HTML specification a button's activation behavior
+> returns early if the element is disabled, and activation runs *after* the
+> click listeners. The click's default form submission was therefore suppressed
+> and the `submit` listener never fired. The table below is wrong on that point.
+>
+> What *was* reproducible, and what this feature actually fixes:
+>
+> - **The "continue" never happens** (spec consequence 3, US2/FR-006). After a
+>   bulk **Add & Continue**, dismissing the dialog left the filled-in form in
+>   place.
+> - **A continue submission contaminated the next plain Add** (D3 below). The
+>   appended `submit_type=continue` input survived a bulk submission, which
+>   never navigates away, and `form.submit()` sends no submitter — so the stale
+>   input was the only `submit_type` in a subsequent single-item payload and the
+>   server routed a plain **Add** back to the Add form.
+>
+> The decisions below (D1-D4, D7) are unchanged and were all implemented: they
+> remain correct, and D1 in particular removes a genuine fragility — the code
+> was relying on the disabled-button suppression, undocumented and one edit away
+> from breaking. But the issue-#52 "error" was not observed in this environment,
+> so no test in this feature reproduces it. See the implementation notes in
+> [tasks.md](./tasks.md).
+
 ## Root cause, established
 
 `app/templates/inventory/add.html:349` declares the continue button inside the form:

--- a/specs/010-fix-bulk-add-continue/research.md
+++ b/specs/010-fix-bulk-add-continue/research.md
@@ -1,0 +1,226 @@
+# Phase 0 Research: Fix Add & Continue With Quantity Greater Than One
+
+The spec deliberately says nothing about mechanism. This file records what the code actually does
+today and the seven decisions that follow from it.
+
+## Root cause, established
+
+`app/templates/inventory/add.html:349` declares the continue button inside the form:
+
+```html
+<button type="submit" name="submit_type" value="continue" id="submit-and-continue-btn">
+```
+
+`app/static/js/inventory-add.js:76-81` wires two independent entry points to the same handler:
+
+```js
+this.form.addEventListener('submit', (e) => this.handleSubmit(e));
+document.getElementById('submit-and-continue-btn').addEventListener('click', () => {
+    this.handleSubmit(null, true);          // event is null
+});
+```
+
+`handleSubmit` begins `if (event) { event.preventDefault(); }` (line 655). With `null` passed, the
+click's default action is never suppressed, so pressing **Add & Continue** runs `handleSubmit`
+**twice**: once from the click listener with `continueAdding = true`, then once from the `submit`
+listener with `continueAdding = false`.
+
+What each pass does depends on the quantity, checked at line 707:
+
+| Quantity | Pass 1 (click, `continue`) | Pass 2 (submit) | Result |
+|----------|---------------------------|-----------------|--------|
+| 1 | appends `submit_type=continue`, calls `form.submit()` **synchronously** | navigation already underway | Works. The duplication is invisible **and load-bearing** — pass 1 is what makes continue work at all. |
+| > 1 | `await fetch(...)` — POST #1 dispatched, handler yields | reaches the same branch, POST #2 dispatched | **Two concurrent bulk creations.** |
+
+Both POSTs enter `_process_item_creation` (`app/main/routes.py:222`), which computes its starting
+ID at line 314 as `service.get_max_ja_id_number() + 1`. There is no reservation between the read
+and the writes, so the outcome depends on interleaving:
+
+- **Collide** — both compute the same start, the loser fails every insert, the route returns 500
+  with `Failed to create any items`, and the browser shows an error toast *next to* pass 1's
+  success dialog. This is the error in issue #52.
+- **Serialize** — pass 2 reads the max after pass 1 commits and creates a second full batch. No
+  error at all, and the inventory silently gains 2N items. This is the worse outcome and the
+  reason the spec leads with count correctness rather than with the error message.
+
+Pressing plain **Add** does not reproduce it: `#submit-btn` has no click listener, so the `submit`
+listener fires once. That asymmetry is the whole defect.
+
+---
+
+## D1 — One submission per user action: derive the button from `event.submitter`
+
+**Decision**: Delete the click listener entirely. Keep both buttons as `type="submit"`. Read
+which one was pressed from `event.submitter` inside the single `submit` listener:
+
+```js
+this.form.addEventListener('submit', (e) => this.handleSubmit(e));
+// inside handleSubmit:
+const continueAdding = event?.submitter?.value === 'continue';
+```
+
+**Rationale**: One listener on one event cannot double-fire — the failure mode is removed
+structurally rather than patched. It also deletes code rather than adding it, which is what
+Principle I asks for. `event.submitter` is the platform's own answer to "which button submitted
+this form" and has been baseline in every major browser since 2021; the app targets one desktop
+Chrome and the test suite runs Playwright's bundled Chromium.
+
+Implicit submission (pressing Enter in a text field) sets `submitter` to the form's first submit
+button, which is `#submit-btn` — so Enter means **Add**, which is the sensible default and matches
+today's behavior.
+
+**Alternatives considered**:
+- *Pass the event through and `preventDefault()` in the click handler.* Fixes this instance but
+  leaves two listeners racing for one action, so the next person to touch either one re-opens it.
+- *Re-entrancy guard alone.* Insufficient on its own and subtly wrong: the `submit` listener would
+  have to `preventDefault()` **before** hitting the guard, otherwise the early return lets the
+  browser navigate natively and abort the in-flight `fetch`. Ordering that correctly is exactly
+  the kind of non-obvious code the constitution warns against. Kept as a *second* line of defense
+  (D2), not as the fix.
+- *`type="button"` on the continue button.* Works, and was the first candidate. Rejected in favor
+  of `event.submitter` because it leaves two handlers where one will do, and because a form whose
+  buttons are not submit buttons loses implicit-submission semantics for no gain.
+
+## D2 — Re-entrancy guard for repeated presses
+
+**Decision**: Add an instance flag, set after `preventDefault()` and cleared in a `finally`:
+
+```js
+if (this.submitting) return;
+this.submitting = true;
+try { ... } finally { this.submitting = false; }
+```
+
+**Rationale**: D1 removes the *structural* double-fire, but a user can still press a button twice
+before the first response lands. The buttons are disabled during flight (existing behavior at
+lines 684-685), and a disabled button cannot be clicked — but Enter-key submission still reaches
+the form even while its buttons are disabled. The spec calls for this explicitly under Edge Cases
+("repeated presses", "keyboard submission") and FR-005. Four lines.
+
+The `finally` also satisfies FR-005's "restored… success, failure, or error" more honestly than
+today's arrangement, which restores the buttons in the success branch and again in the `catch`
+branch — two copies of the same cleanup that can drift apart.
+
+**Alternatives considered**: *Debounce or throttle.* Rejected — timing-based, and this is a state
+question, not a rate question. Same reasoning the constitution applies to test waits.
+
+## D3 — Carry the submit type in a persistent hidden field
+
+**Decision**: Add `<input type="hidden" name="submit_type" id="submit-type" value="add">` to
+`add.html`, and set `.value` from `event.submitter` at submission time. Remove the runtime
+`document.createElement('input')` append at `inventory-add.js:669-673`.
+
+**Rationale**: The quantity-1 path submits with `this.form.submit()`, which is *programmatic* and
+therefore carries **no submitter** — so the button's own `name="submit_type" value="continue"` is
+never transmitted on that path. That is precisely why the current code appends a hidden input by
+hand. A field that always exists and whose value is assigned is more obvious than one conjured
+per submission, and it fixes a latent accumulation bug: today, a bulk submission that fails
+(which does not navigate away) leaves its appended input behind, and a subsequent press appends
+another. `request.form.get()` returns the first, so a later plain **Add** would be read as a
+`continue`.
+
+**Alternatives considered**:
+- *Skip `preventDefault()` for quantity 1 and let the native submission carry the submitter.*
+  Fewest lines, but the resulting handler reads as "sometimes we prevent the default and sometimes
+  we mysteriously do not." Rejected on readability.
+- *`form.requestSubmit(submitter)`.* Re-fires the `submit` event — infinite recursion.
+
+## D4 — Continue after a bulk creation: navigate when the dialog closes
+
+**Decision**: Listen for `hidden.bs.modal` on `#bulkLabelPrintingModal`. If the submission that
+opened it was a continue, `window.location.href = '/inventory/add'`.
+
+**Rationale**: This produces byte-for-byte the same end state as the single-item continue path,
+which is a server redirect to the same URL (`routes.py:607`) — a fresh server-rendered form with
+`autoPopulateJaId()` having fetched the next free JA ID. FR-006 asks for the state to *match* the
+single-item path, and re-rendering it is the only way to guarantee that rather than approximate it.
+
+Carry-forward (FR-008) needs nothing extra: `handleSubmit` already writes the submitted values to
+`sessionStorage` before submitting (lines 692-697) and `initializeCarryForwardData()` reads them
+back on load (line 620), which is how carry-forward already survives the single-item redirect.
+
+`hidden.bs.modal` is the right event because it fires after Bootstrap tears down the backdrop —
+the same reason `tests/e2e/waits.py:wait_for_modal_hidden` waits on the backdrop rather than the
+`show` class.
+
+**Alternatives considered**:
+- *Call the existing `clearFormForContinue()`.* Rejected, and see D7 — it is dead code that only
+  half-does the job: it blanks a fixed list of fields but never repopulates the JA ID, so the next
+  entry would start with an empty required field where the single-item path pre-fills it.
+- *Have the server redirect.* Impossible on this path — the bulk response is JSON consumed by
+  `fetch`; the browser does not navigate on it.
+- *Reset the form in place without navigating.* Would have to replicate page-load initialization
+  (JA ID allocation, material taxonomy state, photo manager) by hand. More code, more drift.
+
+## D5 — No server-side change
+
+**Decision**: `app/main/routes.py` is not modified.
+
+**Rationale**: With exactly one request per action (D1/D2), the existing sequential allocation at
+`routes.py:314-329` already yields distinct, non-colliding JA IDs — FR-004 holds. The bulk branch
+at `routes.py:577` returns JSON before it ever reads `submit_type`, so "continue" has no
+server-side meaning above quantity 1; under D4 the client owns that navigation, so it does not
+need one. Partial-failure reporting (FR-009) is already implemented at `routes.py:363-378` and is
+untouched.
+
+Adding an ID reservation, a uniqueness retry, or an idempotency key would be scale machinery for
+a problem this feature removes at its source, on a single-user LAN application whose spec puts
+cross-session concurrency out of scope. Principle I forbids it.
+
+**Alternatives considered**: *Make the server reject a second identical submission.* Rejected as
+speculative generality — it defends against a client that, after this change, does not exist.
+
+## D6 — Screenshots are not regenerated
+
+**Decision**: Do not run `nox -s screenshots`. State the reason in the PR.
+
+**Rationale**: The change is a `type` attribute, a hidden input, and JavaScript event wiring. None
+of it renders. `.github/workflows/screenshots.yml` is informational by design — its header records
+that CI-side diffing was removed because font rasterization differs between machines (issue #77),
+and the comment it posts says "Nothing here blocks the merge" and warns that regeneration is not
+reproducible. Regenerating would commit byte-different PNGs representing zero visual change, which
+is diff noise of exactly the kind the constitution's anti-reformatting rule exists to prevent.
+
+**Alternatives considered**: *Regenerate anyway to satisfy the letter of the constitution.*
+Rejected; the constitution's own text on this point ("CI blocks merge on stale screenshots") is
+stale relative to the workflow, and the plan flags that separately rather than acting on it.
+
+## D7 — Remove `clearFormForContinue()`
+
+**Decision**: Delete `inventory-add.js:823-846`.
+
+**Rationale**: It is dead — defined once, called nowhere (verified across `app/`). Leaving a
+function named for the exact behavior D4 implements, which does *not* implement it correctly,
+is a trap for whoever reads this file next looking for how continue works.
+
+## Test strategy
+
+**Where**: `tests/e2e/test_bulk_creation.py`. Bulk-through-the-form already lives there with a
+`BulkCreationPage` object; the new cases reuse it rather than starting a parallel page object.
+
+**The sharpest guard is a request count.** Attaching `page.on("request", ...)` and asserting
+exactly one `POST /inventory/add` fails today with 2 and passes after the fix. It tests FR-001
+directly rather than inferring it from a symptom, and it cannot be satisfied by accident.
+
+**Second guard: an absolute item count.** Reading `len(InventoryService(...).get_all_items())`
+before and after and asserting the delta equals the requested quantity catches the silent-doubling
+interleaving, which the request count would also catch but which deserves its own assertion
+because it is the outcome that corrupts the inventory (FR-002).
+
+**Waiting discipline** (`CLAUDE.md`, Constitution IV):
+
+| What is awaited | Signal | Why it is valid |
+|-----------------|--------|-----------------|
+| Bulk POST resolved | `wait_for_modal_shown(page, "bulkLabelPrintingModal")` | Pattern C. `showBulkLabelPrintingModal()` is called only after `await fetch(...)` resolves, so an open modal cannot predate a completed response. Already used by the existing bulk tests. |
+| Dialog dismissed | `wait_for_modal_hidden(...)` | Existing helper; waits for backdrop teardown, not the `show` class. |
+| Continue navigation landed | `expect(page).to_have_url(re.compile(r"/inventory/add$"))` then `expect(ja_id_field).not_to_have_value("")` | `expect` polls. The second wait is CLAUDE.md pattern G — `autoPopulateJaId()` writes the field *after* awaiting `/api/inventory/next-ja-id`, so the form is not actually ready until that write lands. |
+| No error was shown | Clear `#toast-container` before submitting, then assert absence *after* the modal is established | CLAUDE.md's negative-assertion rule: "the toast is absent" passes trivially against a page that has not rendered. The modal being open is what establishes the region. |
+
+**Regression surface to re-run, not just the new file**: `test_add_item.py::test_add_and_continue_carry_forward_workflow`
+(quantity-1 continue), the eight existing tests in `test_bulk_creation.py` (quantity > 1 via
+**Add**), and — because Principle VI names the add path — the active-status and history suites.
+In practice: the full `nox -s e2e`.
+
+**No new unit tests.** The change is browser event wiring and a template attribute; there is no
+Python behavior to assert. `tests/unit/test_routes.py:123` already covers the server's
+`submit_type` handling and must keep passing unchanged, which is the point.

--- a/specs/010-fix-bulk-add-continue/spec.md
+++ b/specs/010-fix-bulk-add-continue/spec.md
@@ -1,0 +1,222 @@
+# Feature Specification: Fix Add & Continue With Quantity Greater Than One
+
+**Feature Branch**: `010-fix-bulk-add-continue`
+
+**Created**: 2026-08-10
+
+**Status**: Draft
+
+**Input**: GitHub issue #52 — "11. Error on Add & Continue with quantity": *Browser throws an error when using Add & Continue button if Quantity is greater than 1.*
+
+## Problem Statement
+
+On the Add Item form, the **Quantity to Create** field lets the user create several identical
+items in one submission, each receiving its own sequential JA ID. The form offers two submit
+actions: **Add** (create, then go to the inventory list) and **Add & Continue** (create, then
+return to an empty Add form so the next item can be entered without navigating).
+
+The two features do not work together. With **Quantity to Create** set to 1, **Add & Continue**
+works. With **Quantity to Create** set to 2 or more, pressing **Add & Continue** reports an error
+to the user, and the number of items actually recorded in the inventory does not reliably match
+the quantity requested — the same submission is sent to the server twice, and the two attempts
+race each other. Depending on which attempt lands first, the user sees either an error message
+alongside a success dialog, or no error at all while twice the requested number of items is
+created. Pressing **Add** with the same quantity does not produce the error.
+
+The consequences, in order of severity:
+
+1. **Inventory can silently gain items the user never asked for.** A request for 3 items can
+   record 6. The user has no indication this happened, and physical stock will not match.
+2. **An error is shown for an operation that partly succeeded.** The user cannot tell from the
+   screen whether the items were created, so the safe response is to go check the inventory list
+   by hand.
+3. **The "continue" part of Add & Continue never happens.** Even when creation succeeds, the form
+   is not reset for the next entry, so the button does not do what its label says.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Bulk create without spurious errors or extra items (Priority: P1)
+
+The user is entering a box of identical stock — say six lengths of the same steel bar. They fill
+in the Add Item form once, set **Quantity to Create** to 6, and press **Add & Continue**. Six
+items are created, each with its own JA ID, and no error is shown.
+
+**Why this priority**: This is the reported defect, and it is the one that can corrupt the
+inventory. Fixing it alone restores a trustworthy result even if nothing else changes.
+
+**Independent Test**: Fill the Add form, set quantity above 1, press **Add & Continue**, and check
+that the inventory contains exactly the requested number of new items and that no error message
+was displayed. Fully testable on its own; delivers a correct inventory.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid, complete Add Item form with **Quantity to Create** set to 6, **When** the
+   user presses **Add & Continue**, **Then** exactly 6 new items are recorded, each with a
+   distinct sequential JA ID, and no error message is shown.
+2. **Given** the same submission, **When** the user afterwards views the inventory list, **Then**
+   it contains exactly 6 new items — not 12, and not a partial subset.
+3. **Given** a valid form with **Quantity to Create** set to 6, **When** the user presses
+   **Add & Continue**, **Then** the server receives exactly one creation request for that
+   submission.
+4. **Given** a valid form with **Quantity to Create** set to 1, **When** the user presses
+   **Add & Continue**, **Then** the existing single-item behavior is unchanged: the item is
+   created and the user is returned to an empty Add form.
+5. **Given** a valid form with **Quantity to Create** set to 6, **When** the user presses **Add**
+   (not **Add & Continue**), **Then** the existing bulk behavior is unchanged: 6 items are
+   created and the bulk label-printing dialog is offered.
+
+---
+
+### User Story 2 - Continue into the next entry after a bulk create (Priority: P2)
+
+Having created six identical bars, the user wants to enter the next batch straight away. After the
+bulk creation completes and the label-printing dialog is dismissed, the Add form is ready for the
+next entry, exactly as it would be after a single-item **Add & Continue**.
+
+**Why this priority**: This is what the button's label promises. It is a usability gap rather than
+a correctness one, so it ranks below Story 1 — but without it, **Add & Continue** and **Add**
+behave identically for quantity above 1, which is its own kind of wrong.
+
+**Independent Test**: Complete a bulk **Add & Continue**, dismiss the label dialog, and confirm the
+form is in the same ready-for-next-entry state that a single-item **Add & Continue** leaves behind.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bulk **Add & Continue** that created its items successfully, **When** the user
+   dismisses the label-printing dialog, **Then** the Add form is presented ready for a new entry
+   with the per-item fields cleared.
+2. **Given** the form after a bulk **Add & Continue**, **When** the user presses **Carry Forward**,
+   **Then** the values from the batch just created are restored, matching the behavior after a
+   single-item **Add & Continue**.
+3. **Given** a bulk **Add** (not **Add & Continue**), **When** the creation succeeds, **Then** the
+   user is **not** returned to a cleared Add form — the two buttons remain distinguishable.
+
+---
+
+### User Story 3 - Honest reporting when a bulk create does not fully succeed (Priority: P3)
+
+If some of the requested items genuinely cannot be created, the user is told how many were created
+and how many were not, and the message is not confusable with the spurious error this feature
+removes.
+
+**Why this priority**: Partial-failure reporting already exists; this story only requires that it
+survives the fix and is not masked. It has no value without Story 1 being correct first.
+
+**Independent Test**: Force a bulk creation to fail partway and confirm the reported counts match
+what was actually recorded.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bulk creation in which some items cannot be created, **When** the submission
+   completes, **Then** the user is told how many items were created and that the rest failed, and
+   the count stated matches the inventory.
+2. **Given** a bulk creation in which no items can be created, **When** the submission completes,
+   **Then** the user is told the creation failed and the inventory is unchanged.
+
+---
+
+### Edge Cases
+
+- **Repeated presses.** If the user presses **Add & Continue** twice in quick succession, or
+  presses **Add** and **Add & Continue** in quick succession, only one batch is created. The
+  submit controls are unavailable while a submission is in flight and are restored when it
+  settles, whether it succeeded or failed.
+- **Keyboard submission.** Pressing Enter to submit the form produces the same single, correct
+  submission as clicking a button, for both quantity 1 and quantity above 1.
+- **Invalid form with quantity above 1.** If a required field is missing, pressing
+  **Add & Continue** reports the validation problem and creates nothing — no partial batch, no
+  request sent.
+- **Quantity at the boundaries.** Quantity 1 takes the single-item path. Quantity 2 takes the bulk
+  path. Quantity at the maximum allowed (100) behaves as any other bulk value. A quantity outside
+  the permitted range is rejected with a message and creates nothing.
+- **Server failure mid-batch.** If the request fails outright (server error, connection dropped),
+  the submit controls are restored and the user is told the creation did not complete, so they can
+  check the list rather than blindly retrying.
+- **Bulk creation with photos attached.** Photos attached on the Add form behave the same for a
+  bulk **Add & Continue** as for a bulk **Add**.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Pressing **Add & Continue** on the Add Item form MUST result in exactly one creation
+  request being sent to the server, for every value of **Quantity to Create**.
+- **FR-002**: A bulk creation initiated with **Add & Continue** MUST create exactly the requested
+  number of items — never more.
+- **FR-003**: A bulk creation initiated with **Add & Continue** that succeeds MUST NOT display any
+  error message.
+- **FR-004**: Each item created in a bulk submission MUST receive a distinct JA ID, and no JA ID
+  MUST collide with an item that already exists.
+- **FR-005**: While a creation request is in flight, both submit controls MUST be unavailable, and
+  they MUST be restored to their normal labels and enabled state when the request settles —
+  success, failure, or error.
+- **FR-006**: After a successful bulk creation initiated with **Add & Continue**, once the
+  label-printing dialog is dismissed, the system MUST present the Add form ready for the next
+  entry, with per-item fields cleared, matching the state left by a single-item
+  **Add & Continue**.
+- **FR-007**: After a successful bulk creation initiated with **Add** (not **Add & Continue**), the
+  system MUST NOT clear the form for a further entry — the two controls MUST remain behaviorally
+  distinct.
+- **FR-008**: The values of the just-submitted batch MUST remain available to **Carry Forward**
+  after a bulk **Add & Continue**, as they are after a single-item **Add & Continue**.
+- **FR-009**: When a bulk creation partly succeeds, the message shown MUST state how many items
+  were created, and that number MUST match what was recorded.
+- **FR-010**: When a submission fails validation before anything is created, the system MUST report
+  the validation problem and MUST NOT create any items.
+- **FR-011**: Existing behavior for **Add** with quantity 1, **Add & Continue** with quantity 1,
+  and **Add** with quantity above 1 MUST be unchanged by this work.
+- **FR-012**: Automated end-to-end coverage MUST exercise **Add & Continue** with a quantity above
+  1 through the Add Item form, asserting both the count of items created and the absence of an
+  error — the combination has no such coverage today, which is why the defect reached the user.
+
+### Key Entities
+
+- **Inventory item**: an individual piece of stock identified by its JA ID. A bulk submission
+  creates several of these from one set of form values, differing only in JA ID.
+- **Add submission**: one user action on the Add Item form, carrying the form values, a quantity,
+  and which of the two submit controls was used. One user action must correspond to exactly one
+  submission.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For every quantity from 1 to 10, pressing **Add & Continue** creates exactly that
+  number of items — 100% agreement between requested and recorded counts, with no over-creation.
+- **SC-002**: A successful bulk **Add & Continue** displays zero error messages.
+- **SC-003**: A user entering three consecutive batches of identical stock can do so without
+  leaving the Add form and without manually verifying the inventory list between batches.
+- **SC-004**: Pressing a submit control repeatedly during a submission produces no more items than
+  a single press.
+- **SC-005**: The automated test suite catches the defect if it is reintroduced — verified by
+  confirming the new coverage fails against today's behavior and passes after the fix.
+- **SC-006**: All existing automated checks continue to pass, and total end-to-end suite runtime
+  grows by no more than the cost of the one new scenario (under 30 seconds).
+
+## Assumptions
+
+- The reported "error" is the user-visible failure message produced by the duplicated submission;
+  no separate, unrelated fault is being reported in issue #52. The issue text gives no error
+  string, so this specification treats any error surfaced by a successful bulk **Add & Continue**
+  as in scope.
+- The existing bulk label-printing dialog remains part of the bulk flow; this work changes when the
+  form is reset relative to that dialog, not whether the dialog appears.
+- The permitted quantity range (1–100) is unchanged.
+- The **Carry Forward** feature and its persistence across page loads are unchanged in behavior;
+  they need only continue to work after a bulk **Add & Continue**.
+- No change to the item data model, the database schema, or the JA-ID format is required.
+- The standalone API client's bulk-creation path is out of scope: it does not use the form's submit
+  controls and does not exhibit the defect.
+- Per the project constitution, the fix is sized to the defect — no new submission framework,
+  queueing, or request-deduplication infrastructure beyond what removing the duplicate submission
+  requires.
+
+## Out of Scope
+
+- Redesigning the Add Item form or the bulk-creation user experience.
+- Changing how JA IDs are allocated for bulk creation, beyond what is needed to guarantee
+  FR-004 for a single submission.
+- Concurrency between two different browser sessions submitting at the same time. This is a
+  single-user application on a LAN; the duplication addressed here originates from one user action
+  in one page.
+- The bulk *duplication* feature on the item view (a separate path with its own quantity field).

--- a/specs/010-fix-bulk-add-continue/tasks.md
+++ b/specs/010-fix-bulk-add-continue/tasks.md
@@ -50,8 +50,8 @@ production change at all and can be done any time.
 
 **Purpose**: Make later failures attributable to this change rather than to the environment.
 
-- [ ] T001 Activate the repository virtualenv (`venv/`) and confirm the `nox` sessions resolve Python 3.13 — put pyenv's 3.13 ahead of the system Python on `PATH` if `nox -l` reports a missing interpreter
-- [ ] T002 Record the green baseline: run `nox -s e2e -- tests/e2e/test_bulk_creation.py tests/e2e/test_add_item.py` and confirm all pass **before** any edit, so a later failure in these files is known to be caused by this work
+- [X] T001 Activate the repository virtualenv (`venv/`) and confirm the `nox` sessions resolve Python 3.13 — put pyenv's 3.13 ahead of the system Python on `PATH` if `nox -l` reports a missing interpreter
+- [X] T002 Record the green baseline: run `nox -s e2e -- tests/e2e/test_bulk_creation.py tests/e2e/test_add_item.py` and confirm all pass **before** any edit, so a later failure in these files is known to be caused by this work
 
 **Checkpoint**: Toolchain resolves and the files this feature touches are green.
 
@@ -64,8 +64,8 @@ without it.
 
 **⚠️ Both tasks edit `tests/e2e/test_bulk_creation.py` — strictly sequential, no `[P]`.**
 
-- [ ] T003 Add `submit_and_continue()` to the `BulkCreationPage` class in `tests/e2e/test_bulk_creation.py`, mirroring the existing `submit_form()` (clear `#toast-container`, set `window.__awaitingSubmit`, click `#submit-and-continue-btn`, then `wait_for_function` settling on document replacement, a toast, or `#bulkLabelPrintingModal.show`) — reuse the existing helper's body rather than inventing a second waiting strategy
-- [ ] T004 Add a module-level `count_add_posts(page)` helper in `tests/e2e/test_bulk_creation.py` that attaches `page.on("request", ...)` and returns a mutable counter of `POST` requests whose URL ends in `/inventory/add`; document at the call site that this counts requests *dispatched*, which is what FR-001 constrains
+- [X] T003 Add `submit_and_continue()` to the `BulkCreationPage` class in `tests/e2e/test_bulk_creation.py`, mirroring the existing `submit_form()` (clear `#toast-container`, set `window.__awaitingSubmit`, click `#submit-and-continue-btn`, then `wait_for_function` settling on document replacement, a toast, or `#bulkLabelPrintingModal.show`) — reuse the existing helper's body rather than inventing a second waiting strategy
+- [X] T004 Add a module-level `count_add_posts(page)` helper in `tests/e2e/test_bulk_creation.py` that attaches `page.on("request", ...)` and returns a mutable counter of `POST` requests whose URL ends in `/inventory/add`; document at the call site that this counts requests *dispatched*, which is what FR-001 constrains
 
 **Checkpoint**: A test can drive **Add & Continue** at any quantity and count the resulting POSTs.
 
@@ -86,18 +86,18 @@ that the inventory gained exactly the requested number of items and that no erro
 > error toast (`Failed to create any items`), depending on interleaving. Both outcomes are the
 > bug; if T006 passes on the first run, run it again before believing it.
 
-- [ ] T005 [US1] Add `test_bulk_add_and_continue_sends_one_request` to `tests/e2e/test_bulk_creation.py`: fill a valid item, set quantity 3, submit via `submit_and_continue()`, wait with `wait_for_modal_shown(page, "bulkLabelPrintingModal")`, then assert the T004 counter equals exactly 1
-- [ ] T006 [US1] Add `test_bulk_add_and_continue_creates_exact_count` to `tests/e2e/test_bulk_creation.py`: read `len(InventoryService(live_server.storage).get_all_items())` before submitting, set quantity 3, submit via `submit_and_continue()`, wait for the modal, then assert the count delta is exactly 3 and that `#toast-container .toast-body` contains no error text — establish the modal with `wait_for_modal_shown` *before* the negative toast assertion, per the negative-assertion rule in `CLAUDE.md`
+- [X] T005 [US1] Add `test_bulk_add_and_continue_sends_one_request` to `tests/e2e/test_bulk_creation.py`: fill a valid item, set quantity 3, submit via `submit_and_continue()`, wait with `wait_for_modal_shown(page, "bulkLabelPrintingModal")`, then assert the T004 counter equals exactly 1
+- [X] T006 [US1] Add `test_bulk_add_and_continue_creates_exact_count` to `tests/e2e/test_bulk_creation.py`: read `len(InventoryService(live_server.storage).get_all_items())` before submitting, set quantity 3, submit via `submit_and_continue()`, wait for the modal, then assert the count delta is exactly 3 and that `#toast-container .toast-body` contains no error text — establish the modal with `wait_for_modal_shown` *before* the negative toast assertion, per the negative-assertion rule in `CLAUDE.md`
 
 ### Implementation for User Story 1
 
-- [ ] T007 [US1] In `app/templates/inventory/add.html`, add `<input type="hidden" name="submit_type" id="submit-type" value="add">` inside `#add-item-form` (near the existing `csrf_token` field at line 31); leave both submit buttons' `name`/`value` attributes in place so `event.submitter.value` keeps working
-- [ ] T008 [US1] In `app/static/js/inventory-add.js`, collapse the two submission entry points into one: delete the `#submit-and-continue-btn` click listener (lines 79-81), change `handleSubmit(event, continueAdding = false)` to derive `const continueAdding = event?.submitter?.value === 'continue'`, delete the `document.createElement('input')` block (lines 668-674), and instead assign `document.getElementById('submit-type').value = continueAdding ? 'continue' : 'add'` — see research.md D1 and D3
-- [ ] T009 [US1] In `app/static/js/inventory-add.js` `handleSubmit()`, add the re-entrancy guard: `if (this.submitting) return;` immediately after `event.preventDefault()` and the validity check, set `this.submitting = true`, and move the button-state restoration into a single `finally` block replacing the duplicated restores in the success and `catch` branches (research.md D2, FR-005)
+- [X] T007 [US1] In `app/templates/inventory/add.html`, add `<input type="hidden" name="submit_type" id="submit-type" value="add">` inside `#add-item-form` (near the existing `csrf_token` field at line 31); leave both submit buttons' `name`/`value` attributes in place so `event.submitter.value` keeps working
+- [X] T008 [US1] In `app/static/js/inventory-add.js`, collapse the two submission entry points into one: delete the `#submit-and-continue-btn` click listener (lines 79-81), change `handleSubmit(event, continueAdding = false)` to derive `const continueAdding = event?.submitter?.value === 'continue'`, delete the `document.createElement('input')` block (lines 668-674), and instead assign `document.getElementById('submit-type').value = continueAdding ? 'continue' : 'add'` — see research.md D1 and D3
+- [X] T009 [US1] In `app/static/js/inventory-add.js` `handleSubmit()`, add the re-entrancy guard: `if (this.submitting) return;` immediately after `event.preventDefault()` and the validity check, set `this.submitting = true`, and move the button-state restoration into a single `finally` block replacing the duplicated restores in the success and `catch` branches (research.md D2, FR-005)
 
 ### Verification for User Story 1
 
-- [ ] T010 [US1] Confirm T005 and T006 now pass, then run `nox -s e2e -- tests/e2e/test_bulk_creation.py tests/e2e/test_add_item.py` — the eight pre-existing bulk tests and `test_add_and_continue_carry_forward_workflow` (quantity-1 continue) are the FR-011 regression surface and must be unchanged
+- [X] T010 [US1] Confirm T005 and T006 now pass, then run `nox -s e2e -- tests/e2e/test_bulk_creation.py tests/e2e/test_add_item.py` — the eight pre-existing bulk tests and `test_add_and_continue_carry_forward_workflow` (quantity-1 continue) are the FR-011 regression surface and must be unchanged
 
 **Checkpoint**: The reported defect is fixed and the inventory is trustworthy. **This is a
 shippable stopping point** — the button's label is still misleading for bulk, but nothing is
@@ -119,18 +119,18 @@ matches what a single-item **Add & Continue** leaves behind.
 
 > All three fail before T014: today the page simply stays put after the dialog closes.
 
-- [ ] T011 [US2] Add `test_bulk_add_and_continue_returns_to_empty_form` to `tests/e2e/test_bulk_creation.py`: submit quantity 3 via `submit_and_continue()`, `close_modal()`, then `expect(page).to_have_url(re.compile(r"/inventory/add$"))` followed by `expect(page.locator("#ja_id")).not_to_have_value("")` — the second wait is `CLAUDE.md` pattern G, because `autoPopulateJaId()` writes the field only after awaiting `/api/inventory/next-ja-id`; then assert `#notes` and `#length` are empty
-- [ ] T012 [US2] Add `test_carry_forward_after_bulk_add_and_continue` to `tests/e2e/test_bulk_creation.py`: after the flow in T011, click `#carry-forward-btn`, wait for the toast, and assert material, location, type and shape are restored from the batch just created (FR-008)
-- [ ] T013 [US2] Add `test_bulk_add_does_not_return_to_empty_form` to `tests/e2e/test_bulk_creation.py`: submit quantity 3 via the **existing** `submit_form()` (plain **Add**), `close_modal()`, and assert the URL did not change and `#material` still holds the submitted value — this is FR-007, the guard against the two buttons collapsing into one, and it is the assertion most easily lost
+- [X] T011 [US2] Add `test_bulk_add_and_continue_returns_to_empty_form` to `tests/e2e/test_bulk_creation.py`: submit quantity 3 via `submit_and_continue()`, `close_modal()`, then `expect(page).to_have_url(re.compile(r"/inventory/add$"))` followed by `expect(page.locator("#ja_id")).not_to_have_value("")` — the second wait is `CLAUDE.md` pattern G, because `autoPopulateJaId()` writes the field only after awaiting `/api/inventory/next-ja-id`; then assert `#notes` and `#length` are empty
+- [X] T012 [US2] Add `test_carry_forward_after_bulk_add_and_continue` to `tests/e2e/test_bulk_creation.py`: after the flow in T011, click `#carry-forward-btn`, wait for the toast, and assert material, location, type and shape are restored from the batch just created (FR-008)
+- [X] T013 [US2] Add `test_bulk_add_does_not_return_to_empty_form` to `tests/e2e/test_bulk_creation.py`: submit quantity 3 via the **existing** `submit_form()` (plain **Add**), `close_modal()`, and assert the URL did not change and `#material` still holds the submitted value — this is FR-007, the guard against the two buttons collapsing into one, and it is the assertion most easily lost
 
 ### Implementation for User Story 2
 
-- [ ] T014 [US2] In `app/static/js/inventory-add.js`, set `this.continueAfterBulk = continueAdding` before dispatching the bulk `fetch`, and register a `hidden.bs.modal` listener on `#bulkLabelPrintingModal` that navigates to `/inventory/add` when the flag is set (research.md D4) — register it once during setup, not per submission
-- [ ] T015 [US2] Delete the dead `clearFormForContinue()` method from `app/static/js/inventory-add.js` (lines 823-846); it is called from nowhere in `app/` or `tests/`, and leaving a method named for exactly what T014 implements — which it does not correctly do, since it never repopulates the JA ID — misleads the next reader (research.md D7)
+- [X] T014 [US2] In `app/static/js/inventory-add.js`, set `this.continueAfterBulk = continueAdding` before dispatching the bulk `fetch`, and register a `hidden.bs.modal` listener on `#bulkLabelPrintingModal` that navigates to `/inventory/add` when the flag is set (research.md D4) — register it once during setup, not per submission
+- [X] T015 [US2] Delete the dead `clearFormForContinue()` method from `app/static/js/inventory-add.js` (lines 823-846); it is called from nowhere in `app/` or `tests/`, and leaving a method named for exactly what T014 implements — which it does not correctly do, since it never repopulates the JA ID — misleads the next reader (research.md D7)
 
 ### Verification for User Story 2
 
-- [ ] T016 [US2] Confirm T011-T013 pass and re-run `nox -s e2e -- tests/e2e/test_bulk_creation.py tests/e2e/test_add_item.py`
+- [X] T016 [US2] Confirm T011-T013 pass and re-run `nox -s e2e -- tests/e2e/test_bulk_creation.py tests/e2e/test_add_item.py`
 
 **Checkpoint**: **Add & Continue** honors its label at every quantity, and **Add** remains
 distinct from it.
@@ -156,8 +156,8 @@ first, last, or concurrently.
 > same `monkeypatch` technique already used by `test_partial_failure_returns_207`
 > (`tests/unit/test_routes.py:1511`), not end to end.
 
-- [ ] T017 [P] [US3] Add a form-path partial-failure test to `tests/unit/test_routes.py`: monkeypatch `app.main.routes._create_single_item` to fail the second of three items, `POST /inventory/add` with `quantity_to_create=3`, and assert the response is 500 with `success: false`, `count == 2`, and `len(ja_ids) == 2` — the form branch is separate from the JSON API branch already covered at line 1511, and `count`/`ja_ids` are what FR-009's "the count stated matches the inventory" rests on
-- [ ] T018 [P] [US3] Add a form-path complete-failure test to `tests/unit/test_routes.py`: monkeypatch `_create_single_item` to fail every item, `POST /inventory/add` with `quantity_to_create=2`, and assert 500 with the `Failed to create any items` message and no items recorded
+- [X] T017 [P] [US3] Add a form-path partial-failure test to `tests/unit/test_routes.py`: monkeypatch `app.main.routes._create_single_item` to fail the second of three items, `POST /inventory/add` with `quantity_to_create=3`, and assert the response is 500 with `success: false`, `count == 2`, and `len(ja_ids) == 2` — the form branch is separate from the JSON API branch already covered at line 1511, and `count`/`ja_ids` are what FR-009's "the count stated matches the inventory" rests on
+- [X] T018 [P] [US3] Add a form-path complete-failure test to `tests/unit/test_routes.py`: monkeypatch `_create_single_item` to fail every item, `POST /inventory/add` with `quantity_to_create=2`, and assert 500 with the `Failed to create any items` message and no items recorded
 
 **Checkpoint**: The form path's bulk failure reporting is covered, in the fast suite.
 
@@ -165,11 +165,11 @@ first, last, or concurrently.
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T019 Verify SC-005 by proving the guard bites: stash the T007-T009 changes (`git stash`), run T005 alone, confirm it fails with a request count of 2, then restore (`git stash pop`) — a regression test never seen red is not yet a regression test
-- [ ] T020 Run `nox -s tests` and confirm the unit suite is green, including the untouched `tests/unit/test_routes.py:123` audit-logging tests for the **Add & Continue** workflow, whose passing unchanged is the evidence that server behavior did not move
-- [ ] T021 Run the full `nox -s e2e` with a 15-minute tool timeout — the add path is named in Constitution VI, so the active-status, history and multi-row suites are part of this change's regression surface — then confirm `git status` is clean, since an e2e run must not modify tracked files
-- [ ] T022 Walk the ten-step manual acceptance table in [quickstart.md](./quickstart.md) § 3, which covers the requirements no automated test reaches: Enter-key submission (step 10), double-press (step 9), and the quantity-1 paths (steps 6-7)
-- [ ] T023 Prepare the PR: confirm new lines satisfy `nox -s lint` without reformatting surrounding code (the session is red at baseline on pre-existing E501 failures and is advisory), and state in the PR description that documentation screenshots were deliberately **not** regenerated because the change alters a hidden input and event wiring, neither of which renders — the `Screenshot Reminder` workflow will comment on this PR regardless and blocks nothing (research.md D6)
+- [X] T019 Verify SC-005 by proving the guard bites: stash the T007-T009 changes (`git stash`), run T005 alone, confirm it fails with a request count of 2, then restore (`git stash pop`) — a regression test never seen red is not yet a regression test
+- [X] T020 Run `nox -s tests` and confirm the unit suite is green, including the untouched `tests/unit/test_routes.py:123` audit-logging tests for the **Add & Continue** workflow, whose passing unchanged is the evidence that server behavior did not move
+- [X] T021 Run the full `nox -s e2e` with a 15-minute tool timeout — the add path is named in Constitution VI, so the active-status, history and multi-row suites are part of this change's regression surface — then confirm `git status` is clean, since an e2e run must not modify tracked files
+- [X] T022 Walk the ten-step manual acceptance table in [quickstart.md](./quickstart.md) § 3, which covers the requirements no automated test reaches: Enter-key submission (step 10), double-press (step 9), and the quantity-1 paths (steps 6-7)
+- [X] T023 Prepare the PR: confirm new lines satisfy `nox -s lint` without reformatting surrounding code (the session is red at baseline on pre-existing E501 failures and is advisory), and state in the PR description that documentation screenshots were deliberately **not** regenerated because the change alters a hidden input and event wiring, neither of which renders — the `Screenshot Reminder` workflow will comment on this PR regardless and blocks nothing (research.md D6)
 
 ---
 
@@ -251,3 +251,69 @@ the browser work; it shares nothing with the rest and its result is informative 
 - Commit after each phase checkpoint rather than after each task; the tasks within a phase are
   fine-grained edits to one file.
 - No Alembic revision, no schema change, no new dependency, no new pytest marker.
+
+---
+
+## Implementation notes (2026-08-10)
+
+### The stated root cause did not reproduce
+
+T005 and T006 were written to fail first, per the Phase 3 preamble. **They passed
+against the unmodified code.** Measured directly rather than inferred:
+
+| Observation, unmodified code, quantity 3, one press of **Add & Continue** | Predicted | Measured |
+|---|---|---|
+| `POST /inventory/add` requests dispatched | 2 | **1** |
+| `Submit: Submitting form with type: …` console lines | 2 (`continue`, `add`) | **1** (`continue`) |
+| Items created | 3 or 6 | **3** |
+| Error toast / JS page error | one of them | **none** |
+
+`handleSubmit` sets `continueBtn.disabled = true` synchronously, before its first
+`await`. A button's activation behavior returns early when the element is
+disabled, and activation runs after the click listeners — so the click's default
+form submission was suppressed and the `submit` listener never fired. research.md
+carries the same correction at its root-cause section.
+
+**Consequence for SC-005**: T019 as written (stash the fix, watch T005 fail with
+a request count of 2) cannot succeed, because the count was never 2. The stash
+experiment was run anyway and recorded what actually goes red:
+
+| New test | Against unmodified code |
+|---|---|
+| `test_bulk_add_and_continue_sends_one_request` | PASSED (characterization) |
+| `test_bulk_add_and_continue_creates_exact_count` | PASSED (characterization) |
+| `test_bulk_add_and_continue_returns_to_empty_form` | **FAILED** |
+| `test_carry_forward_after_bulk_add_and_continue` | **FAILED** |
+| `test_plain_add_after_bulk_continue_is_not_a_continue` | **FAILED** |
+
+So SC-005 holds for the defects that were real, and three of the five new e2e
+tests have been seen red. The two FR-001/FR-002 tests are characterization
+tests: required by FR-012, but they guard a property rather than reproduce a
+failure.
+
+### Tests added beyond the task list
+
+- `test_plain_add_after_bulk_continue_is_not_a_continue` — the stale
+  `submit_type` defect (research.md D3), the one cross-submission bug that was
+  reproducibly broken. Not in the original task list because the plan attributed
+  everything to the double submission.
+- `test_repeated_submission_creates_one_batch` and
+  `test_enter_key_submits_as_plain_add` — T022's manual acceptance table steps 9
+  and 10. These cover FR-005 and the keyboard-submission edge case, which no
+  automated test reached; they are asserted in the suite rather than walked by
+  hand. Steps 1-8 of that table are covered by the tests in this file and in
+  `test_add_item.py`.
+
+`test_enter_key_submits_as_plain_add` initially failed for an unrelated reason
+worth recording: implicit submission is **silent** when the form is invalid — the
+submit event fires, `checkValidity()` returns false, the handler returns, and
+nothing observable changes. The test had used a material outside the taxonomy.
+It now establishes `is-valid` on `#material` and a populated `#ja_id` before
+pressing Enter.
+
+### Not done
+
+- **Screenshots not regenerated**, per research.md D6 — the change is a hidden
+  input, a `type` attribute and event wiring, none of which renders.
+- **T022 was not walked manually.** Its uncovered steps were automated instead
+  (above). Steps requiring a human at a real browser were not performed.

--- a/specs/010-fix-bulk-add-continue/tasks.md
+++ b/specs/010-fix-bulk-add-continue/tasks.md
@@ -311,6 +311,27 @@ nothing observable changes. The test had used a material outside the taxonomy.
 It now establishes `is-valid` on `#material` and a populated `#ja_id` before
 pressing Enter.
 
+### Deviation from T007: `name` removed from the submit buttons
+
+T007 said to leave both submit buttons' `name`/`value` attributes in place "so
+`event.submitter.value` keeps working". Only `value` is needed for that — a
+`<button>` exposes `.value` regardless of whether it has a `name`. Keeping the
+names left three controls called `submit_type` in one form, which is ambiguous
+on any native submission (the hidden field wins by document order, so
+**Add & Continue** would read as a plain **Add**). Raised in review on PR #83.
+
+The `name` attributes were therefore dropped from both buttons, leaving exactly
+one `submit_type` control. No supported path changes behavior: `FormData(form)`
+never includes submit-button entries, and `form.submit()` sends no submitter, so
+the hidden field was already the only `submit_type` transmitted in both the bulk
+and single-item paths.
+
+The reviewer's alternative — strip `name` from the *hidden* input and have the
+handler add it back before submitting — was declined: it restores the
+per-submission field mutation that D3 removed, and introduces a failure mode
+where a missed assignment sends no `submit_type` at all, which the server reads
+as a plain **Add**.
+
 ### Not done
 
 - **Screenshots not regenerated**, per research.md D6 — the change is a hidden

--- a/specs/010-fix-bulk-add-continue/tasks.md
+++ b/specs/010-fix-bulk-add-continue/tasks.md
@@ -1,0 +1,253 @@
+---
+
+description: "Task list for feature 010: Fix Add & Continue With Quantity Greater Than One"
+---
+
+# Tasks: Fix Add & Continue With Quantity Greater Than One
+
+**Input**: Design documents from `/specs/010-fix-bulk-add-continue/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/add-item-submission.md), [quickstart.md](./quickstart.md)
+
+**Tests**: **Required, not optional.** FR-012 makes end-to-end coverage of the defective
+combination a deliverable, and Constitution IV requires that behavior changes land with tests
+covering that behavior. Test tasks come before the implementation they guard.
+
+**Organization**: Tasks are grouped by user story. Note the honest caveat below — these stories
+are *sequenced*, not independent.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths appear in every task
+
+## Path Conventions
+
+Server-rendered Flask app, repository root. Production code in `app/`, tests in `tests/unit/` and
+`tests/e2e/`. No new directories.
+
+## Read this before starting
+
+**Parallelism here is nearly nil, and pretending otherwise would cause conflicts.** US1 and US2
+are successive edits to the same 40 lines of `app/static/js/inventory-add.js`, and their tests are
+successive additions to the same `tests/e2e/test_bulk_creation.py`. Only Phase 5 (US3) touches a
+disjoint file set and is genuinely parallelizable. The `[P]` marker appears on exactly two tasks
+in this file, and both occurrences are real.
+
+**The stories are not independently deliverable in the template's sense.** US2 without US1 would
+mean navigating away after a submission that may have created twice what was asked. US1 is the
+MVP and ships alone if you stop early; US2 layered on US1 is the complete feature. US3 needs no
+production change at all and can be done any time.
+
+**Run tests through `nox`, never bare `pytest`** (Constitution IV). `nox` sessions pin Python
+3.13; if the system Python is newer, put pyenv's 3.13 on `PATH` first. Give `nox -s e2e` a
+15-minute tool timeout.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Make later failures attributable to this change rather than to the environment.
+
+- [ ] T001 Activate the repository virtualenv (`venv/`) and confirm the `nox` sessions resolve Python 3.13 — put pyenv's 3.13 ahead of the system Python on `PATH` if `nox -l` reports a missing interpreter
+- [ ] T002 Record the green baseline: run `nox -s e2e -- tests/e2e/test_bulk_creation.py tests/e2e/test_add_item.py` and confirm all pass **before** any edit, so a later failure in these files is known to be caused by this work
+
+**Checkpoint**: Toolchain resolves and the files this feature touches are green.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Test scaffolding that both US1 and US2 need. Nothing in Phase 3 or 4 can be written
+without it.
+
+**⚠️ Both tasks edit `tests/e2e/test_bulk_creation.py` — strictly sequential, no `[P]`.**
+
+- [ ] T003 Add `submit_and_continue()` to the `BulkCreationPage` class in `tests/e2e/test_bulk_creation.py`, mirroring the existing `submit_form()` (clear `#toast-container`, set `window.__awaitingSubmit`, click `#submit-and-continue-btn`, then `wait_for_function` settling on document replacement, a toast, or `#bulkLabelPrintingModal.show`) — reuse the existing helper's body rather than inventing a second waiting strategy
+- [ ] T004 Add a module-level `count_add_posts(page)` helper in `tests/e2e/test_bulk_creation.py` that attaches `page.on("request", ...)` and returns a mutable counter of `POST` requests whose URL ends in `/inventory/add`; document at the call site that this counts requests *dispatched*, which is what FR-001 constrains
+
+**Checkpoint**: A test can drive **Add & Continue** at any quantity and count the resulting POSTs.
+
+---
+
+## Phase 3: User Story 1 — Bulk create without spurious errors or extra items (Priority: P1) 🎯 MVP
+
+**Goal**: One press of **Add & Continue** at quantity *N* produces exactly one request and exactly
+*N* items, with no error shown.
+
+**Independent Test**: Fill the Add form, set quantity above 1, press **Add & Continue**, and check
+that the inventory gained exactly the requested number of items and that no error message appeared.
+
+### Tests for User Story 1 ⚠️
+
+> **Write these first and watch them FAIL.** T005 fails today with `2 != 1`. T006 is
+> nondeterministic today — it fails either on the item count (6 when 3 were asked for) or on the
+> error toast (`Failed to create any items`), depending on interleaving. Both outcomes are the
+> bug; if T006 passes on the first run, run it again before believing it.
+
+- [ ] T005 [US1] Add `test_bulk_add_and_continue_sends_one_request` to `tests/e2e/test_bulk_creation.py`: fill a valid item, set quantity 3, submit via `submit_and_continue()`, wait with `wait_for_modal_shown(page, "bulkLabelPrintingModal")`, then assert the T004 counter equals exactly 1
+- [ ] T006 [US1] Add `test_bulk_add_and_continue_creates_exact_count` to `tests/e2e/test_bulk_creation.py`: read `len(InventoryService(live_server.storage).get_all_items())` before submitting, set quantity 3, submit via `submit_and_continue()`, wait for the modal, then assert the count delta is exactly 3 and that `#toast-container .toast-body` contains no error text — establish the modal with `wait_for_modal_shown` *before* the negative toast assertion, per the negative-assertion rule in `CLAUDE.md`
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] In `app/templates/inventory/add.html`, add `<input type="hidden" name="submit_type" id="submit-type" value="add">` inside `#add-item-form` (near the existing `csrf_token` field at line 31); leave both submit buttons' `name`/`value` attributes in place so `event.submitter.value` keeps working
+- [ ] T008 [US1] In `app/static/js/inventory-add.js`, collapse the two submission entry points into one: delete the `#submit-and-continue-btn` click listener (lines 79-81), change `handleSubmit(event, continueAdding = false)` to derive `const continueAdding = event?.submitter?.value === 'continue'`, delete the `document.createElement('input')` block (lines 668-674), and instead assign `document.getElementById('submit-type').value = continueAdding ? 'continue' : 'add'` — see research.md D1 and D3
+- [ ] T009 [US1] In `app/static/js/inventory-add.js` `handleSubmit()`, add the re-entrancy guard: `if (this.submitting) return;` immediately after `event.preventDefault()` and the validity check, set `this.submitting = true`, and move the button-state restoration into a single `finally` block replacing the duplicated restores in the success and `catch` branches (research.md D2, FR-005)
+
+### Verification for User Story 1
+
+- [ ] T010 [US1] Confirm T005 and T006 now pass, then run `nox -s e2e -- tests/e2e/test_bulk_creation.py tests/e2e/test_add_item.py` — the eight pre-existing bulk tests and `test_add_and_continue_carry_forward_workflow` (quantity-1 continue) are the FR-011 regression surface and must be unchanged
+
+**Checkpoint**: The reported defect is fixed and the inventory is trustworthy. **This is a
+shippable stopping point** — the button's label is still misleading for bulk, but nothing is
+broken.
+
+---
+
+## Phase 4: User Story 2 — Continue into the next entry after a bulk create (Priority: P2)
+
+**Goal**: After a bulk **Add & Continue**, dismissing the label dialog returns the user to a fresh
+Add form — the same state the single-item path reaches by server redirect.
+
+**Independent Test**: Complete a bulk **Add & Continue**, dismiss the dialog, and confirm the form
+matches what a single-item **Add & Continue** leaves behind.
+
+**Depends on**: Phase 3. These tasks edit the same handler US1 just rewrote.
+
+### Tests for User Story 2 ⚠️
+
+> All three fail before T014: today the page simply stays put after the dialog closes.
+
+- [ ] T011 [US2] Add `test_bulk_add_and_continue_returns_to_empty_form` to `tests/e2e/test_bulk_creation.py`: submit quantity 3 via `submit_and_continue()`, `close_modal()`, then `expect(page).to_have_url(re.compile(r"/inventory/add$"))` followed by `expect(page.locator("#ja_id")).not_to_have_value("")` — the second wait is `CLAUDE.md` pattern G, because `autoPopulateJaId()` writes the field only after awaiting `/api/inventory/next-ja-id`; then assert `#notes` and `#length` are empty
+- [ ] T012 [US2] Add `test_carry_forward_after_bulk_add_and_continue` to `tests/e2e/test_bulk_creation.py`: after the flow in T011, click `#carry-forward-btn`, wait for the toast, and assert material, location, type and shape are restored from the batch just created (FR-008)
+- [ ] T013 [US2] Add `test_bulk_add_does_not_return_to_empty_form` to `tests/e2e/test_bulk_creation.py`: submit quantity 3 via the **existing** `submit_form()` (plain **Add**), `close_modal()`, and assert the URL did not change and `#material` still holds the submitted value — this is FR-007, the guard against the two buttons collapsing into one, and it is the assertion most easily lost
+
+### Implementation for User Story 2
+
+- [ ] T014 [US2] In `app/static/js/inventory-add.js`, set `this.continueAfterBulk = continueAdding` before dispatching the bulk `fetch`, and register a `hidden.bs.modal` listener on `#bulkLabelPrintingModal` that navigates to `/inventory/add` when the flag is set (research.md D4) — register it once during setup, not per submission
+- [ ] T015 [US2] Delete the dead `clearFormForContinue()` method from `app/static/js/inventory-add.js` (lines 823-846); it is called from nowhere in `app/` or `tests/`, and leaving a method named for exactly what T014 implements — which it does not correctly do, since it never repopulates the JA ID — misleads the next reader (research.md D7)
+
+### Verification for User Story 2
+
+- [ ] T016 [US2] Confirm T011-T013 pass and re-run `nox -s e2e -- tests/e2e/test_bulk_creation.py tests/e2e/test_add_item.py`
+
+**Checkpoint**: **Add & Continue** honors its label at every quantity, and **Add** remains
+distinct from it.
+
+---
+
+## Phase 5: User Story 3 — Honest reporting when a bulk create does not fully succeed (Priority: P3)
+
+**Goal**: Partial-failure reporting on the *form* path states a count that matches what was
+recorded, and this survives the change.
+
+**Independent Test**: Force a bulk creation to fail partway and confirm the reported counts match
+the inventory.
+
+**Fully independent of Phases 3 and 4** — different files, no production change. Can be done
+first, last, or concurrently.
+
+> **These are characterization tests and should PASS on first run.** The behavior already exists
+> at `app/main/routes.py:585-591`; what is missing is coverage. If either test fails, that is a
+> real defect in the partial-failure path and is in scope for this feature. A partial failure is
+> not reachable through the browser — the server's allocation (`routes.py:314`) starts above the
+> current maximum precisely to avoid collisions — so this is verified at the unit level with the
+> same `monkeypatch` technique already used by `test_partial_failure_returns_207`
+> (`tests/unit/test_routes.py:1511`), not end to end.
+
+- [ ] T017 [P] [US3] Add a form-path partial-failure test to `tests/unit/test_routes.py`: monkeypatch `app.main.routes._create_single_item` to fail the second of three items, `POST /inventory/add` with `quantity_to_create=3`, and assert the response is 500 with `success: false`, `count == 2`, and `len(ja_ids) == 2` — the form branch is separate from the JSON API branch already covered at line 1511, and `count`/`ja_ids` are what FR-009's "the count stated matches the inventory" rests on
+- [ ] T018 [P] [US3] Add a form-path complete-failure test to `tests/unit/test_routes.py`: monkeypatch `_create_single_item` to fail every item, `POST /inventory/add` with `quantity_to_create=2`, and assert 500 with the `Failed to create any items` message and no items recorded
+
+**Checkpoint**: The form path's bulk failure reporting is covered, in the fast suite.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T019 Verify SC-005 by proving the guard bites: stash the T007-T009 changes (`git stash`), run T005 alone, confirm it fails with a request count of 2, then restore (`git stash pop`) — a regression test never seen red is not yet a regression test
+- [ ] T020 Run `nox -s tests` and confirm the unit suite is green, including the untouched `tests/unit/test_routes.py:123` audit-logging tests for the **Add & Continue** workflow, whose passing unchanged is the evidence that server behavior did not move
+- [ ] T021 Run the full `nox -s e2e` with a 15-minute tool timeout — the add path is named in Constitution VI, so the active-status, history and multi-row suites are part of this change's regression surface — then confirm `git status` is clean, since an e2e run must not modify tracked files
+- [ ] T022 Walk the ten-step manual acceptance table in [quickstart.md](./quickstart.md) § 3, which covers the requirements no automated test reaches: Enter-key submission (step 10), double-press (step 9), and the quantity-1 paths (steps 6-7)
+- [ ] T023 Prepare the PR: confirm new lines satisfy `nox -s lint` without reformatting surrounding code (the session is red at baseline on pre-existing E501 failures and is advisory), and state in the PR description that documentation screenshots were deliberately **not** regenerated because the change alters a hidden input and event wiring, neither of which renders — the `Screenshot Reminder` workflow will comment on this PR regardless and blocks nothing (research.md D6)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies.
+- **Phase 2 (Foundational)**: Depends on Phase 1. **Blocks Phases 3 and 4** — both stories' tests
+  call the helpers it adds. Does **not** block Phase 5.
+- **Phase 3 (US1)**: Depends on Phase 2.
+- **Phase 4 (US2)**: Depends on Phase 3 — same handler, same test file.
+- **Phase 5 (US3)**: Depends only on Phase 1.
+- **Phase 6 (Polish)**: Depends on every phase you intend to ship.
+
+### Story Dependencies
+
+- **US1 (P1)**: The MVP. Ships alone.
+- **US2 (P2)**: Requires US1. Navigating away after a submission that might have double-created
+  would make the defect harder to notice, not easier.
+- **US3 (P3)**: Independent of both. No production code change.
+
+### File Conflict Map
+
+Tasks touching the same file must not be run concurrently:
+
+| File | Tasks |
+|------|-------|
+| `tests/e2e/test_bulk_creation.py` | T003, T004, T005, T006, T011, T012, T013 |
+| `app/static/js/inventory-add.js` | T008, T009, T014, T015 |
+| `app/templates/inventory/add.html` | T007 |
+| `tests/unit/test_routes.py` | T017, T018 |
+
+### Parallel Opportunities
+
+Two, and only two:
+
+- T017 and T018 carry `[P]` **with respect to Phases 2-4** — `tests/unit/test_routes.py` shares no
+  file with the JS or e2e work, and US3 needs no production change. They are not parallel with
+  *each other* (same file).
+- Nothing else qualifies. Note in particular that T019 must run **alone**: it stashes and restores
+  the working tree, so anything running beside it would see a half-applied checkout.
+
+Everything else is a chain. This is a small bug fix in one handler; a task list claiming
+widespread parallelism would be describing a different feature.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 → Phase 2 → Phase 3.
+2. **STOP and VALIDATE**: T010. The inventory can no longer gain items the user did not ask for,
+   and the reported error is gone.
+3. Shippable. **Add & Continue** at quantity > 1 now behaves like **Add** — imperfect, but correct.
+
+### Full Feature
+
+4. Phase 4 (US2) → **Add & Continue** honors its label at every quantity.
+5. Phase 5 (US3) at any point → closes the coverage gap on the form's bulk failure reporting.
+6. Phase 6 → full suites, manual walkthrough, PR.
+
+### Suggested Ordering If Interleaving
+
+Run Phase 5 first if you want a quick green win in the sub-second unit suite before starting on
+the browser work; it shares nothing with the rest and its result is informative either way.
+
+---
+
+## Notes
+
+- `[P]` = different files, no dependency. Used on two tasks here, both justified above.
+- Every new wait must name an element or a page condition — no `wait_for_timeout`, no
+  `time.sleep`, no `networkidle` (Constitution IV). `wait_for_modal_shown` and
+  `wait_for_modal_hidden` already exist in `tests/e2e/waits.py`; do not write new ones.
+- Before every `count()`, `text_content()`, `is_visible()` or `get_attribute()` in a new test, ask
+  what established that region. Against a JS-rendered page they read "empty" rather than waiting.
+- Commit after each phase checkpoint rather than after each task; the tasks within a phase are
+  fine-grained edits to one file.
+- No Alembic revision, no schema change, no new dependency, no new pytest marker.

--- a/tests/e2e/test_bulk_creation.py
+++ b/tests/e2e/test_bulk_creation.py
@@ -5,10 +5,34 @@ Tests the "Quantity to Create" feature that allows creating multiple identical
 items with sequential JA IDs in a single form submission.
 """
 
+import re
+
 import pytest
 from playwright.sync_api import expect
 from tests.e2e.pages.base_page import BasePage
 from tests.e2e.waits import wait_for_modal_hidden, wait_for_modal_shown
+
+
+def count_add_posts(page):
+    """Count POST requests to /inventory/add dispatched from this point on.
+
+    Returns a single-element list used as a mutable counter; read it as
+    `counter[0]`. This counts requests *dispatched*, not responses received,
+    which is exactly what FR-001 constrains: one press of a submit button must
+    produce one request, regardless of how the server answers it.
+
+    Attach this before the submission being measured -- Playwright delivers
+    `request` events for the page's whole lifetime, so a listener attached
+    afterwards sees nothing.
+    """
+    counter = [0]
+
+    def _on_request(request):
+        if request.method == "POST" and request.url.endswith("/inventory/add"):
+            counter[0] += 1
+
+    page.on("request", _on_request)
+    return counter
 
 
 class BulkCreationPage(BasePage):
@@ -77,6 +101,28 @@ class BulkCreationPage(BasePage):
             """() => window.__awaitingSubmit === undefined
                   || !!document.querySelector('#toast-container .toast')
                   || !!document.querySelector('#bulkLabelPrintingModal.show')"""
+        )
+
+    def submit_and_continue(self):
+        """Press **Add & Continue** and wait for that submission to resolve.
+
+        Same settling strategy as submit_form(), for the same reasons -- see
+        its docstring. The only difference is which button is pressed, so the
+        body is deliberately identical rather than a second waiting strategy
+        that could drift from the first.
+        """
+        self.page.evaluate(
+            """() => {
+                window.__awaitingSubmit = true;
+                const c = document.getElementById('toast-container');
+                if (c) c.innerHTML = '';
+            }"""
+        )
+        self.page.locator("#submit-and-continue-btn").click()
+        self.page.wait_for_function(
+            """() => window.__awaitingSubmit === undefined
+                || !!document.querySelector('#toast-container .toast')
+                || !!document.querySelector('#bulkLabelPrintingModal.show')"""
         )
 
     def get_success_message(self):
@@ -456,6 +502,342 @@ def test_bulk_label_printing_modal_content(page, live_server):
         item_text = items.nth(i).inner_text()
         assert "JA" in item_text
         assert "Stainless Steel" in item_text
+
+
+@pytest.mark.e2e
+def test_bulk_add_and_continue_sends_one_request(page, live_server):
+    """One press of Add & Continue at quantity > 1 dispatches exactly one POST.
+
+    This is FR-001 asserted directly rather than inferred from a symptom, and
+    it holds the single-submission property in place now that the continue
+    button is wired through one listener rather than two.
+    """
+    bulk_page = BulkCreationPage(page, live_server.url)
+    bulk_page.navigate_to_add_page()
+
+    item_data = {
+        'item_type': 'Bar',
+        'shape': 'Round',
+        'material': 'Aluminum',
+        'length': '24',
+        'width': '1',
+        'location': 'Storage A',
+    }
+    bulk_page.fill_item_details(item_data)
+    bulk_page.set_quantity_to_create(3)
+
+    post_count = count_add_posts(page)
+
+    bulk_page.submit_and_continue()
+    wait_for_modal_shown(page, "bulkLabelPrintingModal")
+
+    assert post_count[0] == 1, (
+        f"Add & Continue dispatched {post_count[0]} POSTs to /inventory/add; "
+        "one press must produce exactly one request"
+    )
+
+
+@pytest.mark.e2e
+def test_bulk_add_and_continue_creates_exact_count(page, live_server):
+    """Add & Continue at quantity N creates exactly N items and shows no error.
+
+    FR-002 and FR-003. Both assertions are here because a duplicated bulk
+    submission can show up either way: two concurrent creations that collide on
+    JA IDs surface as an error toast beside the success dialog, while two that
+    serialise record 2N items and show no error at all. The count is the
+    assertion that catches the silent variant.
+    """
+    from app.mariadb_inventory_service import InventoryService
+
+    service = InventoryService(live_server.storage)
+    count_before = len(service.get_all_items())
+
+    bulk_page = BulkCreationPage(page, live_server.url)
+    bulk_page.navigate_to_add_page()
+
+    item_data = {
+        'item_type': 'Plate',
+        'shape': 'Rectangular',
+        'material': 'Steel',
+        'length': '12',
+        'width': '6',
+        'thickness': '0.25',
+        'location': 'Shop Floor',
+    }
+    bulk_page.fill_item_details(item_data)
+    bulk_page.set_quantity_to_create(3)
+
+    bulk_page.submit_and_continue()
+
+    # The open modal is what establishes the toast region for the negative
+    # assertion below -- "no error toast" passes trivially against a page that
+    # has not finished the submission.
+    wait_for_modal_shown(page, "bulkLabelPrintingModal")
+
+    error_toasts = page.locator("#toast-container .toast.text-bg-error")
+    expect(error_toasts).to_have_count(0)
+
+    count_after = len(service.get_all_items())
+    assert count_after - count_before == 3, (
+        f"expected 3 new items, got {count_after - count_before}"
+    )
+
+
+@pytest.mark.e2e
+def test_bulk_add_and_continue_returns_to_empty_form(page, live_server):
+    """Dismissing the bulk dialog after Add & Continue lands on a fresh form.
+
+    FR-006. Before the fix the bulk path had no notion of "continue" at all --
+    the dialog closed and left the filled-in form exactly as it was, so the
+    button did not do what its label says.
+    """
+    bulk_page = BulkCreationPage(page, live_server.url)
+    bulk_page.navigate_to_add_page()
+
+    bulk_page.fill_item_details({
+        'item_type': 'Bar',
+        'shape': 'Round',
+        'material': 'Aluminum',
+        'length': '24',
+        'width': '1',
+        'location': 'Storage A',
+        'notes': 'Batch one',
+    })
+    bulk_page.set_quantity_to_create(3)
+
+    bulk_page.submit_and_continue()
+    wait_for_modal_shown(page, "bulkLabelPrintingModal")
+    bulk_page.close_modal()
+
+    expect(page).to_have_url(re.compile(r"/inventory/add$"))
+
+    # CLAUDE.md pattern G: autoPopulateJaId() writes #ja_id only after awaiting
+    # /api/inventory/next-ja-id, so the form is not actually ready -- and the
+    # per-item assertions below are not meaningful -- until that write lands.
+    expect(page.locator("#ja_id")).not_to_have_value("")
+
+    expect(page.locator("#notes")).to_have_value("")
+    expect(page.locator("#length")).to_have_value("")
+
+
+@pytest.mark.e2e
+def test_carry_forward_after_bulk_add_and_continue(page, live_server):
+    """Carry Forward restores the batch just created (FR-008).
+
+    The values reach the fresh form through sessionStorage, written by
+    handleSubmit() before the request goes out, which is the same route the
+    single-item continue path already uses.
+    """
+    bulk_page = BulkCreationPage(page, live_server.url)
+    bulk_page.navigate_to_add_page()
+
+    bulk_page.fill_item_details({
+        'item_type': 'Plate',
+        'shape': 'Rectangular',
+        'material': 'Stainless Steel',
+        'length': '12',
+        'width': '6',
+        'thickness': '0.25',
+        'location': 'Materials Rack',
+    })
+    bulk_page.set_quantity_to_create(3)
+
+    bulk_page.submit_and_continue()
+    wait_for_modal_shown(page, "bulkLabelPrintingModal")
+    bulk_page.close_modal()
+
+    expect(page).to_have_url(re.compile(r"/inventory/add$"))
+    expect(page.locator("#ja_id")).not_to_have_value("")
+
+    page.locator("#carry-forward-btn").click()
+
+    # carryForwardData() raises this toast as its last step, after populating
+    # every field, so the toast appearing means the fields are written.
+    expect(page.locator("#toast-container .toast-body")).to_contain_text(
+        "carried forward"
+    )
+
+    expect(page.locator("#material")).to_have_value("Stainless Steel")
+    expect(page.locator("#location")).to_have_value("Materials Rack")
+    expect(page.locator("#item_type")).to_have_value("Plate")
+    expect(page.locator("#shape")).to_have_value("Rectangular")
+
+
+@pytest.mark.e2e
+def test_bulk_add_does_not_return_to_empty_form(page, live_server):
+    """Plain Add at quantity > 1 must NOT navigate away (FR-007).
+
+    This is the assertion most easily lost: if Add starts continuing too, every
+    count is still right and the two buttons have silently collapsed into one.
+    """
+    bulk_page = BulkCreationPage(page, live_server.url)
+    bulk_page.navigate_to_add_page()
+
+    bulk_page.fill_item_details({
+        'item_type': 'Bar',
+        'shape': 'Round',
+        'material': 'Copper',
+        'length': '18',
+        'width': '0.75',
+        'location': 'Storage D',
+    })
+    bulk_page.set_quantity_to_create(3)
+
+    bulk_page.submit_form()
+    wait_for_modal_shown(page, "bulkLabelPrintingModal")
+    url_after_submit = page.url
+    bulk_page.close_modal()
+
+    assert page.url == url_after_submit
+    expect(page.locator("#material")).to_have_value("Copper")
+
+
+@pytest.mark.e2e
+def test_plain_add_after_bulk_continue_is_not_a_continue(page, live_server):
+    """A bulk Add & Continue must not turn a later plain Add into a continue.
+
+    This is the one case in this file that was reproducibly broken before the
+    fix. The old handler appended a fresh `submit_type=continue` input per
+    continue submission, and a bulk submission never navigates away, so the
+    input survived. The single-item path submits with form.submit(), which
+    carries no submitter, leaving that stale input as the only `submit_type` in
+    the payload -- so the next plain Add was read by the server as a continue
+    and returned to the Add form instead of the inventory list.
+
+    Two changes close it: the submit type now lives in one persistent field
+    that is assigned on every submission, and a bulk continue re-renders the
+    form.
+    """
+    bulk_page = BulkCreationPage(page, live_server.url)
+    bulk_page.navigate_to_add_page()
+
+    bulk_page.fill_item_details({
+        'item_type': 'Bar',
+        'shape': 'Round',
+        'material': 'Aluminum',
+        'length': '24',
+        'width': '1',
+        'location': 'Storage A',
+    })
+    bulk_page.set_quantity_to_create(3)
+    bulk_page.submit_and_continue()
+    wait_for_modal_shown(page, "bulkLabelPrintingModal")
+    bulk_page.close_modal()
+
+    expect(page).to_have_url(re.compile(r"/inventory/add$"))
+    expect(page.locator("#ja_id")).not_to_have_value("")
+
+    # Now a plain, single-item Add. It must land on the inventory list.
+    bulk_page.fill_item_details({
+        'item_type': 'Bar',
+        'shape': 'Round',
+        'material': 'Brass',
+        'length': '10',
+        'width': '1',
+        'location': 'Storage B',
+    })
+    bulk_page.set_quantity_to_create(1)
+    bulk_page.submit_form()
+
+    expect(page).to_have_url(re.compile(r"/inventory(\?.*)?$"))
+
+
+@pytest.mark.e2e
+def test_repeated_submission_creates_one_batch(page, live_server):
+    """Two submissions fired back to back produce one batch (FR-005).
+
+    Disabling the buttons covers a double *click*, but Enter still reaches the
+    form while they are disabled, so the re-entrancy flag is what actually
+    holds. requestSubmit() models that: it raises a real submit event carrying
+    the continue button as submitter, exactly as Enter would, and bypasses the
+    disabled state a second click would run into.
+    """
+    from app.mariadb_inventory_service import InventoryService
+
+    service = InventoryService(live_server.storage)
+    count_before = len(service.get_all_items())
+
+    bulk_page = BulkCreationPage(page, live_server.url)
+    bulk_page.navigate_to_add_page()
+    bulk_page.fill_item_details({
+        'item_type': 'Bar',
+        'shape': 'Round',
+        'material': 'Aluminum',
+        'length': '24',
+        'width': '1',
+        'location': 'Storage A',
+    })
+    bulk_page.set_quantity_to_create(4)
+
+    post_count = count_add_posts(page)
+
+    page.evaluate(
+        """() => {
+            const c = document.getElementById('toast-container');
+            if (c) c.innerHTML = '';
+            const form = document.getElementById('add-item-form');
+            const btn = document.getElementById('submit-and-continue-btn');
+            form.requestSubmit(btn);
+            form.requestSubmit(btn);
+        }"""
+    )
+    wait_for_modal_shown(page, "bulkLabelPrintingModal")
+
+    assert post_count[0] == 1, (
+        f"two rapid submissions dispatched {post_count[0]} requests"
+    )
+    assert len(service.get_all_items()) - count_before == 4
+
+    # FR-005: both controls come back to their normal labels and enabled state.
+    expect(page.locator("#submit-btn")).to_be_enabled()
+    expect(page.locator("#submit-and-continue-btn")).to_be_enabled()
+    expect(page.locator("#submit-btn")).not_to_contain_text("Adding...")
+
+
+@pytest.mark.e2e
+def test_enter_key_submits_as_plain_add(page, live_server):
+    """Enter in a text field behaves as Add, not as Add & Continue.
+
+    Implicit submission reports the form's first submit button as the
+    submitter, which is #submit-btn. The observable consequence is that
+    dismissing the dialog does not navigate away.
+    """
+    bulk_page = BulkCreationPage(page, live_server.url)
+    bulk_page.navigate_to_add_page()
+    bulk_page.fill_item_details({
+        'item_type': 'Bar',
+        'shape': 'Round',
+        'material': 'Brass',
+        'length': '24',
+        'width': '1',
+        'location': 'Storage E',
+    })
+    bulk_page.set_quantity_to_create(4)
+
+    # Implicit submission is silent when the form is invalid -- it raises the
+    # submit event, the handler finds checkValidity() false and returns, and
+    # nothing observable happens. So both preconditions are established first:
+    # the material is accepted (CLAUDE.md pattern F, is-valid rather than the
+    # absence of is-invalid) and the auto-populated JA ID has landed (pattern
+    # G, autoPopulateJaId() writes it only after awaiting its fetch).
+    expect(page.locator("#material")).to_have_class(
+        re.compile(r"\bis-valid\b"))
+    expect(page.locator("#ja_id")).not_to_have_value("")
+
+    post_count = count_add_posts(page)
+
+    # #ja_id and #location swallow Enter for the barcode scanner, so this uses
+    # an ordinary text field.
+    page.locator("#width").press("Enter")
+    wait_for_modal_shown(page, "bulkLabelPrintingModal")
+
+    assert post_count[0] == 1
+
+    url_after_submit = page.url
+    bulk_page.close_modal()
+
+    assert page.url == url_after_submit
+    expect(page.locator("#material")).to_have_value("Brass")
 
 
 @pytest.mark.e2e

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1649,6 +1649,63 @@ class TestFormAddItemRouteAfterRefactor:
         assert data['count'] == 2
         assert len(data['ja_ids']) == 2
 
+    def test_bulk_form_partial_failure_reports_count(
+            self, client, monkeypatch):
+        """A partly-successful bulk form submission states what it recorded.
+
+        FR-009 rests on `count` and `ja_ids` describing what actually reached
+        the database, not what was requested. The form branch builds its own
+        response separately from the JSON API branch covered by
+        TestApiCreateItems, so it needs its own coverage.
+
+        A partial failure is not reachable through the browser -- the server
+        allocates above the current maximum precisely to avoid collisions -- so
+        it is provoked here the same way the JSON API test does it.
+        """
+        from app.main.routes import _create_single_item as real_create
+
+        call_count = {'n': 0}
+
+        def flaky_create(service, form_data, bulk_context=None):
+            call_count['n'] += 1
+            if call_count['n'] == 2:
+                return (False, form_data.get('ja_id'),
+                        'simulated failure', 'error')
+            return real_create(service, form_data, bulk_context)
+
+        monkeypatch.setattr(
+            'app.main.routes._create_single_item', flaky_create)
+
+        form = self._minimum_form(quantity_to_create='3')
+        response = client.post('/inventory/add', data=form)
+
+        assert response.status_code == 500
+        data = response.get_json()
+        assert data['success'] is False
+        assert data['count'] == 2
+        assert len(data['ja_ids']) == 2
+
+    def test_bulk_form_complete_failure_creates_nothing(
+            self, client, app, monkeypatch):
+        """When no item can be created the form says so and records none."""
+        def always_fail(service, form_data, bulk_context=None):
+            return (False, form_data.get('ja_id'),
+                    'simulated total failure', 'error')
+
+        monkeypatch.setattr('app.main.routes._create_single_item', always_fail)
+
+        form = self._minimum_form(quantity_to_create='2')
+        response = client.post('/inventory/add', data=form)
+
+        assert response.status_code == 500
+        data = response.get_json()
+        assert data['success'] is False
+        assert 'Failed to create any items' in data['error']
+
+        from app.main.routes import _get_inventory_service
+        with app.app_context():
+            assert _get_inventory_service().get_all_items() == []
+
 
 class TestFieldSuggestionsRoute:
     """Tests for GET /api/inventory/field-suggestions/<field>."""


### PR DESCRIPTION
Closes #52.

## What was actually broken

**Pressing Add & Continue with a quantity above 1 never continued.** The bulk path answers with JSON consumed by `fetch()`, so the server cannot redirect the way it does for a single item, and nothing on the client picked that up. The dialog closed and left the filled-in form exactly where it was.

**A second, quieter defect came with it.** The handler appended a fresh `submit_type=continue` input per continue submission, and a bulk submission never navigates away, so the input survived. The single-item path submits with `form.submit()`, which is programmatic and carries no submitter — leaving that stale input as the only `submit_type` in the payload. So the *next* plain **Add** was read by the server as a continue and returned to the Add form instead of the inventory list.

## Correction to the spec's root cause

The plan attributed everything to one press producing two POSTs (click listener + submit listener). **That was not reproducible.** Measured against unmodified code with `page.on("request", ...)`:

| Observation — quantity 3, one press of Add & Continue | Predicted | Measured |
|---|---|---|
| `POST /inventory/add` dispatched | 2 | **1** |
| `Submit: Submitting form with type: …` lines | 2 | **1** (`continue`) |
| Items created | 3 or 6 | **3** |
| Error toast / JS page error | one of them | **none** |

`handleSubmit` sets `continueBtn.disabled = true` synchronously before its first `await`. Per the HTML spec a button's activation behavior returns early when the element is disabled, and activation runs *after* click listeners — so the click's default form submission was suppressed. The code was accidentally correct, relying on an undocumented mechanism one edit away from breaking.

`research.md` and `tasks.md` are updated to record this rather than describing a bug that does not occur.

**If you saw a real error in the browser**, it may not suppress the second submission the way Chromium does — worth knowing which browser. The fix removes the fragile dependence either way.

## The change

- **One submission entry point.** The continue button's click listener is gone; which control was pressed comes from `event.submitter` on the form's own submit listener.
- **One persistent hidden `submit_type` field**, assigned on every submission, replacing the per-submission appended input.
- **A re-entrancy guard.** Disabling the buttons covers a double click, but Enter still reaches the form while they are disabled.
- **Button state restored in a single `finally`** instead of duplicated across the success and catch branches.
- **Dead `clearFormForContinue()` removed** — called from nowhere, and named for exactly what this change implements, which it did not do.

Client-side only. No route, service, storage, schema, or migration change.

## Tests

7 new e2e tests in `test_bulk_creation.py`: request count, exact item count, return-to-empty-form, carry-forward, plain **Add** staying put, the stale-`submit_type` regression, repeated submission, and Enter-key submission. 2 new unit tests cover the form path's bulk partial- and complete-failure reporting, which had no coverage.

**SC-005** — stashing the production fix confirms three of the new e2e tests go red:

| Test | Against unmodified code |
|---|---|
| `test_bulk_add_and_continue_sends_one_request` | PASSED (characterization) |
| `test_bulk_add_and_continue_creates_exact_count` | PASSED (characterization) |
| `test_bulk_add_and_continue_returns_to_empty_form` | **FAILED** |
| `test_carry_forward_after_bulk_add_and_continue` | **FAILED** |
| `test_plain_add_after_bulk_continue_is_not_a_continue` | **FAILED** |

The two FR-001/FR-002 tests guard a property rather than reproduce a failure — required by FR-012, but honest about what they are.

- `nox -s tests`: **1216 passed**
- `nox -s e2e` (full): **459 passed**, working tree clean afterward
- `nox -s lint`: **zero new findings** (both touched files sit at their exact 142-finding baseline; the session is red at baseline on pre-existing E501)

## Notes for review

- **Screenshots deliberately not regenerated.** The change is a hidden input, a `type` attribute and event wiring — none of it renders. Regenerating would commit byte-different PNGs for zero visual change. The `Screenshot Reminder` workflow will comment on this PR regardless; it blocks nothing and its own text says regeneration is not reproducible. (research.md D6.)
- **The manual acceptance walkthrough in quickstart.md §3 was not walked by hand.** Its two steps with no automated coverage — double-press (step 9) and Enter-key submission (step 10) — were automated instead. Steps 1–8 were already covered. A human pass over the real app is still outstanding if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7LLGYmpXK2Jof2zDfZJRH
