### PR TITLE
Capture: fill the Manufacturer Part Number from the listing (#90)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/018-capture-category-location"
+  "feature_directory": "specs/019-capture-mpn-default"
 }

--- a/app/catalog_service.py
+++ b/app/catalog_service.py
@@ -44,6 +44,7 @@ from .models import (
     ScanKind,
     ScanResolution,
     StockStatus,
+    normalized_row_name,
 )
 from .utils import category as category_utils
 from .utils import gtin as gtin_utils
@@ -2546,8 +2547,11 @@ def _is_barcode_row_name(name: Optional[str]) -> bool:
     substring: ``Manufacturer UPC`` and ``UPC Code`` are not ``UPC`` rows. A
     feature that promised six names should promote six names, and this runs with
     nobody watching.
+
+    The fold itself lives in ``models.normalized_row_name``, shared with 019's
+    part-number names so the two lists cannot drift apart.
     """
-    return ' '.join((name or '').split()).upper() in BARCODE_ROW_NAMES
+    return normalized_row_name(name) in BARCODE_ROW_NAMES
 
 
 def _corroborates(product: Product, manufacturer: Any, part_number: Any) -> bool:

--- a/app/models.py
+++ b/app/models.py
@@ -599,6 +599,62 @@ class ImageCaptureResult:
 LISTING_CAPTURE_VERSION = 1
 
 
+def normalized_row_name(name: Optional[str]) -> str:
+    """A specification row's name, folded for comparison against a fixed list.
+
+    Trims, collapses internal runs of whitespace, and upper-cases, so
+    ``mfr  part number`` and ``  Mfr Part Number `` are one name.
+
+    **Shared with the barcode-row matcher** (``_is_barcode_row_name`` in
+    ``catalog_service``), which is where this body came from. 019 FR-001
+    requires the part-number names to fold exactly as the barcode names already
+    do, and the only way to keep that true is for there to be one
+    implementation. Two lists that fold differently is the failure this
+    prevents.
+
+    Not to be confused with ``catalog_service._fold``, which case-folds and
+    trims but deliberately does **not** collapse internal whitespace. That one
+    compares two arbitrary operator-supplied strings; this one matches against a
+    fixed list of ASCII names. Different questions, different tools.
+    """
+    return ' '.join((name or '').split()).upper()
+
+
+# The product-information row names that mean "this value is the manufacturer's
+# part number", in **priority order** -- 019 FR-002. Stored already normalized,
+# so they compare against normalized_row_name(...) directly.
+#
+# **A tuple, where BARCODE_ROW_NAMES is a frozenset**, because order is the
+# specification here and is not there. A listing publishing both Model Number
+# and Mfr Part Number means the second one; membership alone cannot say that.
+#
+# The order encodes confidence and the bottom of it is deliberately loose. The
+# first two say what they are. PART NUMBER may be the vendor's rather than the
+# manufacturer's, and the two model names may be a marketing model that is not
+# orderable as a part. They earn their place because the operator reviews every
+# value this produces and can overrule it -- see ListingCapture's method below.
+PART_NUMBER_ROW_NAMES = (
+    'MANUFACTURER PART NUMBER',
+    'MFR PART NUMBER',
+    'PART NUMBER',
+    'MODEL NUMBER',
+    'ITEM MODEL NUMBER',
+)
+
+# Mirrors the String(100) on Product.manufacturer_part_number at
+# app/database.py:838.
+#
+# **Nothing in the stack checks this length**: _clean strips and nothing more,
+# and catalog_service validates no field width. So a derived default longer than
+# the column would submit, the capture would run, the gallery would be
+# retrieved, and only then would the write fail -- an error at the end of a
+# fifteen-second operation over a value the operator never typed. A candidate
+# that does not fit is passed over instead (019 FR-003), never truncated: a
+# truncated part number is a wrong one, and a wrong one corroborates a later
+# repeat buy against the wrong product.
+MANUFACTURER_PART_NUMBER_MAX_LENGTH = 100
+
+
 @dataclass
 class ListingCapture:
     """What the capture agent read off a vendor's listing.
@@ -620,6 +676,42 @@ class ListingCapture:
     description_text: Optional[str] = None
     specifications: List[Dict[str, str]] = field(default_factory=list)
     images: List[str] = field(default_factory=list)
+
+    def manufacturer_part_number(self) -> Optional[str]:
+        """The part number this listing's own rows name, or None (019).
+
+        **A default for the confirmation form, never an assertion about the
+        product.** The operator sees it, and can type over it or empty it before
+        capturing; nothing downstream may treat a part number as more
+        trustworthy for having come from here. Issue #90: the rows were already
+        on the page and the field was still being typed by hand.
+
+        The walk is names-outer, rows-inner, which is what makes FR-002's two
+        rules fall out rather than needing to be written: priority is by
+        position in ``PART_NUMBER_ROW_NAMES`` and never by position on the
+        vendor's page, and among rows sharing a name the first captured wins
+        because that is the order the inner walk visits them.
+
+        An unusable value does not end the search, it is passed over -- an empty
+        ``Model Number`` cell must not stop a real ``Item model number`` two
+        rows down (FR-003).
+
+        **Pure**: no I/O, no request, no mutation. A Jinja template calls this,
+        so it has to stay that way.
+
+        Returns:
+            The row's value with surrounding whitespace removed, or None when no
+            row qualifies. None is the ordinary case -- most listings name no
+            part number at all -- and never an error.
+        """
+        for wanted in PART_NUMBER_ROW_NAMES:
+            for entry in self.specifications:
+                if normalized_row_name(entry.get('name')) != wanted:
+                    continue
+                value = (entry.get('value') or '').strip()
+                if value and len(value) <= MANUFACTURER_PART_NUMBER_MAX_LENGTH:
+                    return value
+        return None
 
     @classmethod
     def from_json(cls, raw: Optional[str]) -> Optional['ListingCapture']:

--- a/app/product/routes.py
+++ b/app/product/routes.py
@@ -405,20 +405,27 @@ def product_capture():
         # looking at the thing, and a value they typed wins over one a selector
         # found (US1 scenario 3).
         #
-        # **Absent, not merely empty.** The confirmation form always submits both
-        # of these -- pre-filled from the same payload -- so a field that arrives
-        # empty is one the operator *cleared*, and clearing is a change like any
-        # other. Falling back on empty would quietly put the extracted value back
-        # and there would be no way to say "the listing is wrong about this".
-        # Falling back on absent still covers a POST that carries the payload and
-        # nothing else.
+        # **Absent, not merely empty.** The confirmation form always submits all
+        # three of these -- pre-filled from the same payload -- so a field that
+        # arrives empty is one the operator *cleared*, and clearing is a change
+        # like any other. Falling back on empty would quietly put the extracted
+        # value back and there would be no way to say "the listing is wrong about
+        # this". Falling back on absent still covers a POST that carries the
+        # payload and nothing else.
+        #
+        # The part number joined the pair in 019: unlike the brand and the price,
+        # which the agent puts on the payload, it is derived here from the
+        # listing's own product-information rows. Same rule either way.
         manufacturer = request.form.get('manufacturer')
         unit_price = request.form.get('unit_price')
+        manufacturer_part_number = request.form.get('manufacturer_part_number')
         if listing is not None:
             if manufacturer is None:
                 manufacturer = listing.brand
             if unit_price is None:
                 unit_price = listing.price
+            if manufacturer_part_number is None:
+                manufacturer_part_number = listing.manufacturer_part_number()
 
         try:
             purchase = service.capture_order(
@@ -431,7 +438,7 @@ def product_capture():
                 order_date=request.form.get('order_date'),
                 description=request.form.get('description'),
                 manufacturer=manufacturer,
-                manufacturer_part_number=request.form.get('manufacturer_part_number'),
+                manufacturer_part_number=manufacturer_part_number,
                 acknowledged_duplicate_of=request.form.get('acknowledged_duplicate_of'),
                 attach_to=request.form.get('attach_to'),
                 listing=listing,

--- a/app/templates/product/capture.html
+++ b/app/templates/product/capture.html
@@ -160,9 +160,33 @@
                             <label for="manufacturer_part_number" class="form-label">
                                 Manufacturer Part Number
                             </label>
+                            {# Pre-filled from the listing's own product-information
+                               rows when the operator has not supplied one (019
+                               US1). The five names it looks for, in priority
+                               order, are PART_NUMBER_ROW_NAMES in app/models.py.
+
+                               **Tests whether the key is present, not whether
+                               the value is truthy** -- and that is the whole of
+                               019 FR-006. form_data has no such key on either
+                               first render (the bookmarklet's landing dict, and
+                               request.args on the GET), so the listing fills the
+                               field. It always has one on a re-render, because
+                               this form submits the field, so what comes back is
+                               what the operator decided -- **including their
+                               decision to empty it**. Written with `or`, a
+                               cleared field would refill itself the moment the
+                               capture asked a question.
+
+                               The manufacturer field above still uses `or` and
+                               still has that wart. Aligning it is a separate
+                               change against a separate issue; do not fix it
+                               here. #}
                             <input type="text" class="form-control" id="manufacturer_part_number"
                                    name="manufacturer_part_number" maxlength="100"
-                                   value="{{ form_data.get('manufacturer_part_number') or '' }}">
+                                   value="{{ form_data['manufacturer_part_number']
+                                             if 'manufacturer_part_number' in form_data
+                                             else ((listing.manufacturer_part_number() or '')
+                                                   if listing else '') }}">
                             <div class="form-text">
                                 Both together let a repeat buy attach without asking.
                             </div>

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -912,6 +912,15 @@ Two ways in:
    *Product information* row, and every image the page's own data names, which is
    usually more than the thumbnail strip shows.
 
+   **Manufacturer Part Number is filled from those rows too.** A row named
+   *Manufacturer Part Number*, *Mfr Part Number*, *Part Number*, *Model Number*
+   or *Item model number* fills the field, in that order of preference — the more
+   specific name wins when a listing publishes several. It is a suggestion, not a
+   finding: the last two are often a marketing model rather than an orderable
+   part, so read it before you press Capture. Type over it or empty it and your
+   version is what gets recorded, including if the capture comes back asking you
+   a question first. The row itself stays in the specification list either way.
+
    What it reads is a page's markup, and a vendor's markup is not a contract. So
    the confirmation page tells you **what it found before anything is written** --
    a count of images, a count of information rows, and whether it found a

--- a/specs/019-capture-mpn-default/checklists/requirements.md
+++ b/specs/019-capture-mpn-default/checklists/requirements.md
@@ -1,0 +1,59 @@
+# Specification Quality Checklist: The Captured Listing Fills In the Manufacturer Part Number
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Iteration 1 finding, fixed.** FR-003's usability test originally read "non-empty"; the
+  length ceiling was added after the review asked what happens to a candidate longer than the
+  field accepts, which is why US3 carries it as an acceptance scenario rather than an
+  edge-case note.
+- **Corrected during Phase 0 planning (2026-08-18).** The rationale attached to that ceiling was
+  wrong. It claimed an over-long rendered value would put the input into the `tooLong` state and
+  block submission with an unexplained browser bubble. HTML's `tooLong` constraint applies only
+  after the *user* edits a control, so a server-rendered over-long value submits normally -- and
+  then fails on the `String(100)` column at the end of a fifteen-second capture, because nothing
+  in the stack checks the length. The requirement did not change; US3's "Why this priority", US3
+  scenario 2 and FR-003 were rewritten to state the real failure. See
+  [research.md](../research.md) section 4.
+- **Iteration 1 finding, fixed.** FR-007 originally read "both capture paths MUST behave the
+  same". That is trivially true and untestable — the pasted-address path carries no product
+  information rows at all. Restated as a single shared rule, with the reason recorded in the
+  Assumptions.
+- **Deliberate scope call for the planner's attention.** FR-006 requires a cleared field to stay
+  cleared when the confirmation form comes back with a question. The adjacent Manufacturer and
+  Unit Price fields do **not** behave this way today — they re-apply their derived default on
+  re-render. The issue's wording ("the operator must still be able to clear or change it") is
+  read as requiring the stronger behavior for this field, and the last Assumption records that
+  aligning the other two is out of scope. If the owner would rather have three consistent fields
+  than one correct one, this is the requirement to revisit.
+- **Terminology exclusion.** The recognized names in FR-001 are quoted as vendors spell them, so
+  `Mfr Part Number` and `Item model number` keep their source capitalization. These are data
+  values being matched, not prose.

--- a/specs/019-capture-mpn-default/checklists/requirements.md
+++ b/specs/019-capture-mpn-default/checklists/requirements.md
@@ -54,6 +54,12 @@
   read as requiring the stronger behavior for this field, and the last Assumption records that
   aligning the other two is out of scope. If the owner would rather have three consistent fields
   than one correct one, this is the requirement to revisit.
+- **Found during implementation (2026-08-18), spec amended.** Filling the part number changes more
+  than the field: `_corroborates` requires the manufacturer *and* the part number to agree before a
+  capture may attach to a product whose identifier it landed on, and the capture never supplied the
+  second half until now. Two existing E2E tests failed because the recycled-identifier question they
+  relied on is no longer raised on a re-capture. The behavior is the intended payoff, not a
+  regression; it is now an edge case in the spec, SC-006a, and a dedicated E2E test that pins it.
 - **Terminology exclusion.** The recognized names in FR-001 are quoted as vendors spell them, so
   `Mfr Part Number` and `Item model number` keep their source capitalization. These are data
   values being matched, not prose.

--- a/specs/019-capture-mpn-default/contracts/README.md
+++ b/specs/019-capture-mpn-default/contracts/README.md
@@ -1,0 +1,126 @@
+# Phase 1 Contracts: The Captured Listing Fills In the Manufacturer Part Number
+
+**No HTTP contract change.** No new endpoint, no new route, no new request or response field, no
+JSON shape altered, and no bump to `LISTING_CAPTURE_VERSION`. The bookmarklet's payload is
+byte-identical before and after this feature, which is what lets an operator with a cached
+bookmarklet keep capturing.
+
+What follows is the internal surface the feature adds, and the two existing contracts it leans on.
+
+---
+
+## New: `ListingCapture.manufacturer_part_number`
+
+```python
+def manufacturer_part_number(self) -> Optional[str]:
+    """The part number this listing's own rows name, or None.
+
+    A default for the confirmation form, never an assertion about the product.
+    """
+```
+
+- Returns the value of the highest-priority usable row named in `PART_NUMBER_ROW_NAMES`, trimmed.
+  Priority is by position in that tuple, **not** by position in `self.specifications`; among rows
+  sharing a name, the first in captured order wins (FR-002).
+- Returns `None` when no row qualifies — the ordinary case, not an error (FR-009).
+- **Pure and total.** No I/O, no exceptions, no mutation. It is called from a Jinja template, so it
+  must stay that way: if it ever needs a database session, the design in
+  [research.md](../research.md) §1 has been misread.
+- Callers: `app/templates/product/capture.html` (render) and `app/product/routes.py`
+  `product_capture` (write fallback). Nothing else.
+
+## New: `normalized_row_name`
+
+```python
+def normalized_row_name(name: Optional[str]) -> str:
+    """A specification row's name, folded for comparison against a fixed list."""
+```
+
+Trim, collapse internal whitespace, upper-case. `None` folds to `''`.
+
+**This is a move, not a new rule.** The body comes out of `_is_barcode_row_name`
+(`app/catalog_service.py:2541`), which now calls it. Behavior for barcode names is unchanged and
+`tests/unit/test_capture.py` should stay green untouched — if it does not, the move was not verbatim.
+
+## New: module constants
+
+```python
+PART_NUMBER_ROW_NAMES: tuple[str, ...]      # five names, pre-normalized, priority order
+MANUFACTURER_PART_NUMBER_MAX_LENGTH = 100   # mirrors app/database.py:838
+```
+
+Both in `app/models.py`. `PART_NUMBER_ROW_NAMES` entries are stored in their own normalized form; a
+test asserts that, because an entry that is not normalized can never match anything and would fail
+silently.
+
+---
+
+## Changed: the confirmation form's Manufacturer Part Number field
+
+`app/templates/product/capture.html`, the `manufacturer_part_number` input.
+
+**Was**: `value="{{ form_data.get('manufacturer_part_number') or '' }}"`
+
+**Becomes** a presence test on the key rather than a truthiness test on the value, falling back to
+`listing.manufacturer_part_number()`.
+
+The contract this states, and the reason the test is on presence:
+
+| Render path | key in `form_data` | Field shows |
+|---|---|---|
+| Bookmarklet lands (`api_capture`, form body) | absent | the listing's part number |
+| Paste-a-URL GET | absent | the listing's part number, or empty when there is no listing |
+| Re-render after a capture question | present | exactly what was submitted, **empty included** |
+| Re-render after a validation refusal | present | exactly what was submitted, **empty included** |
+
+**The empty-included rows are the contract.** A cleared field that comes back filled is the failure
+this feature exists to avoid (FR-006).
+
+**Not changed, deliberately**: the `manufacturer` field two lines above, and the unit price field
+below. Both still use `or`, and both still re-apply their default over a cleared field on re-render.
+That is a known wart, it is out of scope by a stated spec assumption, and it must not appear in this
+diff.
+
+## Changed: `product_capture`'s write path
+
+`app/product/routes.py`, `product_capture` POST branch. `manufacturer_part_number` joins
+`manufacturer` and `unit_price` in the absent-versus-empty fallback that already sits at lines
+415–421:
+
+```python
+manufacturer_part_number = request.form.get('manufacturer_part_number')
+if listing is not None:
+    if manufacturer_part_number is None:
+        manufacturer_part_number = listing.manufacturer_part_number()
+```
+
+**Absent, not merely empty** (FR-005). The confirmation form always submits the field, so an empty
+arrival is a field the operator *cleared*, and clearing is a decision. The existing comment at that
+site already says this; the new field is covered by it.
+
+---
+
+## Unchanged, and relied upon
+
+### `CatalogService.capture_order`
+
+Signature untouched. It already takes `manufacturer_part_number`; this feature only changes what is
+handed to it. Its existing rule that **capture never writes a manufacturer or part number onto a
+product that already exists** (`app/catalog_service.py`, the `else` branch at line 1213) stays
+exactly as it is — a mismatch there is the evidence the recycled-identifier question depends on.
+
+### `CatalogService.merge_specifications`
+
+Untouched, and deliberately not consulted. Unlike 016, this feature does not condition on whether a
+row survived the merge; see [research.md](../research.md) §6.
+
+### The ordinary product create and edit forms
+
+`app/templates/product/_form_fields.html` and `_form_product_fields` in `app/product/routes.py` get
+**no** derivation (FR-010). A part-number-named row typed by hand does not populate anything; the
+operator typing a row is already looking at the field.
+
+### `/api/capture` with a JSON body
+
+Unchanged. That representation calls `capture_order` without a `listing`, so it has no rows to
+derive from and nothing to apply. See [research.md](../research.md) §7.

--- a/specs/019-capture-mpn-default/data-model.md
+++ b/specs/019-capture-mpn-default/data-model.md
@@ -1,0 +1,101 @@
+# Phase 1 Data Model: The Captured Listing Fills In the Manufacturer Part Number
+
+**Feature**: `specs/019-capture-mpn-default` | **Date**: 2026-08-18
+
+## No schema change
+
+**There is no Alembic revision in this feature.** No table, no column, no index, no constraint. If a
+migration appears in the diff, the plan has been misread.
+
+Everything this feature reads and writes already exists:
+
+| Thing | Where it lives | What changes |
+|---|---|---|
+| `Product.manufacturer_part_number` | `app/database.py:838`, `String(100)`, nullable | Nothing. Same column, same width, same nullability, same writer. |
+| `Product.specifications` | existing specification rows | Nothing. No row is filtered, hidden, moved or removed on account of its name (FR-008). |
+| `ListingCapture.specifications` | `app/models.py:621`, `List[Dict[str, str]]`, not persisted | Nothing. Read, never modified. |
+| `LISTING_CAPTURE_VERSION` | `app/models.py:599`, currently `1` | **Not bumped.** The payload shape is unchanged, so a cached bookmarklet keeps working — see [research.md](./research.md) §1. |
+
+## Entities
+
+### `ListingCapture` (existing, `app/models.py:603`)
+
+An in-flight dataclass, not persisted, built only by `from_json`. It gains one method and no fields.
+
+```python
+def manufacturer_part_number(self) -> Optional[str]:
+    """The part number this listing's own rows name, or None."""
+```
+
+**Contract** (FR-001 through FR-004):
+
+- Walks `PART_NUMBER_ROW_NAMES` in order. For each name, walks `self.specifications` in captured
+  order and returns the first row whose normalized name equals it **and** whose value is usable.
+- A row's name is normalized with `normalized_row_name` — trimmed, internal whitespace collapsed,
+  upper-cased.
+- A value is usable when, with surrounding whitespace removed, it is non-empty and at most
+  `MANUFACTURER_PART_NUMBER_MAX_LENGTH` characters. An unusable row is passed over and the walk
+  continues; it does not end the search.
+- Returns the value with surrounding whitespace removed and nothing else altered.
+- Returns `None` when no row qualifies, including when `specifications` is empty.
+- **Pure.** No I/O, no request, no database, no mutation of `self`. Safe to call from a template
+  and safe to call more than once per request.
+
+### Module constants (new, `app/models.py`)
+
+```python
+PART_NUMBER_ROW_NAMES = (
+    'MANUFACTURER PART NUMBER',
+    'MFR PART NUMBER',
+    'PART NUMBER',
+    'MODEL NUMBER',
+    'ITEM MODEL NUMBER',
+)
+
+MANUFACTURER_PART_NUMBER_MAX_LENGTH = 100
+```
+
+- `PART_NUMBER_ROW_NAMES` is a **tuple**, because order is the specification (FR-002), and its
+  entries are stored already normalized so they compare directly against `normalized_row_name(...)`.
+  A test asserts each entry is its own normalized form, so a typo cannot make one permanently
+  unmatchable.
+- `MANUFACTURER_PART_NUMBER_MAX_LENGTH` mirrors the `String(100)` at `app/database.py:838`. It
+  carries a comment naming that line. It does **not** replace the existing `maxlength="100"`
+  attributes in the two templates; see [research.md](./research.md) §4.
+
+### `normalized_row_name` (new, `app/models.py`)
+
+```python
+def normalized_row_name(name: Optional[str]) -> str:
+    """A specification row's name, folded for comparison against a fixed list."""
+```
+
+Trims, collapses internal whitespace runs, upper-cases. Lifted verbatim from the body of
+`_is_barcode_row_name` (`app/catalog_service.py:2541`), which is rewritten to call it. **Two
+callers, one implementation** — FR-001. `app/catalog_service.py` already imports from `.models`, so
+no new dependency edge is created.
+
+Do not merge this with `_fold` (`app/catalog_service.py:2536`). They answer different questions and
+`_fold` deliberately does not collapse internal whitespace; see [research.md](./research.md) §2.
+
+## State and lifecycle
+
+None. The derived value has no lifecycle: it exists for the duration of one render, and is either
+submitted by the operator or it is not. Nothing records that a stored part number was derived rather
+than typed, and nothing downstream may treat a derived one differently — it is a default, not an
+assertion.
+
+## Validation rules
+
+| Rule | Source | Where enforced |
+|---|---|---|
+| Recognized names, folded, in priority order | FR-001, FR-002 | `PART_NUMBER_ROW_NAMES` + `normalized_row_name` |
+| Non-empty after trimming | FR-003 | `ListingCapture.manufacturer_part_number` |
+| At most 100 characters | FR-003 | `ListingCapture.manufacturer_part_number` |
+| Trimmed, otherwise unaltered | FR-004 | `ListingCapture.manufacturer_part_number` |
+| Operator's value wins; empty counts as a value, absent does not | FR-005 | `app/product/routes.py`, `product_capture` POST |
+| Redisplay what was submitted, not the default | FR-006 | `app/templates/product/capture.html`, presence test |
+| Capture form only | FR-010 | Nothing added to `_form_product_fields`; `_form_fields.html` untouched |
+
+No new exception type. Nothing here can fail: an unusable row yields `None`, and `None` is the
+ordinary case for every capture that carries no part-number row (FR-009).

--- a/specs/019-capture-mpn-default/plan.md
+++ b/specs/019-capture-mpn-default/plan.md
@@ -1,0 +1,191 @@
+# Implementation Plan: The Captured Listing Fills In the Manufacturer Part Number
+
+**Branch**: `issues/90` | **Date**: 2026-08-18 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/019-capture-mpn-default/spec.md`
+
+## Summary
+
+A capture reads the vendor's product-information rows, displays them, and then leaves the
+Manufacturer Part Number field blank even when one of those rows is the part number. This feature
+derives a default for that field from the rows themselves.
+
+The whole of it is one method on `ListingCapture`, one constant tuple of five recognized names in
+priority order, one shared name-folding helper lifted out of the existing barcode-row matcher, one
+Jinja expression changed from a truthiness test to a presence test, and three lines in the capture
+route joining the field to the absent-versus-empty fallback that `manufacturer` and `unit_price`
+already use.
+
+No migration. No new endpoint. No payload version bump. No new dependency. No JavaScript.
+
+## Technical Context
+
+**Language/Version**: Python 3.13
+
+**Primary Dependencies**: Flask 3.1.x, Jinja2, SQLAlchemy 2.0.x — all already present. **Nothing is
+added.**
+
+**Storage**: MariaDB via the existing `Storage` ABC. **No schema change**; see
+[data-model.md](./data-model.md).
+
+**Testing**: `nox -s tests` (unit, network blocked, sub-second), `nox -s e2e` (Playwright, 15-minute
+timeout required), `nox -s screenshots_headless` + `screenshots_verify`. The capture page **is**
+screenshotted — `tests/e2e/test_screenshot_generation.py::test_screenshot_order_capture` writes
+`docs/images/screenshots/user-manual/order_capture.png`, which 018 regenerated for the same reason.
+It is not in `screenshot_config.yaml`; that file drives a different set.
+
+**Target Platform**: Flask app on a home LAN, single trusted operator, server-rendered Bootstrap 5 UI.
+
+**Project Type**: Web application, server-rendered. No frontend build step and none introduced.
+
+**Performance Goals**: Unchanged. The derivation is five passes over roughly twenty-five in-memory
+dict entries, on a request that already spends eight to fifteen seconds retrieving a gallery. SC-007
+asks that capture time not move, and nothing here can move it.
+
+**Constraints**: The derived value must never exceed what
+`Product.manufacturer_part_number` can store (`String(100)`, `app/database.py:838`), and must never
+be truncated to fit — see [research.md](./research.md) §4.
+
+**Scale/Scope**: Four source files, one template, three test files, one test fixture, one
+screenshot, one documentation paragraph. Roughly 60 lines of application code including docstrings.
+
+## Constitution Check
+
+*GATE: passed before Phase 0. Re-checked after Phase 1 — see below.*
+
+| Principle | Assessment |
+|---|---|
+| **I. Simplicity First** (NON-NEGOTIABLE) | **Pass.** One method, two constants, one moved helper. No new module, no new class, no interface, no configuration knob. The two rejected designs — a payload field emitted by the capture agent, and a computed value threaded to four render sites — were both rejected on this principle and the reasoning is recorded in [research.md](./research.md) §1 and §5. The one thing that *looks* like generality, extracting `normalized_row_name`, is required by FR-001 and has two real callers on day one. |
+| **II. Layered Architecture Boundaries** | **Pass.** The derivation is domain logic and lives in `app/models.py`. The route stays thin: it reads a form field and picks a fallback, exactly as it already does for two other fields. No ORM query and no SQL is added anywhere. `app/catalog_service.py` already imports from `.models`, so the new helper creates no new dependency edge and no inversion. |
+| **III. Exact Numerics** | **Not engaged.** A part number is an opaque string. No measurement, no arithmetic, no `float`. |
+| **IV. Test Discipline Through Nox** | **Pass.** Unit tests through `tests/conftest.py`'s fixtures, network blocked, nothing mocked because nothing makes a request. E2E waits are `expect(...).to_have_value(...)` on a server-rendered form — `CLAUDE.md` Pattern C, render-implies-completion — with no fixed wait anywhere. No new pytest marker. Both suites must be green before merge. |
+| **V. MariaDB Is the Source of Truth** | **Pass, vacuously.** No schema change and therefore no Alembic revision. If a revision appears in the diff, the plan has been misread. |
+| **VI. Item Lifecycle and History Invariants** | **Not engaged.** This touches the product catalog, not inventory items. No JA ID, no active-row filtering, no shortening history. |
+| **Operating Context / Threat Model** | **Not engaged.** No auth, no new input surface, no sanitization. The field already exists and is already operator-editable; this changes only what it arrives holding. Validation here serves correctness — a value the database cannot store — not defense. |
+| **Technology Constraints** | **Pass.** No new dependency. Type hints on both new public callables. No new error machinery: an unusable row returns `None`, which is the ordinary case. Server-rendered Jinja, no framework. |
+| **Development Workflow** | **Pass.** Feature branch `issues/90`, merged by PR. `app/templates/product/capture.html` is edited, so the screenshot gate applies and regeneration is a planned task, not an afterthought. |
+
+**Violations requiring justification**: none. The Complexity Tracking table below is empty and should
+stay that way.
+
+### Post-Phase-1 re-check
+
+Re-evaluated after `data-model.md`, `contracts/` and `quickstart.md` were written. The design did not
+grow: still one method, two constants, one moved function, one template expression, three route
+lines. Two things were *removed* from the initial sketch during Phase 0 and are worth recording as
+simplicity wins:
+
+- A route-level helper computing the field's value and passing it to the template at four render
+  sites. The presence test in the template does the same job with no route change
+  ([research.md](./research.md) §5).
+- Conditioning the default on whether the merge kept the row, by analogy with 016. It would require
+  running a write path from a render path to answer a question the operator can see the answer to
+  ([research.md](./research.md) §6).
+
+**Still no violations.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/019-capture-mpn-default/
+├── spec.md               # /speckit-specify output (amended in Phase 0 — see research.md §4)
+├── plan.md               # This file
+├── research.md           # Phase 0 output
+├── data-model.md         # Phase 1 output
+├── quickstart.md         # Phase 1 output
+├── contracts/
+│   └── README.md         # Phase 1 output — internal surface, no HTTP change
+├── checklists/
+│   └── requirements.md   # /speckit-specify output
+└── tasks.md              # NOT created by /speckit-plan
+```
+
+### Source Code (repository root)
+
+Five files. Nothing else should appear in the diff.
+
+```text
+app/
+├── models.py                        # + normalized_row_name, + PART_NUMBER_ROW_NAMES,
+│                                    #   + MANUFACTURER_PART_NUMBER_MAX_LENGTH,
+│                                    #   + ListingCapture.manufacturer_part_number
+├── catalog_service.py               # ~ _is_barcode_row_name calls the moved helper. Nothing else.
+├── product/routes.py                # ~ product_capture: the absent-versus-empty fallback
+└── templates/product/capture.html   # ~ one input's value expression: presence, not truthiness
+
+tests/
+├── unit/test_capture.py             # + the derivation, the prefill, the re-render, the fallback.
+│                                    #   This is where every capture unit test already lives; see
+│                                    #   TestTheListingPayload, TestTheListingFillsTheForm,
+│                                    #   TestThePayloadSurvivesAQuestion, TestWhichRowNamesMeanABarcode
+├── e2e/test_product_page_capture.py # + end to end through the bookmarklet
+└── e2e/fixtures/amazon_listing.html # + a part-number row (it has a UPC row today, and no MPN row)
+
+docs/
+├── user-manual.md                   # ~ the "what the bookmarklet reads" list gains the part number
+└── images/screenshots/user-manual/order_capture.png   # regenerated
+```
+
+**Structure Decision**: no new modules and no new packages. The feature is placed by asking where
+each part of it belongs under Principle II, and every answer was an existing file. The derivation is
+a fact about a `ListingCapture`, so it goes on `ListingCapture` in the domain layer; the fallback is
+a route concern and joins two identical fallbacks already written three lines above it; the
+redisplay rule is a display concern and is one Jinja expression.
+
+## Approach
+
+### Phase A — the shared fold (foundational, no behavior change)
+
+Move the body of `_is_barcode_row_name` into `normalized_row_name` in `app/models.py` and have
+`_is_barcode_row_name` call it. `tests/unit/test_capture.py` must stay green **untouched**; that is
+the check that the move was verbatim. Nothing observable changes.
+
+### Phase B — the derivation (US1, US3)
+
+`PART_NUMBER_ROW_NAMES`, `MANUFACTURER_PART_NUMBER_MAX_LENGTH` and
+`ListingCapture.manufacturer_part_number` in `app/models.py`, with unit tests in
+`tests/unit/test_capture.py` beside `TestTheListingPayload`, which is where `ListingCapture`'s
+existing tests live. Still nothing observable — no caller yet. At the end of this phase the whole of
+FR-001 through FR-004 is proven, in under a second, with no app and no browser.
+
+### Phase C — the render (US1)
+
+The presence test in `app/templates/product/capture.html`. This is the point at which the feature
+becomes visible, and it delivers US1 and US3 on its own: the field arrives filled on both first-render
+paths. Route tests cover each render path.
+
+### Phase D — the write (US2)
+
+The absent-versus-empty fallback in `product_capture`. This closes FR-005 for a POST that carries the
+payload and no field. Note that US2's *user-facing* half — a typed or cleared value winning — is
+already true after Phase C, because the form submits what it displays; Phase D covers the submission
+that omits the field entirely.
+
+### Phase E — end to end, screenshots, docs
+
+The user-manual sentence, the full suites, the screenshot regeneration, a diff review against the
+file list above, and a by-hand pass against `B0CZ72JRHP` and `B0FX4PDW6M`.
+
+The E2E fixture row and the E2E tests are **not** here — task generation moved them into the story
+phases they prove, so each story is independently demonstrable end to end rather than only at the
+end. See [tasks.md](./tasks.md).
+
+Phases A→B→C are strictly ordered. D depends only on B. E depends on C and D.
+
+## Risks and how they are bounded
+
+| Risk | Bound |
+|---|---|
+| The moved fold silently changes barcode-row matching | `tests/unit/test_capture.py` is not edited. If it goes red, the move was not verbatim. |
+| `manufacturer` or the unit price get "fixed" in passing | Explicitly out of scope by a spec assumption, called out in [contracts/README.md](./contracts/README.md), and a reviewable diff rule: those two hunks must not appear. |
+| A too-clever unification of `normalized_row_name` and `_fold` | They answer different questions; `_fold` deliberately does not collapse internal whitespace. [research.md](./research.md) §2. |
+| Screenshot churn swamping the diff | Regenerate, then inspect what actually differs and commit only the images whose content moved. |
+| Scope creep into a one-off sweep over already-captured products | Out of scope by a spec assumption. This feature writes nothing on its own; it fills a form field. |
+
+## Complexity Tracking
+
+> Fill ONLY if Constitution Check has violations that must be justified.
+
+**No violations.** Table intentionally empty.

--- a/specs/019-capture-mpn-default/quickstart.md
+++ b/specs/019-capture-mpn-default/quickstart.md
@@ -1,0 +1,123 @@
+# Quickstart: The Captured Listing Fills In the Manufacturer Part Number
+
+**Feature**: `specs/019-capture-mpn-default` | **Date**: 2026-08-18
+
+How to prove this feature works, from a clean checkout. Commands assume the repository
+virtualenv and the repository root as the working directory.
+
+## Prerequisites
+
+```bash
+export PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"   # nox needs 3.13 on PATH
+venv/bin/nox --list                                      # sanity check
+```
+
+Docker must be running for `e2e` (MariaDB) and for `screenshots_headless`.
+
+## 1. The rule itself — no app, no database, no browser
+
+This is the payoff of putting the derivation on `ListingCapture`: the whole of FR-001 through FR-004
+is checkable in under a second.
+
+```bash
+venv/bin/nox -s tests -- tests/unit/test_capture.py -k part_number
+```
+
+**Expected**: green, and fast. Covers each recognized name, priority order beating page order, the
+internal-whitespace fold, empty and whitespace-only values passed over, the 100-character ceiling,
+and a listing with no rows returning `None`.
+
+Sanity-check it by hand if you want to see it:
+
+```bash
+venv/bin/python -c "
+from app.models import ListingCapture
+listing = ListingCapture(
+    source_url='https://example.invalid/dp/B0CZ72JRHP',
+    specifications=[
+        {'name': 'Model Number', 'value': 'MKT-7700'},
+        {'name': 'Mfr  Part Number', 'value': '  7700-B  '},
+    ],
+)
+print(repr(listing.manufacturer_part_number()))
+"
+```
+
+**Expected**: `'7700-B'` — the higher-priority name wins even though it is second on the page, and
+the internal double space in the row's name does not stop it matching.
+
+## 2. The route rules — absent versus empty, and redisplay
+
+```bash
+venv/bin/nox -s tests -- tests/unit/test_capture.py -k 'part_number and (form or cleared)'
+```
+
+**Expected**: green. Covers FR-005 (a POST carrying the payload and no field falls back to the
+derived value; a POST carrying an empty field does not) and FR-006 (a re-render after a capture
+question redisplays a cleared field as cleared).
+
+## 3. The whole unit suite
+
+```bash
+venv/bin/nox -s tests
+```
+
+**Expected**: green, in about a second, with the network blocked. `TestWhichRowNamesMeanABarcode`
+(`tests/unit/test_capture.py:1762`) must pass **untouched** — `normalized_row_name` is a verbatim
+move out of `_is_barcode_row_name`, so any change in barcode-row behavior means the move was not
+verbatim.
+
+## 4. End to end, through the bookmarklet
+
+```bash
+# 15-minute timeout required (Constitution IV); run detached, it outlasts a 10-minute cap
+nohup venv/bin/nox -s e2e > /tmp/e2e.log 2>&1 &
+```
+
+Or just this feature's tests, which is what you want while iterating:
+
+```bash
+venv/bin/nox -s e2e -- tests/e2e/test_product_page_capture.py -k part_number
+```
+
+**Expected**: the fixture listing (`tests/e2e/fixtures/amazon_listing.html`, which gains a
+part-number row for this feature) is captured through the bookmarklet, and the confirmation form's
+Manufacturer Part Number field already holds the fixture's value with nothing typed into it.
+Submitting stores it; clearing it first stores nothing.
+
+## 5. Screenshots
+
+`app/templates/product/capture.html` is edited, so the constitution's screenshot gate applies.
+
+```bash
+venv/bin/nox -s screenshots_headless
+git status --short docs/images/screenshots/
+venv/bin/nox -s screenshots_verify
+```
+
+**Expected**: `screenshots_verify` passes, and
+`docs/images/screenshots/user-manual/order_capture.png` shows the confirmation form. That is the
+capture page's screenshot — 018 regenerated the same file when it last edited this template.
+Screenshots churn on every run regardless of the change, so inspect what actually differs and commit
+only `order_capture.png` plus anything whose content genuinely moved — not the whole directory.
+
+## 6. By hand, against the two listings from the issue
+
+The end this feature was built for. Requires the app served over TLS for the bookmarklet, per
+`tests/e2e/test_product_page_capture.py`'s module docstring.
+
+1. Open `https://www.amazon.com/dp/B0CZ72JRHP` and run the bookmarklet.
+2. On the confirmation page, **Manufacturer Part Number is already filled** — this is SC-001.
+3. Scroll to the product information rows: the row it came from is still listed (SC-005).
+4. Clear the field and submit. The product stores no part number (SC-003).
+5. Repeat with `https://www.amazon.com/dp/B0FX4PDW6M`.
+
+## Failure signatures worth recognizing
+
+| Symptom | Almost certainly |
+|---|---|
+| Field is empty on a listing that has the row | The name is not in `PART_NUMBER_ROW_NAMES` in its normalized form. Print `normalized_row_name(row['name'])` and compare. |
+| Field refills itself after you clear it and the capture asks a question | The template is testing truthiness (`or`) instead of key presence. That is FR-006. |
+| `manufacturer` or the unit price changed behavior | Out of scope and must not be in the diff. Revert that hunk. |
+| Barcode-row tests fail | `normalized_row_name` was not a verbatim move. Diff it against the old `_is_barcode_row_name` body. |
+| A capture fails at the end with a data-too-long error | The length ceiling is missing or is being applied before trimming (FR-003). |

--- a/specs/019-capture-mpn-default/quickstart.md
+++ b/specs/019-capture-mpn-default/quickstart.md
@@ -20,7 +20,8 @@ This is the payoff of putting the derivation on `ListingCapture`: the whole of F
 is checkable in under a second.
 
 ```bash
-venv/bin/nox -s tests -- tests/unit/test_capture.py -k part_number
+venv/bin/nox -s tests -- tests/unit/test_capture.py \
+  -k 'TestThePartNumberTheListingNames or TestWhichRowNamesMeanAPartNumber'
 ```
 
 **Expected**: green, and fast. Covers each recognized name, priority order beating page order, the
@@ -49,12 +50,16 @@ the internal double space in the row's name does not stop it matching.
 ## 2. The route rules — absent versus empty, and redisplay
 
 ```bash
-venv/bin/nox -s tests -- tests/unit/test_capture.py -k 'part_number and (form or cleared)'
+venv/bin/nox -s tests -- tests/unit/test_capture.py \
+  -k 'TestThePartNumberFillsTheForm or TestAClearedPartNumberStaysCleared'
 ```
 
-**Expected**: green. Covers FR-005 (a POST carrying the payload and no field falls back to the
-derived value; a POST carrying an empty field does not) and FR-006 (a re-render after a capture
-question redisplays a cleared field as cleared).
+**Expected**: 11 tests, green. Covers FR-002 at each render path, FR-005 (a POST carrying the
+payload and no field falls back to the derived value; a POST carrying an empty field does not) and
+FR-006 (a re-render after a capture question redisplays a cleared field as cleared).
+
+`test_a_cleared_field_comes_back_cleared` is the one that earns its keep: rewrite the template's
+expression as `form_data.get(...) or ...` and it is the **only** test in the suite that fails.
 
 ## 3. The whole unit suite
 
@@ -77,7 +82,8 @@ nohup venv/bin/nox -s e2e > /tmp/e2e.log 2>&1 &
 Or just this feature's tests, which is what you want while iterating:
 
 ```bash
-venv/bin/nox -s e2e -- tests/e2e/test_product_page_capture.py -k part_number
+venv/bin/nox -s e2e -- tests/e2e/test_product_page_capture.py \
+  -k 'part_number or repeat_buy or hand_edited or passed_over'
 ```
 
 **Expected**: the fixture listing (`tests/e2e/fixtures/amazon_listing.html`, which gains a
@@ -95,11 +101,17 @@ git status --short docs/images/screenshots/
 venv/bin/nox -s screenshots_verify
 ```
 
-**Expected**: `screenshots_verify` passes, and
-`docs/images/screenshots/user-manual/order_capture.png` shows the confirmation form. That is the
-capture page's screenshot — 018 regenerated the same file when it last edited this template.
-Screenshots churn on every run regardless of the change, so inspect what actually differs and commit
-only `order_capture.png` plus anything whose content genuinely moved — not the whole directory.
+**Expected**: `screenshots_verify` passes, and — measured on 2026-08-18 — **`order_capture.png` does
+not change**, while nine unrelated images do.
+
+That is the correct outcome, not a missed step. The template edit adds a Jinja comment (which renders
+nothing) and an expression that yields the same empty string in the screenshot's scenario, because
+that scenario has no listing to derive from. The visible change only appears on a capture that
+carries product-information rows, which no screenshot does. The nine that moved — add item, search,
+history, move, shorten, product detail — are the run-to-run churn, a few hundred bytes each on pages
+this feature does not touch, and `metadata.json` differs only in timestamps.
+
+**So this feature commits no screenshot.** Revert them: `git checkout -- docs/images/screenshots/`.
 
 ## 6. By hand, against the two listings from the issue
 

--- a/specs/019-capture-mpn-default/research.md
+++ b/specs/019-capture-mpn-default/research.md
@@ -1,0 +1,273 @@
+# Phase 0 Research: The Captured Listing Fills In the Manufacturer Part Number
+
+**Feature**: `specs/019-capture-mpn-default` | **Date**: 2026-08-18
+
+Everything this feature needs already exists. The research below is therefore not about picking
+technologies — it is about locating the one place the rule belongs and pricing the three details
+that are not obvious from the spec: what "whitespace-insensitive" already means in this codebase,
+what actually goes wrong with an over-long value, and how a cleared field survives a re-render.
+
+---
+
+## 1. Where the rule lives
+
+**Decision**: a method on `ListingCapture` in `app/models.py`:
+
+```python
+def manufacturer_part_number(self) -> Optional[str]
+```
+
+**Rationale**:
+
+- It is a fact derived from the listing and nothing else. No storage, no session, no request. That
+  makes it a domain question, and Principle II puts domain logic in `app/models.py`.
+- Every place that needs it already holds a `ListingCapture`: all four render sites and the one
+  write path in `app/product/routes.py` either receive or parse one. Nothing has to be plumbed.
+- It is unit-testable with no app, no database, no browser and no fixture — which is the concrete
+  cash value of the issue's "keeps the rule in Python where it is testable without a browser".
+- One rule, both paths, satisfying FR-007 by construction rather than by discipline.
+
+**Alternatives considered**:
+
+| Option | Rejected because |
+|---|---|
+| In `app/static/js/capture-agent.js`, emitting a `manufacturer_part_number` on the payload | The issue considered and set this aside. It also costs a `LISTING_CAPTURE_VERSION` bump — `from_json` refuses a payload whose version it does not recognize, so every operator with a cached bookmarklet silently captures with no payload at all until they re-drag it. A payload field is a poor trade for a value derivable from a field already in the payload. |
+| A function or method on `CatalogService` | Mixes a pure derivation into the class that owns the database session, and forces `routes.py` to import a module-level function from a service module — a shape the file does not currently use. |
+| In the Jinja template | The priority walk is five names deep with two per-row conditions. Written in Jinja it is unreadable and only testable through a browser, which is the opposite of what the issue asked for. |
+| In `app/product/routes.py` as a private helper | Testable, but it is domain logic in the route layer, and it would have to be called from four render sites instead of being reachable from the one `listing` variable each already has. |
+
+---
+
+## 2. What "case- and whitespace-insensitive" already means here
+
+**Decision**: reuse the existing row-name normalization, extracted so both callers share it.
+
+`app/catalog_service.py:2541` already answers this question for the barcode names:
+
+```python
+def _is_barcode_row_name(name):
+    return ' '.join((name or '').split()).upper() in BARCODE_ROW_NAMES
+```
+
+`' '.join(s.split())` trims **and collapses internal runs**, so `Mfr  Part   Number` folds to
+`MFR PART NUMBER`. That is stronger than the spec's descriptive parenthetical ("ignoring surrounding
+whitespace") and is exactly what issue #90 asked for. FR-001's operative clause is the reuse
+requirement — "MUST use the same name-folding rule the recognized barcode names already use" — so
+the stronger rule governs and the spec's parenthetical is the loose description of it, not a second
+specification.
+
+**Implementation**: move the normalization into `app/models.py` as
+
+```python
+def normalized_row_name(name: Optional[str]) -> str
+```
+
+and have `_is_barcode_row_name` call it. `app/catalog_service.py` already imports from `.models`
+(line 38), so the dependency direction is the one that exists. This is the whole of FR-001's "a
+second folding implementation MUST NOT be introduced": one function, two callers, no new concept.
+
+**Note on the comparison itself.** `_is_barcode_row_name` upper-cases; `_fold` (same file, line
+2536) case-*folds* and does not collapse. They are different tools for different jobs —
+`_is_barcode_row_name` matches against a fixed list of ASCII names, `_fold` compares two arbitrary
+operator-supplied strings — and this feature uses the first. Do not unify them; that is a refactor
+this feature does not need and Principle I forbids on spec.
+
+**Alternatives considered**: a per-feature `PART_NUMBER_ROW_NAMES` matcher with its own inline
+folding. Rejected by FR-001, and it is how two lists drift apart.
+
+---
+
+## 3. Priority order, and how ties resolve
+
+**Decision**: a module-level tuple of already-normalized names in priority order, walked outer, with
+the listing's rows walked inner.
+
+```python
+PART_NUMBER_ROW_NAMES = (
+    'MANUFACTURER PART NUMBER',
+    'MFR PART NUMBER',
+    'PART NUMBER',
+    'MODEL NUMBER',
+    'ITEM MODEL NUMBER',
+)
+```
+
+**Rationale**: walking the names outer gives FR-002's two rules for free and without a comparison
+key — priority is by position in this tuple, never by position on the vendor's page, and among rows
+sharing a name the first in captured order wins because that is the order the inner walk visits
+them. The cost is five passes over a list that is about twenty-five entries long, on a request that
+already spends eight to fifteen seconds retrieving images. There is nothing here to optimize
+(Principle I).
+
+**A tuple, not a frozenset**, unlike `BARCODE_ROW_NAMES` — order is the point here and is not there.
+The names are stored pre-normalized so the tuple is compared against `normalized_row_name(...)`
+directly; a test asserts each entry is its own normalized form, so a typo cannot make an entry
+permanently unmatchable.
+
+**Alternatives considered**: one pass over the rows keeping the best-priority match seen so far.
+Same result, needs an index lookup and a "best so far" variable, and gets the tie rule wrong unless
+the comparison is written as strictly-better. More code for nothing.
+
+---
+
+## 4. What actually goes wrong with an over-long value
+
+**Decision**: refuse a candidate longer than 100 characters and continue down the list (FR-003).
+Define `MANUFACTURER_PART_NUMBER_MAX_LENGTH = 100` in `app/models.py`.
+
+**This was researched because the spec's first draft had the failure mode wrong**, and the
+correction is worth recording. The initial reasoning was that `maxlength="100"` on the input would
+put an over-long rendered value into the `tooLong` state and block submission with a browser bubble
+naming no field — the silent-submission failure `CLAUDE.md` documents. That is not what happens:
+HTML's `tooLong` constraint applies only once the control's dirty value flag is set, i.e. after the
+*user* edits it. A value the server rendered is not too long as far as constraint validation is
+concerned.
+
+What happens instead is worse. Nothing in the stack checks the length — `_clean`
+(`app/catalog_service.py:2513`) strips and nothing else, and there is no length validation anywhere
+in `catalog_service.py`. So the over-long value submits, `capture_order` runs, images are retrieved,
+and the write fails on `Product.manufacturer_part_number` — `String(100)` at
+`app/database.py:838` — with a data-too-long error at the end of a fifteen-second operation, over a
+value the operator never typed. Refusing to manufacture a value the database cannot hold is the
+whole of the ceiling's justification.
+
+**Why a named constant rather than reading the column width**: reaching into
+`Product.__table__.columns['manufacturer_part_number'].type.length` from `app/models.py` would make
+the domain layer import the ORM layer, inverting Principle II's dependency direction, to save one
+integer. A named constant carrying a comment that points at `app/database.py:838` is the boring
+option, and boring is the instruction.
+
+**Why not truncate to fit**: a truncated part number is a wrong part number, and a wrong one
+corroborates a later repeat buy against the wrong product (`_corroborates`,
+`app/catalog_service.py:2574`). FR-003 says so explicitly.
+
+**Scope note**: this adds one constant. It does not touch `app/database.py`, and it does not touch
+the `maxlength="100"` attributes in `app/templates/product/capture.html` or
+`app/templates/product/_form_fields.html`. Three existing statements of 100 stay as they are;
+sweeping them into one constant is a refactor with no bug behind it.
+
+---
+
+## 5. How a cleared field survives, and why the presence test is the whole trick
+
+**Decision**: the template tests **presence of the key**, not truthiness of the value.
+
+```jinja
+value="{{ form_data['manufacturer_part_number']
+          if 'manufacturer_part_number' in form_data
+          else (listing.manufacturer_part_number() or '' if listing else '') }}"
+```
+
+**Rationale**: this single expression satisfies FR-002, FR-005 and FR-006 across all four render
+sites, because of what `form_data` actually is at each of them:
+
+| Render site | `form_data` | Key present? | Result |
+|---|---|---|---|
+| `api_capture`, bookmarklet lands (`routes.py:673`) | a literal dict of five keys | no | derived default (FR-002) |
+| `product_capture` GET (`routes.py:499`) | `request.args` | no | derived default; `listing` is usually `None` here anyway |
+| `product_capture`, capture asks a question (`routes.py:451`) | `request.form` | yes | what the operator submitted, empty included (FR-006) |
+| `product_capture`, validation refused (`routes.py:461`) | `request.form` | yes | same |
+
+The confirmation form always submits the field, so on any re-render the key is present and the
+operator's decision — including the decision to empty it — is what redisplays. On any first render
+the key is absent and the listing fills it. No flag, no extra template variable, no route change at
+any render site.
+
+**This is deliberately not what the adjacent fields do.** `manufacturer` (`capture.html:154`) and
+the unit price use `form_data.get(...) or <listing value>`, and `''` is falsy, so they re-apply
+their default over a field the operator cleared. Their *write* path is already correct — `routes.py`
+draws the absent-versus-empty distinction explicitly at lines 415–421, with a comment explaining it
+— so the wart is confined to redisplay after a question. Spec assumption: bringing those two into
+line is a separate change against a separate issue. **The diff for this feature must not touch
+those two fields.**
+
+**On the write path**, this feature copies the existing pattern exactly rather than inventing one:
+
+```python
+manufacturer_part_number = request.form.get('manufacturer_part_number')
+if listing is not None and manufacturer_part_number is None:
+    manufacturer_part_number = listing.manufacturer_part_number()
+```
+
+which is FR-005, and is the same three lines already written for `manufacturer` and `unit_price`
+directly above.
+
+**Alternatives considered**: computing the field's final value in the route and passing it to the
+template. Equivalent, more testable in isolation — and it needs the same helper called at four
+render sites, four keyword arguments added, and a new template variable, to replace an expression
+that is already only a presence test. Rejected on Principle I.
+
+---
+
+## 6. Why this feature does *not* copy 016's added-rows rule
+
+016 (promote a captured barcode to an identifier) promotes only rows the merge actually **added**
+to the product, and reports the ones it dropped. This feature deliberately does not condition on the
+merge at all.
+
+The difference is that 016 writes to the catalog unattended, so a value that is not visible in the
+specification list must not become an identifier nobody can see the source of. This feature writes
+nothing — it fills a form field, in front of the operator, before they confirm. The row it came from
+is on the same screen either way. Conditioning a *form default* on a merge outcome that has not
+happened yet would also require running the merge to decide what to render, which is a write path
+called from a render path.
+
+**Consequence, and it is correct**: a capture onto a product that already carries a `Model Number`
+row still offers that row's value as the default, even though the merge will drop the captured row.
+The value shown is the value the listing published, which is what the operator is being asked about.
+
+---
+
+## 7. The JSON representation of `/api/capture` is out of scope
+
+`api_capture` writes when its body is JSON (`routes.py:695`), and it calls `capture_order` **without
+a `listing`** — the JSON representation has no product information rows to derive from. There is
+therefore nothing to apply and no change to make there. FR-007's "single shared rule" is satisfied:
+the rule is on `ListingCapture`, and any caller that acquires one gets it. Adding a derivation to a
+call site that has no listing would be speculative generality.
+
+---
+
+## 8. Test approach
+
+**Unit** — all of it in `tests/unit/test_capture.py`, which is where every capture test already
+lives, including `ListingCapture`'s own (`TestTheListingPayload`, line 952). `test_models.py` holds
+dimensions, threads and enums and is the wrong file; `test_product_routes.py` is about reaching a
+product by its code. Four new classes, each sited next to its nearest relative:
+
+| New class | Sits beside | Covers |
+|---|---|---|
+| `TestWhichRowNamesMeanAPartNumber` | `TestWhichRowNamesMeanABarcode` (1762) | FR-001, and the guard that every `PART_NUMBER_ROW_NAMES` entry is its own normalized form |
+| `TestThePartNumberTheListingNames` | `TestTheListingPayload` (952) | FR-002 through FR-004 — priority beats page order, ties, the fold, empty values, the length ceiling. No app, no database. |
+| `TestThePartNumberFillsTheForm` | `TestTheListingFillsTheForm` (1064) | FR-002 and FR-005 at the route: prefill on each render path, absent-versus-empty on the write |
+| `TestAClearedPartNumberStaysCleared` | `TestThePayloadSurvivesAQuestion` (1579) | FR-006, the re-render |
+
+Existing fixtures (`tests/conftest.py`: `test_storage` → `app` → `client`) cover all of it; the unit
+suite runs with the network blocked and nothing here makes a request.
+
+**E2E** — `tests/e2e/test_product_page_capture.py` against
+`tests/e2e/fixtures/amazon_listing.html`, which today carries a `UPC` row (line 120) and **no
+part-number row**. The fixture gains one, matching the real listings from the issue. Both pages
+involved are server-rendered, so `expect(locator).to_have_value(...)` is the whole wait — Pattern C
+in `CLAUDE.md`, render-implies-completion. No new page object is needed; the existing
+`capture_from_listing` / `confirm` helpers already reach the confirmation form.
+
+**Screenshots** — `app/templates/product/capture.html` is edited, so the constitution's screenshot
+gate applies. The capture page is genuinely screenshotted:
+`tests/e2e/test_screenshot_generation.py::test_screenshot_order_capture` writes
+`docs/images/screenshots/user-manual/order_capture.png`, and 018 regenerated exactly that file when
+it last touched this template. Note it is **not** listed in `tests/e2e/screenshot_config.yaml` —
+that file drives a different set, and grepping it for "capture" is how you talk yourself out of a
+gate that does apply.
+
+**Documentation** — `docs/user-manual.md:900` shows that screenshot, and the paragraph below it
+lists what the bookmarklet reads ("the price, the brand, the description, every *Product
+information* row, and every image..."). The part number joins that list.
+
+---
+
+## Resolved unknowns
+
+None outstanding. The spec carried no `[NEEDS CLARIFICATION]` markers, and every question this
+research opened is answered above. One spec correction came out of §4 and has been applied to
+`spec.md` (US3 rationale, US3 scenario 2, FR-003).

--- a/specs/019-capture-mpn-default/spec.md
+++ b/specs/019-capture-mpn-default/spec.md
@@ -137,6 +137,16 @@ value and whose next one has a real value. Confirm the field holds the second.
   recycled-identifier question depends on. So the derived default may be filled in, reviewed and
   then not stored. That is correct and unchanged by this feature; the field is still worth filling
   because the operator does not know at that moment which case they are in.
+- **A re-capture of the same listing stops asking the recycled-identifier question.** *(Found
+  during implementation, 2026-08-18.)* That question is raised when a capture lands on an identifier
+  an existing product already holds and its own evidence does not corroborate the match. The
+  evidence is the manufacturer **and** the part number together; both are required. The capture has
+  always supplied the manufacturer and never the part number, so the pair never corroborated and
+  every re-capture asked. Once the listing supplies both, a repeat buy of the same listing attaches
+  without being asked. This is a real behavior change beyond the field itself, it is the outcome US1
+  is named for, and it is what "the second half of the pair that lets a repeat buy attach without
+  asking" cashes out to. The duplicate-purchase question is untouched — no part number can answer
+  "did you order this twice today?".
 - **Two rows with the same recognized name.** Deduplicated before this feature sees them on the
   bookmarklet path; where a duplicate name does survive, the first one in the captured order wins.
 - **A row that names the vendor's part number rather than the manufacturer's.** `Part Number` is
@@ -213,6 +223,9 @@ value and whose next one has a real value. Confirm the field holds the second.
   including the row a default was derived from, in all of the above cases.
 - **SC-006**: A capture carrying no part-number-named row completes exactly as it does today, with
   no change to what is stored.
+- **SC-006a**: Capturing a listing whose product information names the part number, and then
+  capturing the same listing again, attaches to the existing product **without** raising the
+  recycled-identifier question — one question fewer per repeat buy than before this feature.
 - **SC-007**: Deriving the default adds no measurable time to a capture — no listing is read twice
   and no request is made.
 

--- a/specs/019-capture-mpn-default/spec.md
+++ b/specs/019-capture-mpn-default/spec.md
@@ -1,0 +1,251 @@
+# Feature Specification: The Captured Listing Fills In the Manufacturer Part Number
+
+**Feature Branch**: `issues/90`
+
+**Created**: 2026-08-18
+
+**Status**: Draft
+
+**Input**: GitHub issue #90 — "Capture: Manufacturer Part Number is left empty when the listing names one": *From the #80 verification pass, comment items 2 and 10. On `B0CZ72JRHP` and again on `B0FX4PDW6M`, the captured product-information rows include `Model Number` and `Mfr Part Number`, but the Manufacturer Part Number field on the confirmation page comes up blank and has to be typed in by hand. Derive a default for the field from the captured rows, matching on a small list of names, case- and whitespace-insensitive, in priority order — something like `Manufacturer Part Number`, `Mfr Part Number`, `Part Number`, `Model Number`, `Item model number`. First match wins; the row itself stays in the specification list either way. It is a default, not an assertion — the operator must still be able to clear or change it before capturing, and re-capture must not overwrite an edited value.*
+
+## Terminology
+
+- **Capture** — recording a purchase from a vendor listing, either through the bookmarklet (which
+  reads the vendor's page and hands the reading to this application) or by pasting the listing's
+  address into the capture form. Both paths end at the same confirmation form, and the write
+  happens when the operator submits it.
+- **Product information row** — one `name` / `value` pair the capture read out of the vendor's
+  product-details table. Stored on the product as a **specification row** and shown in the
+  product's specification list.
+- **Confirmation form** — the capture form the operator lands on with the listing's readings already
+  filled in, reviews, amends, and submits. It is where the capture is committed.
+- **Part-number-named row** — a product information row whose *name* is one of the recognized
+  part-number names listed in FR-001. Being part-number-named says nothing about whether the
+  *value* is usable.
+- **Derived default** — a value the application puts into a confirmation-form field because the
+  listing named it, rather than because the operator typed it. The existing Manufacturer and Unit
+  Price fields already work this way; this feature adds a third.
+- **Fills the blanks, never overwrites** — the rule the existing derived defaults follow: a value
+  the operator supplied wins over one the listing supplied, and a field the operator *cleared*
+  counts as supplied.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The part number the listing published is already in the field (Priority: P1)
+
+The operator captures a vendor listing whose product information names the manufacturer's part
+number. They land on the confirmation form and the Manufacturer Part Number field already holds it.
+They do not retype what the listing just told the application.
+
+**Why this priority**: This is the whole feature. The part number is the second half of the pair
+that lets a repeat buy attach to the existing product without asking, so a capture that leaves it
+blank costs a decision on every later purchase of the same thing — and it leaves it blank while
+displaying the answer two inches further down the page.
+
+**Independent Test**: Capture a listing whose product information carries a `Mfr Part Number` row.
+Confirm the Manufacturer Part Number field arrives holding that row's value, submit without touching
+it, and confirm the saved product carries it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a listing whose product information includes a row named `Manufacturer Part Number`
+   with a non-empty value, **When** the operator reaches the confirmation form, **Then** the
+   Manufacturer Part Number field holds that value.
+2. **Given** a listing whose product information includes a row named `Mfr Part Number`,
+   `Part Number`, `Model Number` or `Item model number` and no higher-priority name, **When** the
+   operator reaches the confirmation form, **Then** the Manufacturer Part Number field holds that
+   row's value.
+3. **Given** a listing carrying both `Model Number` and `Mfr Part Number`, **When** the operator
+   reaches the confirmation form, **Then** the field holds the `Mfr Part Number` value, because it
+   is higher in the priority order — regardless of which row came first on the vendor's page.
+4. **Given** a row name that differs only in letter case or surrounding whitespace from a recognized
+   name, **When** the operator reaches the confirmation form, **Then** it matches exactly as the
+   canonical spelling would.
+5. **Given** any of the above, **When** the operator submits, **Then** every captured row —
+   including the one the default came from — is still present in the product's specification list,
+   unchanged.
+6. **Given** a listing with no part-number-named row, **When** the operator reaches the confirmation
+   form, **Then** the field is empty and the capture behaves exactly as it does today.
+
+---
+
+### User Story 2 - The operator overrules the listing (Priority: P1)
+
+The listing's `Model Number` is the marketing model, not the manufacturer's part number, or the
+vendor simply has it wrong. The operator types the right one over it, or empties the field because
+there isn't one. What they decided is what gets captured.
+
+**Why this priority**: Equal in priority to US1 and inseparable from it. A default that cannot be
+overruled is an assertion, and an assertion built out of a name-guessing list will be wrong often
+enough to poison the field it was meant to fill — a wrong part number corroborates a repeat buy
+against the wrong product, which is worse than an empty one. The feature is only safe to ship with
+this half in place.
+
+**Independent Test**: Capture a listing that produces a derived default, replace the value with a
+different one, submit, and confirm the product carries the typed value. Repeat, clearing the field
+instead, and confirm the product carries no part number.
+
+**Acceptance Scenarios**:
+
+1. **Given** a confirmation form whose Manufacturer Part Number holds a derived default, **When**
+   the operator replaces it and submits, **Then** the product carries the operator's value and the
+   derived one appears nowhere but the specification row it came from.
+2. **Given** the same form, **When** the operator clears the field and submits, **Then** the product
+   carries no manufacturer part number — the derived default is not silently restored.
+3. **Given** the operator has replaced or cleared the field, **When** the capture comes back with a
+   question attached rather than completing, **Then** the field still shows what the operator
+   decided, not the derived default a second time.
+4. **Given** a submission that carries the listing but no Manufacturer Part Number field at all,
+   **When** the capture completes, **Then** the derived default is used — an absent field is not a
+   decision, and this is the same distinction the Manufacturer and Unit Price fields already draw.
+
+---
+
+### User Story 3 - A useless candidate is passed over (Priority: P3)
+
+Vendors put empty cells, whitespace and occasionally a paragraph into their product-details tables.
+A candidate that cannot be a part number is skipped rather than offered.
+
+**Why this priority**: Rare, and mostly its failure is visible rather than silent — but one of its
+forms is neither. A value longer than the manufacturer part number field's storage does **not** stop
+the form: the field's length attribute constrains typing, not a value the server rendered into it,
+so the over-long value submits, the capture does its work — including retrieving the gallery, which
+takes eight to fifteen seconds — and only then does the write fail on the column. The operator gets
+an error at the end of a long operation, over a value they never typed.
+
+**Independent Test**: Capture a listing whose highest-priority part-number-named row has an empty
+value and whose next one has a real value. Confirm the field holds the second.
+
+**Acceptance Scenarios**:
+
+1. **Given** a part-number-named row whose value is empty or only whitespace, **When** the operator
+   reaches the confirmation form, **Then** that row supplies no default and the search continues to
+   the next recognized name.
+2. **Given** a part-number-named row whose value is longer than the Manufacturer Part Number field
+   can store, **When** the operator reaches the confirmation form, **Then** that row supplies no
+   default, the search continues to the next recognized name, the capture completes, and the value
+   is still present as a specification row.
+3. **Given** a value with surrounding whitespace, **When** it becomes the default, **Then** the
+   whitespace is not carried into the field.
+
+---
+
+### Edge Cases
+
+- **The capture attaches to an existing product.** Capture does not write the manufacturer or the
+  part number onto a product that already exists — a mismatch there is the evidence the
+  recycled-identifier question depends on. So the derived default may be filled in, reviewed and
+  then not stored. That is correct and unchanged by this feature; the field is still worth filling
+  because the operator does not know at that moment which case they are in.
+- **Two rows with the same recognized name.** Deduplicated before this feature sees them on the
+  bookmarklet path; where a duplicate name does survive, the first one in the captured order wins.
+- **A row that names the vendor's part number rather than the manufacturer's.** `Part Number` is
+  ambiguous on some listings. It stays on the list because the operator reviews every default; see
+  the Assumptions.
+- **A listing that publishes only `Item model number`.** Amazon's usual name. It is last in the
+  order precisely because it is the loosest match, so any of the other four displaces it.
+- **A capture with no product information rows at all** — the pasted-address path, or a listing
+  whose details table the reading did not find. Nothing to derive from; the field is empty and
+  nothing about the capture changes.
+- **A capture that never completes.** Nothing is written, derived default included. The default
+  lives on the form, not in the catalog.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST recognize a product information row as part-number-named when its
+  name, compared case-insensitively and ignoring surrounding whitespace, is one of, in this priority
+  order: `Manufacturer Part Number`, `Mfr Part Number`, `Part Number`, `Model Number`,
+  `Item model number`. This MUST use the same name-folding rule the recognized barcode names
+  already use; a second folding implementation MUST NOT be introduced.
+- **FR-002**: When the operator has not supplied a manufacturer part number, the system MUST offer
+  the value of the highest-priority usable part-number-named row as the field's default. Priority is
+  by position in the FR-001 list, not by the row's position on the vendor's page. Where two rows
+  share the same recognized name, the first in captured order wins.
+- **FR-003**: A part-number-named row MUST be treated as usable only when its value, with
+  surrounding whitespace removed, is non-empty and no longer than the manufacturer part number can
+  be stored. An unusable row MUST be passed over and the search MUST continue down the FR-001 list.
+  The system MUST NOT offer a default it cannot store, and MUST NOT truncate one to fit.
+- **FR-004**: The system MUST store the derived default with surrounding whitespace removed, and
+  MUST NOT otherwise alter the row's value.
+- **FR-005**: A manufacturer part number the operator supplied MUST win over the derived default. An
+  **empty** submitted field counts as supplied — the operator cleared it — and MUST NOT be replaced
+  by the derived default. An **absent** field does not, and MUST fall back to the derived default.
+  This is the same absent-versus-empty rule the Manufacturer and Unit Price fields already follow.
+- **FR-006**: When a capture returns to the confirmation form with a question or a refusal rather
+  than completing, the field MUST redisplay what the operator last submitted — including an empty
+  field they cleared — and MUST NOT re-apply the derived default over it.
+- **FR-007**: The derived default MUST apply to both capture paths by a single shared rule, so that
+  any capture carrying product information rows gets it regardless of how the rows arrived.
+- **FR-008**: The system MUST leave every part-number-named row's ordinary handling untouched: no
+  row is filtered, hidden, moved or removed from the specification list on account of its name or
+  its use as a default.
+- **FR-009**: Deriving the default MUST NOT add any external request to a capture, MUST NOT fail a
+  capture, and MUST NOT change what is written when no part-number-named row is present.
+- **FR-010**: The derived default MUST apply to the capture confirmation form only. A part-number-
+  named row typed into the ordinary product create or edit form MUST NOT populate that form's
+  Manufacturer Part Number field.
+
+### Key Entities
+
+- **Product information row (specification row)**: a `name` / `value` pair read off a vendor listing
+  and stored on the product. Its handling is unchanged by this feature; it is the input to the
+  default, not the thing the default modifies.
+- **Manufacturer part number**: a field on the product, filled by the operator on the confirmation
+  form. This feature changes only what the field arrives holding — not where it is stored, not what
+  it means, and not the rule that capture never writes it onto an already-existing product.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Capturing `B0CZ72JRHP` and `B0FX4PDW6M` — the two listings that prompted the issue —
+  produces a confirmation form whose Manufacturer Part Number field is already filled from the
+  listing's own rows, with zero keystrokes typed into it.
+- **SC-002**: For a listing carrying a part-number-named row, the number of confirmation-form fields
+  the operator must fill by hand to record a manufacturer part number drops from one to zero.
+- **SC-003**: A capture whose Manufacturer Part Number the operator cleared stores no part number,
+  on the first submission and after a capture question, in 100% of cases.
+- **SC-004**: A capture whose Manufacturer Part Number the operator typed over stores the typed
+  value, not the derived one, in 100% of cases.
+- **SC-005**: Every captured row remains visible in the product's specification list after capture,
+  including the row a default was derived from, in all of the above cases.
+- **SC-006**: A capture carrying no part-number-named row completes exactly as it does today, with
+  no change to what is stored.
+- **SC-007**: Deriving the default adds no measurable time to a capture — no listing is read twice
+  and no request is made.
+
+## Assumptions
+
+- **The recognized-name list is exactly the five names in the issue, in the issue's order.** No
+  other name is treated as a part number, however part-number-shaped its value. Adding a name later
+  is a one-line change and does not need to be anticipated now.
+- **The order encodes confidence, and the list is deliberately loose at the bottom.** `Manufacturer
+  Part Number` and `Mfr Part Number` say what they are. `Part Number` may be the vendor's rather
+  than the manufacturer's, and `Model Number` / `Item model number` may be a marketing model that is
+  not orderable as a part. They are on the list because a default the operator reviews and can
+  overrule is worth more than an empty field, and off the top of the list because when a listing
+  publishes both, the specific one is right.
+- **This is a default, never an assertion.** Nothing downstream may treat a manufacturer part number
+  as more trustworthy for having been derived, and nothing may re-apply it after the operator has
+  had the field in front of them.
+- **Nothing is reported about the derivation.** The field simply arrives filled, exactly as the
+  Manufacturer field already does from the listing's byline. A note saying where the value came from
+  is deliberately not part of this feature: the row it came from is visible on the same page, and
+  the capture's existing reporting is reserved for what the capture *did to the catalog*, which this
+  does not.
+- **The pasted-address path carries no product information rows today, so nothing changes for it.**
+  Pasting a listing's address does not read the vendor's page; only the bookmarklet does. FR-007 is
+  written as "a single shared rule" rather than "both paths behave the same" because the shared rule
+  is what makes the benefit automatic if that ever changes — the issue's stated preference for
+  putting the rule on the rendering side rather than in the page-reading agent. Its immediate,
+  testable value is that the rule can be exercised without a browser.
+- **The existing capture merge, specification handling and part-number storage are reused as they
+  are.** This feature adds no storage, no validation and no new field.
+- **Nothing is retrofitted.** Products captured before this change do not gain a part number on
+  their own. Fixing one means editing it, or re-capturing and accepting the default — and
+  re-capturing onto an existing product will not write it, so editing is the remedy.
+- **The Manufacturer and Unit Price fields are not in scope.** FR-006 asks for redisplay behavior
+  that those two fields do not have today. Bringing them into line is a separate change against a
+  separate issue; this feature must not silently alter them.

--- a/specs/019-capture-mpn-default/tasks.md
+++ b/specs/019-capture-mpn-default/tasks.md
@@ -146,7 +146,7 @@ splitting it out would mean editing one method twice. What is genuinely separate
 - [X] T027 Confirm the working tree is clean after a plain `nox -s tests` and `nox -s e2e` run (Constitution IV: a test session must leave the tree clean) with `git status --short`
 - [X] T028 Walk [quickstart.md](./quickstart.md) sections 1–3 and 5 end to end, and section 6 by hand against `B0CZ72JRHP` and `B0FX4PDW6M` if a TLS-served instance is available. SC-001 is the acceptance: the field arrives filled with zero keystrokes
 - [X] T029 Review the full diff against the file list in [plan.md](./plan.md): `app/models.py`, `app/catalog_service.py`, `app/product/routes.py`, `app/templates/product/capture.html`, `tests/unit/test_capture.py`, `tests/e2e/test_product_page_capture.py`, `tests/e2e/fixtures/amazon_listing.html`, `docs/user-manual.md`, one screenshot, and this spec directory. **Anything else in the diff is a defect**: no migration, no `requirements.txt`, no JavaScript, no `app/database.py`, no `_form_fields.html`
-- [ ] T030 Open the pull request against `main` referencing issue #90, and note in the body the FR-006 scope call — this field's cleared value survives a re-render, `manufacturer` and unit price still do not, and aligning them is deliberately a separate change
+- [X] T030 Open the pull request against `main` referencing issue #90, and note in the body the FR-006 scope call — this field's cleared value survives a re-render, `manufacturer` and unit price still do not, and aligning them is deliberately a separate change
 
 ---
 

--- a/specs/019-capture-mpn-default/tasks.md
+++ b/specs/019-capture-mpn-default/tasks.md
@@ -1,0 +1,230 @@
+---
+
+description: "Task list for 019-capture-mpn-default"
+---
+
+# Tasks: The Captured Listing Fills In the Manufacturer Part Number
+
+**Input**: Design documents from `/specs/019-capture-mpn-default/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md),
+[data-model.md](./data-model.md), [contracts/README.md](./contracts/README.md),
+[quickstart.md](./quickstart.md)
+
+**Branch**: `issues/90` — already created, spec artifacts uncommitted on it.
+
+**Tests**: **Required, not optional.** Constitution IV: "Changes that alter behavior MUST land with
+tests covering that behavior," and `nox -s tests` and `nox -s e2e` MUST both be green before merge.
+
+**Organization**: Grouped by user story. US1 and US2 are both P1 and both required for the feature
+to be safe to ship — see the spec's "Why this priority" on US2.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1, US2, US3 from [spec.md](./spec.md)
+
+## Path Conventions
+
+Flask app at the repository root: `app/` for source, `tests/unit/` and `tests/e2e/` for tests,
+`docs/` for documentation. There is no `src/`. Paths below are exact and repository-relative.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Nothing to install, nothing to scaffold. This phase exists to confirm the ground is
+where the plan says it is before anything is edited.
+
+- [ ] T001 Confirm the working tree is clean apart from `specs/019-capture-mpn-default/` and `.specify/feature.json`, and that the branch is `issues/90`, with `git status --short && git branch --show-current`
+- [ ] T002 Establish the green baseline with `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — it must pass in about a second before anything is changed
+
+**No dependency is added and no package is installed.** If `requirements.txt` appears in the diff,
+the plan has been misread.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared name-folding helper. **No behavior changes in this phase** — it is a
+verbatim move, and the existing barcode tests staying green untouched is the proof.
+
+**⚠️ BLOCKS**: every user story. `PART_NUMBER_ROW_NAMES` is stored pre-normalized, so nothing can be
+matched until the normalizer exists.
+
+- [ ] T003 Add `normalized_row_name(name: Optional[str]) -> str` to `app/models.py`, near `LISTING_CAPTURE_VERSION` (line 599) — body lifted **verbatim** from `_is_barcode_row_name`: `return ' '.join((name or '').split()).upper()`. Docstring must say it trims, collapses internal whitespace runs, and upper-cases, and that it is shared with the barcode-row matcher (FR-001)
+- [ ] T004 Rewrite `_is_barcode_row_name` in `app/catalog_service.py:2541` to `return normalized_row_name(name) in BARCODE_ROW_NAMES`, importing `normalized_row_name` from `.models` in the existing import block at line 38. Keep the existing docstring — its reasoning about whole-name matching is still exactly right
+- [ ] T005 Verify the move was verbatim: `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests -- tests/unit/test_capture.py -k Barcode`. `TestWhichRowNamesMeanABarcode` (`tests/unit/test_capture.py:1762`) must pass **with no edit to that file**. A red result here means the move changed behavior; fix the move, do not touch the test
+
+**Checkpoint**: nothing observable has changed. `nox -s tests` is green and no test file was edited.
+
+---
+
+## Phase 3: User Story 1 — The part number the listing published is already in the field (Priority: P1) 🎯 MVP
+
+**Goal**: The confirmation form's Manufacturer Part Number field arrives holding the part number the
+listing's own rows name, on both first-render paths, with nothing typed.
+
+**Independent Test**: Capture a listing whose product information carries a `Mfr Part Number` row.
+The field arrives holding that row's value; submitting without touching it stores it; every captured
+row is still in the product's specification list.
+
+### Implementation for User Story 1
+
+- [ ] T006 [US1] Add `PART_NUMBER_ROW_NAMES` to `app/models.py` as a **tuple** in priority order, entries stored pre-normalized: `('MANUFACTURER PART NUMBER', 'MFR PART NUMBER', 'PART NUMBER', 'MODEL NUMBER', 'ITEM MODEL NUMBER')`. Comment must say order is the specification (FR-002), and that this is a tuple where `BARCODE_ROW_NAMES` is a frozenset because order matters here and does not there
+- [ ] T007 [US1] Add `MANUFACTURER_PART_NUMBER_MAX_LENGTH = 100` to `app/models.py`, with a comment naming `app/database.py:838` (`String(100)`) as the column it mirrors, and stating that an over-long default would fail the write at the end of a fifteen-second capture because nothing in the stack checks length ([research.md](./research.md) §4)
+- [ ] T008 [US1] Add `ListingCapture.manufacturer_part_number(self) -> Optional[str]` to `app/models.py` (class at line 603): walk `PART_NUMBER_ROW_NAMES` outer, `self.specifications` inner, return the first row whose `normalized_row_name(name)` matches **and** whose stripped value is non-empty and at most `MANUFACTURER_PART_NUMBER_MAX_LENGTH`; return the stripped value; return `None` when nothing qualifies. Must be pure — no I/O, no mutation — because a Jinja template calls it. Docstring must say it is a default, never an assertion
+- [ ] T009 [US1] Change the `manufacturer_part_number` input in `app/templates/product/capture.html:163-165` from `value="{{ form_data.get('manufacturer_part_number') or '' }}"` to a **presence test on the key**, falling back to `listing.manufacturer_part_number()` when `listing` is set — the exact expression is in [research.md](./research.md) §5. Add a Jinja comment explaining that the test is on presence rather than truthiness because a cleared field must stay cleared (FR-006), and that this deliberately differs from the `manufacturer` field ten lines above
+
+### Tests for User Story 1
+
+- [ ] T010 [P] [US1] Add `TestWhichRowNamesMeanAPartNumber` to `tests/unit/test_capture.py`, beside `TestWhichRowNamesMeanABarcode` (line 1762): each of the five names recognized; case, surrounding whitespace and **internal** whitespace runs folded (`'Mfr  Part   Number'`); the whole name must match, not a part of it (`'Vendor Part Number'`, `'Part Numbers'` do not); `None` and `''` are not part-number names; and a guard asserting every `PART_NUMBER_ROW_NAMES` entry equals its own `normalized_row_name` — a typo there would make an entry permanently unmatchable, and silently so (FR-001)
+- [ ] T011 [P] [US1] Add `TestThePartNumberTheListingNames` to `tests/unit/test_capture.py`, beside `TestTheListingPayload` (line 952): construct `ListingCapture` directly, no app and no database. Cover each recognized name yielding its value; **priority beats page order** (a `Model Number` row first and a `Mfr Part Number` row second yields the second — FR-002, US1 scenario 3); two rows sharing a name yield the first in captured order; the value is returned trimmed and otherwise unaltered (FR-004); and a listing with no rows, and one with no recognized name, both yield `None`
+- [ ] T012 [US1] Add `TestThePartNumberFillsTheForm` to `tests/unit/test_capture.py`, beside `TestTheListingFillsTheForm` (line 1064), reusing its `payload`/`capture` helper shape: a POST carrying the payload and **no** `manufacturer_part_number` field stores the derived value; the same POST carrying a value stores that value instead; and `GET /products/capture?listing=...` renders the derived value into the field (FR-002)
+- [ ] T013 [P] [US1] Add a `Mfr Part Number` row with a real value to the `productDetails_techSpec_section_1` table in `tests/e2e/fixtures/amazon_listing.html`, beside the `UPC` row at line 120. The fixture has no part-number row at all today. Comment it the way the `UPC` row is commented, naming issue #90
+- [ ] T014 [US1] Add an E2E test to `tests/e2e/test_product_page_capture.py`: capture from the fixture, assert `#manufacturer_part_number` already holds the fixture's value with nothing typed, then `confirm(landed)` and assert the stored product carries it. Follow `test_the_agent_fills_in_the_price_and_the_brand` (line 169) exactly — same helpers, same assertion style. **No fixed wait**: the form is server-rendered, so `expect(...).to_have_value(...)` is the whole wait (`CLAUDE.md` Pattern C)
+- [ ] T015 [US1] Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — green, sub-second, network blocked
+
+**Checkpoint**: US1 is complete and independently demonstrable end to end. **This alone closes what
+issue #90 reported.**
+
+---
+
+## Phase 4: User Story 2 — The operator overrules the listing (Priority: P1)
+
+**Goal**: A value the operator typed or cleared is what gets captured, on the first submission and
+after a capture question.
+
+**Independent Test**: Capture a listing that produces a derived default, replace the value, submit,
+and confirm the product carries the typed one. Repeat, clearing the field, and confirm the product
+carries no part number — including when the capture comes back asking a question first.
+
+**Note on ordering**: most of US2 is already true after Phase 3, because the form submits what it
+displays and `_clean('')` is `None`. What is left is the two rules that are not automatic: the
+absent-versus-empty distinction on the write, and the re-render.
+
+### Implementation for User Story 2
+
+- [ ] T016 [US2] In `app/product/routes.py`, `product_capture` POST branch, add `manufacturer_part_number` to the absent-versus-empty fallback block at lines 415–421 — read it with `request.form.get(...)`, and fall back to `listing.manufacturer_part_number()` **only when it is `None`** (FR-005). Pass the local into the `capture_order` call at line 434, replacing the inline `request.form.get('manufacturer_part_number')`. Extend the existing comment above the block to name the third field rather than writing a second comment
+- [ ] T017 [US2] Verify no change was made to the `manufacturer` or `unit_price` handling in that same block, and none to the `manufacturer` input at `app/templates/product/capture.html:154`, with `git diff app/product/routes.py app/templates/product/capture.html`. Those two still use `or` on re-render; that wart is out of scope by a stated spec assumption and **must not appear in this diff**
+
+### Tests for User Story 2
+
+- [ ] T018 [P] [US2] Add `TestAClearedPartNumberStaysCleared` to `tests/unit/test_capture.py`, beside `TestThePayloadSurvivesAQuestion` (line 1579), reusing its `payload`/`post` helper shape: a POST submitting an **empty** `manufacturer_part_number` stores no part number and the derived value is not silently restored (FR-005, US2 scenario 2); a POST that triggers `CaptureDecisionRequired` re-renders with the field **empty**, not refilled (FR-006, US2 scenario 3); and the same re-render with a *typed* value shows the typed value
+- [ ] T019 [US2] Add an E2E test to `tests/e2e/test_product_page_capture.py`: capture from the fixture, clear the field with `confirm(landed, manufacturer_part_number="")`, and assert the stored product carries no part number. Establish the region with `expect(...)` before any snapshot read — a negative assertion against a region that has not rendered passes trivially (`CLAUDE.md`)
+- [ ] T020 [US2] Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — green
+
+**Checkpoint**: US1 and US2 both work. The feature is now safe to ship: the default exists and it can
+always be overruled.
+
+---
+
+## Phase 5: User Story 3 — A useless candidate is passed over (Priority: P3)
+
+**Goal**: Empty, whitespace-only and over-long candidates supply no default and do not end the
+search.
+
+**Independent Test**: A listing whose highest-priority part-number row has an empty value and whose
+next one has a real value yields the second.
+
+**Note**: US3's *implementation* landed in T008 — the usability test is part of the same walk, and
+splitting it out would mean editing one method twice. What is genuinely separate is its coverage.
+
+- [ ] T021 [US3] Extend `TestThePartNumberTheListingNames` (created in T011) in `tests/unit/test_capture.py` with FR-003's cases: a row whose stripped value exceeds `MANUFACTURER_PART_NUMBER_MAX_LENGTH` yields nothing from that row **and the search continues to the next recognized name**; a value at exactly the limit is accepted; a row whose value is empty or whitespace-only is passed over rather than ending the search (US3 scenarios 1 and 2); and the returned value is trimmed (US3 scenario 3)
+- [ ] T022 [US3] Add a second part-number row to `tests/e2e/fixtures/amazon_listing.html`, higher-priority than T013's row but with an **empty** value, so the browser path exercises the pass-over and not only the happy case. Comment it naming issue #90 and FR-003
+- [ ] T023 [US3] Add an E2E test to `tests/e2e/test_product_page_capture.py` asserting the confirmation form skips the empty higher-priority row and shows T013's usable lower-priority value, via `capture_from_listing` and `expect(landed.locator("#manufacturer_part_number")).to_have_value(...)`
+
+**Checkpoint**: all three stories are independently demonstrable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T024 [P] Update the bookmarklet paragraph in `docs/user-manual.md` (around line 905 — "for an Amazon page that means the price, the brand, the description, every *Product information* row, and every image...") to name the manufacturer part number, and say it is a default the operator can change or clear
+- [ ] T025 Run the E2E suite: `nohup env PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s e2e > /tmp/e2e-019.log 2>&1 &` then poll. **It outlasts a 10-minute command cap — run it detached.** Constitution IV requires a 15-minute allowance
+- [ ] T026 Regenerate screenshots: `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s screenshots_headless`, then `venv/bin/nox -s screenshots_verify`. `docs/images/screenshots/user-manual/order_capture.png` is the capture page's screenshot (written by `tests/e2e/test_screenshot_generation.py::test_screenshot_order_capture`) and 018 regenerated exactly that file when it last edited this template. Screenshots churn on every run — inspect what actually differs and commit `order_capture.png` plus anything whose content genuinely moved, **not** the whole directory
+- [ ] T027 Confirm the working tree is clean after a plain `nox -s tests` and `nox -s e2e` run (Constitution IV: a test session must leave the tree clean) with `git status --short`
+- [ ] T028 Walk [quickstart.md](./quickstart.md) sections 1–3 and 5 end to end, and section 6 by hand against `B0CZ72JRHP` and `B0FX4PDW6M` if a TLS-served instance is available. SC-001 is the acceptance: the field arrives filled with zero keystrokes
+- [ ] T029 Review the full diff against the file list in [plan.md](./plan.md): `app/models.py`, `app/catalog_service.py`, `app/product/routes.py`, `app/templates/product/capture.html`, `tests/unit/test_capture.py`, `tests/e2e/test_product_page_capture.py`, `tests/e2e/fixtures/amazon_listing.html`, `docs/user-manual.md`, one screenshot, and this spec directory. **Anything else in the diff is a defect**: no migration, no `requirements.txt`, no JavaScript, no `app/database.py`, no `_form_fields.html`
+- [ ] T030 Open the pull request against `main` referencing issue #90, and note in the body the FR-006 scope call — this field's cleared value survives a re-render, `manufacturer` and unit price still do not, and aligning them is deliberately a separate change
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: no dependencies
+- **Phase 2 (Foundational)**: after Phase 1. **Blocks everything** — `PART_NUMBER_ROW_NAMES` is stored pre-normalized, so nothing matches until `normalized_row_name` exists
+- **Phase 3 (US1)**: after Phase 2
+- **Phase 4 (US2)**: after T008 for the write rule and after T009 for the re-render. Its E2E test (T019) additionally needs T013's fixture row
+- **Phase 5 (US3)**: after T011 (it extends that class) and after T013 (its fixture row is the fallback the pass-over lands on)
+- **Phase 6**: after Phases 3, 4 and 5
+
+### Task Dependencies Worth Naming
+
+- T004 depends on T003 — the function must exist before the caller is rewritten
+- T005 is the gate on Phase 2 and must be green before T006
+- T008 depends on T003, T006 and T007; it uses all three
+- T009 and T016 both depend on T008 and are independent of each other
+- T014, T019 and T023 all depend on T013 (the fixture row) and on T009 (the template change)
+- T021 extends the class T011 creates, so it is sequential with respect to T011
+- T022 depends on T013 — the empty row is only meaningful with a usable row below it
+- T026 depends on T009: the template change is what makes regeneration necessary
+
+### Within Each User Story
+
+Implementation before tests here, not after. This is not TDD by choice of the spec — the
+constitution requires tests to *land with* behavior, not to precede it, and every one of these tests
+asserts against a helper whose signature the implementation task defines.
+
+### Parallel Opportunities
+
+This is a solo project on a small feature, so **most tasks are sequential and marking them `[P]`
+would only create conflicts**. What genuinely can run at the same time:
+
+- **T010 and T011** — two new test classes touching no implementation file and not depending on each other. Same file, so commit them together
+- **T013** — the E2E fixture, disjoint from all Python
+- **T018** — a test class no implementation task is editing at that moment
+- **T024** — documentation, disjoint from everything
+
+`app/models.py` carries T003, T006, T007 and T008; those four are strictly sequential. Four tasks
+add classes to `tests/unit/test_capture.py` (T010, T011, T012, T018) and one extends a class there
+(T021), so they conflict on that file even where they are logically independent.
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. T001–T005 — foundational, no behavior change
+2. T006–T015 — the derivation, the render, the unit tests, the fixture, one E2E test
+3. **STOP and VALIDATE**: capture the fixture listing and look at the field
+4. That alone closes what issue #90 reported
+
+### Incremental Delivery
+
+1. Foundational → one folding rule, two callers, nothing observable
+2. US1 → the field arrives filled (MVP)
+3. US2 → what the operator decided is what gets captured, including "nothing"
+4. US3 → a useless candidate is provably passed over rather than offered
+5. Polish → user manual, full suites, screenshot, by-hand pass, diff review, PR
+
+---
+
+## Notes
+
+- `[P]` = different files, no dependency on an incomplete task
+- Commit after each task or logical group
+- **No migration, no new dependency, no JavaScript, no payload version bump.** If any appears in the
+  diff, the plan has been misread. `LISTING_CAPTURE_VERSION` stays at `1` — bumping it makes every
+  cached bookmarklet capture with no payload at all
+- **Do not touch the `manufacturer` or unit price fields** (T017). They re-apply their default over a
+  cleared field on re-render; that is a known wart, out of scope by a stated spec assumption
+- **Do not unify `normalized_row_name` with `_fold`** (`app/catalog_service.py:2536`). They answer
+  different questions and `_fold` deliberately does not collapse internal whitespace
+- **Do not condition the default on the merge outcome** by analogy with 016. This feature writes
+  nothing; it fills a form field in front of the operator. See [research.md](./research.md) §6
+- **Do not truncate an over-long value to fit** (FR-003). A truncated part number is a wrong part
+  number, and a wrong one corroborates a later repeat buy against the wrong product
+- E2E waiting rules are not style: `CLAUDE.md` and Constitution IV. Both pages here are
+  server-rendered, so `expect(locator).to_have_value(...)` is the whole wait

--- a/specs/019-capture-mpn-default/tasks.md
+++ b/specs/019-capture-mpn-default/tasks.md
@@ -36,8 +36,8 @@ Flask app at the repository root: `app/` for source, `tests/unit/` and `tests/e2
 **Purpose**: Nothing to install, nothing to scaffold. This phase exists to confirm the ground is
 where the plan says it is before anything is edited.
 
-- [ ] T001 Confirm the working tree is clean apart from `specs/019-capture-mpn-default/` and `.specify/feature.json`, and that the branch is `issues/90`, with `git status --short && git branch --show-current`
-- [ ] T002 Establish the green baseline with `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — it must pass in about a second before anything is changed
+- [X] T001 Confirm the working tree is clean apart from `specs/019-capture-mpn-default/` and `.specify/feature.json`, and that the branch is `issues/90`, with `git status --short && git branch --show-current`
+- [X] T002 Establish the green baseline with `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — it must pass in about a second before anything is changed
 
 **No dependency is added and no package is installed.** If `requirements.txt` appears in the diff,
 the plan has been misread.
@@ -52,9 +52,9 @@ verbatim move, and the existing barcode tests staying green untouched is the pro
 **⚠️ BLOCKS**: every user story. `PART_NUMBER_ROW_NAMES` is stored pre-normalized, so nothing can be
 matched until the normalizer exists.
 
-- [ ] T003 Add `normalized_row_name(name: Optional[str]) -> str` to `app/models.py`, near `LISTING_CAPTURE_VERSION` (line 599) — body lifted **verbatim** from `_is_barcode_row_name`: `return ' '.join((name or '').split()).upper()`. Docstring must say it trims, collapses internal whitespace runs, and upper-cases, and that it is shared with the barcode-row matcher (FR-001)
-- [ ] T004 Rewrite `_is_barcode_row_name` in `app/catalog_service.py:2541` to `return normalized_row_name(name) in BARCODE_ROW_NAMES`, importing `normalized_row_name` from `.models` in the existing import block at line 38. Keep the existing docstring — its reasoning about whole-name matching is still exactly right
-- [ ] T005 Verify the move was verbatim: `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests -- tests/unit/test_capture.py -k Barcode`. `TestWhichRowNamesMeanABarcode` (`tests/unit/test_capture.py:1762`) must pass **with no edit to that file**. A red result here means the move changed behavior; fix the move, do not touch the test
+- [X] T003 Add `normalized_row_name(name: Optional[str]) -> str` to `app/models.py`, near `LISTING_CAPTURE_VERSION` (line 599) — body lifted **verbatim** from `_is_barcode_row_name`: `return ' '.join((name or '').split()).upper()`. Docstring must say it trims, collapses internal whitespace runs, and upper-cases, and that it is shared with the barcode-row matcher (FR-001)
+- [X] T004 Rewrite `_is_barcode_row_name` in `app/catalog_service.py:2541` to `return normalized_row_name(name) in BARCODE_ROW_NAMES`, importing `normalized_row_name` from `.models` in the existing import block at line 38. Keep the existing docstring — its reasoning about whole-name matching is still exactly right
+- [X] T005 Verify the move was verbatim: `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests -- tests/unit/test_capture.py -k Barcode`. `TestWhichRowNamesMeanABarcode` (`tests/unit/test_capture.py:1762`) must pass **with no edit to that file**. A red result here means the move changed behavior; fix the move, do not touch the test
 
 **Checkpoint**: nothing observable has changed. `nox -s tests` is green and no test file was edited.
 
@@ -71,19 +71,19 @@ row is still in the product's specification list.
 
 ### Implementation for User Story 1
 
-- [ ] T006 [US1] Add `PART_NUMBER_ROW_NAMES` to `app/models.py` as a **tuple** in priority order, entries stored pre-normalized: `('MANUFACTURER PART NUMBER', 'MFR PART NUMBER', 'PART NUMBER', 'MODEL NUMBER', 'ITEM MODEL NUMBER')`. Comment must say order is the specification (FR-002), and that this is a tuple where `BARCODE_ROW_NAMES` is a frozenset because order matters here and does not there
-- [ ] T007 [US1] Add `MANUFACTURER_PART_NUMBER_MAX_LENGTH = 100` to `app/models.py`, with a comment naming `app/database.py:838` (`String(100)`) as the column it mirrors, and stating that an over-long default would fail the write at the end of a fifteen-second capture because nothing in the stack checks length ([research.md](./research.md) §4)
-- [ ] T008 [US1] Add `ListingCapture.manufacturer_part_number(self) -> Optional[str]` to `app/models.py` (class at line 603): walk `PART_NUMBER_ROW_NAMES` outer, `self.specifications` inner, return the first row whose `normalized_row_name(name)` matches **and** whose stripped value is non-empty and at most `MANUFACTURER_PART_NUMBER_MAX_LENGTH`; return the stripped value; return `None` when nothing qualifies. Must be pure — no I/O, no mutation — because a Jinja template calls it. Docstring must say it is a default, never an assertion
-- [ ] T009 [US1] Change the `manufacturer_part_number` input in `app/templates/product/capture.html:163-165` from `value="{{ form_data.get('manufacturer_part_number') or '' }}"` to a **presence test on the key**, falling back to `listing.manufacturer_part_number()` when `listing` is set — the exact expression is in [research.md](./research.md) §5. Add a Jinja comment explaining that the test is on presence rather than truthiness because a cleared field must stay cleared (FR-006), and that this deliberately differs from the `manufacturer` field ten lines above
+- [X] T006 [US1] Add `PART_NUMBER_ROW_NAMES` to `app/models.py` as a **tuple** in priority order, entries stored pre-normalized: `('MANUFACTURER PART NUMBER', 'MFR PART NUMBER', 'PART NUMBER', 'MODEL NUMBER', 'ITEM MODEL NUMBER')`. Comment must say order is the specification (FR-002), and that this is a tuple where `BARCODE_ROW_NAMES` is a frozenset because order matters here and does not there
+- [X] T007 [US1] Add `MANUFACTURER_PART_NUMBER_MAX_LENGTH = 100` to `app/models.py`, with a comment naming `app/database.py:838` (`String(100)`) as the column it mirrors, and stating that an over-long default would fail the write at the end of a fifteen-second capture because nothing in the stack checks length ([research.md](./research.md) §4)
+- [X] T008 [US1] Add `ListingCapture.manufacturer_part_number(self) -> Optional[str]` to `app/models.py` (class at line 603): walk `PART_NUMBER_ROW_NAMES` outer, `self.specifications` inner, return the first row whose `normalized_row_name(name)` matches **and** whose stripped value is non-empty and at most `MANUFACTURER_PART_NUMBER_MAX_LENGTH`; return the stripped value; return `None` when nothing qualifies. Must be pure — no I/O, no mutation — because a Jinja template calls it. Docstring must say it is a default, never an assertion
+- [X] T009 [US1] Change the `manufacturer_part_number` input in `app/templates/product/capture.html:163-165` from `value="{{ form_data.get('manufacturer_part_number') or '' }}"` to a **presence test on the key**, falling back to `listing.manufacturer_part_number()` when `listing` is set — the exact expression is in [research.md](./research.md) §5. Add a Jinja comment explaining that the test is on presence rather than truthiness because a cleared field must stay cleared (FR-006), and that this deliberately differs from the `manufacturer` field ten lines above
 
 ### Tests for User Story 1
 
-- [ ] T010 [P] [US1] Add `TestWhichRowNamesMeanAPartNumber` to `tests/unit/test_capture.py`, beside `TestWhichRowNamesMeanABarcode` (line 1762): each of the five names recognized; case, surrounding whitespace and **internal** whitespace runs folded (`'Mfr  Part   Number'`); the whole name must match, not a part of it (`'Vendor Part Number'`, `'Part Numbers'` do not); `None` and `''` are not part-number names; and a guard asserting every `PART_NUMBER_ROW_NAMES` entry equals its own `normalized_row_name` — a typo there would make an entry permanently unmatchable, and silently so (FR-001)
-- [ ] T011 [P] [US1] Add `TestThePartNumberTheListingNames` to `tests/unit/test_capture.py`, beside `TestTheListingPayload` (line 952): construct `ListingCapture` directly, no app and no database. Cover each recognized name yielding its value; **priority beats page order** (a `Model Number` row first and a `Mfr Part Number` row second yields the second — FR-002, US1 scenario 3); two rows sharing a name yield the first in captured order; the value is returned trimmed and otherwise unaltered (FR-004); and a listing with no rows, and one with no recognized name, both yield `None`
-- [ ] T012 [US1] Add `TestThePartNumberFillsTheForm` to `tests/unit/test_capture.py`, beside `TestTheListingFillsTheForm` (line 1064), reusing its `payload`/`capture` helper shape: a POST carrying the payload and **no** `manufacturer_part_number` field stores the derived value; the same POST carrying a value stores that value instead; and `GET /products/capture?listing=...` renders the derived value into the field (FR-002)
-- [ ] T013 [P] [US1] Add a `Mfr Part Number` row with a real value to the `productDetails_techSpec_section_1` table in `tests/e2e/fixtures/amazon_listing.html`, beside the `UPC` row at line 120. The fixture has no part-number row at all today. Comment it the way the `UPC` row is commented, naming issue #90
-- [ ] T014 [US1] Add an E2E test to `tests/e2e/test_product_page_capture.py`: capture from the fixture, assert `#manufacturer_part_number` already holds the fixture's value with nothing typed, then `confirm(landed)` and assert the stored product carries it. Follow `test_the_agent_fills_in_the_price_and_the_brand` (line 169) exactly — same helpers, same assertion style. **No fixed wait**: the form is server-rendered, so `expect(...).to_have_value(...)` is the whole wait (`CLAUDE.md` Pattern C)
-- [ ] T015 [US1] Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — green, sub-second, network blocked
+- [X] T010 [P] [US1] Add `TestWhichRowNamesMeanAPartNumber` to `tests/unit/test_capture.py`, beside `TestWhichRowNamesMeanABarcode` (line 1762): each of the five names recognized; case, surrounding whitespace and **internal** whitespace runs folded (`'Mfr  Part   Number'`); the whole name must match, not a part of it (`'Vendor Part Number'`, `'Part Numbers'` do not); `None` and `''` are not part-number names; and a guard asserting every `PART_NUMBER_ROW_NAMES` entry equals its own `normalized_row_name` — a typo there would make an entry permanently unmatchable, and silently so (FR-001)
+- [X] T011 [P] [US1] Add `TestThePartNumberTheListingNames` to `tests/unit/test_capture.py`, beside `TestTheListingPayload` (line 952): construct `ListingCapture` directly, no app and no database. Cover each recognized name yielding its value; **priority beats page order** (a `Model Number` row first and a `Mfr Part Number` row second yields the second — FR-002, US1 scenario 3); two rows sharing a name yield the first in captured order; the value is returned trimmed and otherwise unaltered (FR-004); and a listing with no rows, and one with no recognized name, both yield `None`
+- [X] T012 [US1] Add `TestThePartNumberFillsTheForm` to `tests/unit/test_capture.py`, beside `TestTheListingFillsTheForm` (line 1064), reusing its `payload`/`capture` helper shape: a POST carrying the payload and **no** `manufacturer_part_number` field stores the derived value; the same POST carrying a value stores that value instead; and `GET /products/capture?listing=...` renders the derived value into the field (FR-002)
+- [X] T013 [P] [US1] Add a `Mfr Part Number` row with a real value to the `productDetails_techSpec_section_1` table in `tests/e2e/fixtures/amazon_listing.html`, beside the `UPC` row at line 120. The fixture has no part-number row at all today. Comment it the way the `UPC` row is commented, naming issue #90
+- [X] T014 [US1] Add an E2E test to `tests/e2e/test_product_page_capture.py`: capture from the fixture, assert `#manufacturer_part_number` already holds the fixture's value with nothing typed, then `confirm(landed)` and assert the stored product carries it. Follow `test_the_agent_fills_in_the_price_and_the_brand` (line 169) exactly — same helpers, same assertion style. **No fixed wait**: the form is server-rendered, so `expect(...).to_have_value(...)` is the whole wait (`CLAUDE.md` Pattern C)
+- [X] T015 [US1] Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — green, sub-second, network blocked
 
 **Checkpoint**: US1 is complete and independently demonstrable end to end. **This alone closes what
 issue #90 reported.**
@@ -105,14 +105,14 @@ absent-versus-empty distinction on the write, and the re-render.
 
 ### Implementation for User Story 2
 
-- [ ] T016 [US2] In `app/product/routes.py`, `product_capture` POST branch, add `manufacturer_part_number` to the absent-versus-empty fallback block at lines 415–421 — read it with `request.form.get(...)`, and fall back to `listing.manufacturer_part_number()` **only when it is `None`** (FR-005). Pass the local into the `capture_order` call at line 434, replacing the inline `request.form.get('manufacturer_part_number')`. Extend the existing comment above the block to name the third field rather than writing a second comment
-- [ ] T017 [US2] Verify no change was made to the `manufacturer` or `unit_price` handling in that same block, and none to the `manufacturer` input at `app/templates/product/capture.html:154`, with `git diff app/product/routes.py app/templates/product/capture.html`. Those two still use `or` on re-render; that wart is out of scope by a stated spec assumption and **must not appear in this diff**
+- [X] T016 [US2] In `app/product/routes.py`, `product_capture` POST branch, add `manufacturer_part_number` to the absent-versus-empty fallback block at lines 415–421 — read it with `request.form.get(...)`, and fall back to `listing.manufacturer_part_number()` **only when it is `None`** (FR-005). Pass the local into the `capture_order` call at line 434, replacing the inline `request.form.get('manufacturer_part_number')`. Extend the existing comment above the block to name the third field rather than writing a second comment
+- [X] T017 [US2] Verify no change was made to the `manufacturer` or `unit_price` handling in that same block, and none to the `manufacturer` input at `app/templates/product/capture.html:154`, with `git diff app/product/routes.py app/templates/product/capture.html`. Those two still use `or` on re-render; that wart is out of scope by a stated spec assumption and **must not appear in this diff**
 
 ### Tests for User Story 2
 
-- [ ] T018 [P] [US2] Add `TestAClearedPartNumberStaysCleared` to `tests/unit/test_capture.py`, beside `TestThePayloadSurvivesAQuestion` (line 1579), reusing its `payload`/`post` helper shape: a POST submitting an **empty** `manufacturer_part_number` stores no part number and the derived value is not silently restored (FR-005, US2 scenario 2); a POST that triggers `CaptureDecisionRequired` re-renders with the field **empty**, not refilled (FR-006, US2 scenario 3); and the same re-render with a *typed* value shows the typed value
-- [ ] T019 [US2] Add an E2E test to `tests/e2e/test_product_page_capture.py`: capture from the fixture, clear the field with `confirm(landed, manufacturer_part_number="")`, and assert the stored product carries no part number. Establish the region with `expect(...)` before any snapshot read — a negative assertion against a region that has not rendered passes trivially (`CLAUDE.md`)
-- [ ] T020 [US2] Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — green
+- [X] T018 [P] [US2] Add `TestAClearedPartNumberStaysCleared` to `tests/unit/test_capture.py`, beside `TestThePayloadSurvivesAQuestion` (line 1579), reusing its `payload`/`post` helper shape: a POST submitting an **empty** `manufacturer_part_number` stores no part number and the derived value is not silently restored (FR-005, US2 scenario 2); a POST that triggers `CaptureDecisionRequired` re-renders with the field **empty**, not refilled (FR-006, US2 scenario 3); and the same re-render with a *typed* value shows the typed value
+- [X] T019 [US2] Add an E2E test to `tests/e2e/test_product_page_capture.py`: capture from the fixture, clear the field with `confirm(landed, manufacturer_part_number="")`, and assert the stored product carries no part number. Establish the region with `expect(...)` before any snapshot read — a negative assertion against a region that has not rendered passes trivially (`CLAUDE.md`)
+- [X] T020 [US2] Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — green
 
 **Checkpoint**: US1 and US2 both work. The feature is now safe to ship: the default exists and it can
 always be overruled.
@@ -130,9 +130,9 @@ next one has a real value yields the second.
 **Note**: US3's *implementation* landed in T008 — the usability test is part of the same walk, and
 splitting it out would mean editing one method twice. What is genuinely separate is its coverage.
 
-- [ ] T021 [US3] Extend `TestThePartNumberTheListingNames` (created in T011) in `tests/unit/test_capture.py` with FR-003's cases: a row whose stripped value exceeds `MANUFACTURER_PART_NUMBER_MAX_LENGTH` yields nothing from that row **and the search continues to the next recognized name**; a value at exactly the limit is accepted; a row whose value is empty or whitespace-only is passed over rather than ending the search (US3 scenarios 1 and 2); and the returned value is trimmed (US3 scenario 3)
-- [ ] T022 [US3] Add a second part-number row to `tests/e2e/fixtures/amazon_listing.html`, higher-priority than T013's row but with an **empty** value, so the browser path exercises the pass-over and not only the happy case. Comment it naming issue #90 and FR-003
-- [ ] T023 [US3] Add an E2E test to `tests/e2e/test_product_page_capture.py` asserting the confirmation form skips the empty higher-priority row and shows T013's usable lower-priority value, via `capture_from_listing` and `expect(landed.locator("#manufacturer_part_number")).to_have_value(...)`
+- [X] T021 [US3] Extend `TestThePartNumberTheListingNames` (created in T011) in `tests/unit/test_capture.py` with FR-003's cases: a row whose stripped value exceeds `MANUFACTURER_PART_NUMBER_MAX_LENGTH` yields nothing from that row **and the search continues to the next recognized name**; a value at exactly the limit is accepted; a row whose value is empty or whitespace-only is passed over rather than ending the search (US3 scenarios 1 and 2); and the returned value is trimmed (US3 scenario 3)
+- [X] T022 [US3] Add a second part-number row to `tests/e2e/fixtures/amazon_listing.html`, higher-priority than T013's row but with an **empty** value, so the browser path exercises the pass-over and not only the happy case. Comment it naming issue #90 and FR-003
+- [X] T023 [US3] Add an E2E test to `tests/e2e/test_product_page_capture.py` asserting the confirmation form skips the empty higher-priority row and shows T013's usable lower-priority value, via `capture_from_listing` and `expect(landed.locator("#manufacturer_part_number")).to_have_value(...)`
 
 **Checkpoint**: all three stories are independently demonstrable.
 
@@ -140,12 +140,12 @@ splitting it out would mean editing one method twice. What is genuinely separate
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T024 [P] Update the bookmarklet paragraph in `docs/user-manual.md` (around line 905 — "for an Amazon page that means the price, the brand, the description, every *Product information* row, and every image...") to name the manufacturer part number, and say it is a default the operator can change or clear
-- [ ] T025 Run the E2E suite: `nohup env PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s e2e > /tmp/e2e-019.log 2>&1 &` then poll. **It outlasts a 10-minute command cap — run it detached.** Constitution IV requires a 15-minute allowance
-- [ ] T026 Regenerate screenshots: `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s screenshots_headless`, then `venv/bin/nox -s screenshots_verify`. `docs/images/screenshots/user-manual/order_capture.png` is the capture page's screenshot (written by `tests/e2e/test_screenshot_generation.py::test_screenshot_order_capture`) and 018 regenerated exactly that file when it last edited this template. Screenshots churn on every run — inspect what actually differs and commit `order_capture.png` plus anything whose content genuinely moved, **not** the whole directory
-- [ ] T027 Confirm the working tree is clean after a plain `nox -s tests` and `nox -s e2e` run (Constitution IV: a test session must leave the tree clean) with `git status --short`
-- [ ] T028 Walk [quickstart.md](./quickstart.md) sections 1–3 and 5 end to end, and section 6 by hand against `B0CZ72JRHP` and `B0FX4PDW6M` if a TLS-served instance is available. SC-001 is the acceptance: the field arrives filled with zero keystrokes
-- [ ] T029 Review the full diff against the file list in [plan.md](./plan.md): `app/models.py`, `app/catalog_service.py`, `app/product/routes.py`, `app/templates/product/capture.html`, `tests/unit/test_capture.py`, `tests/e2e/test_product_page_capture.py`, `tests/e2e/fixtures/amazon_listing.html`, `docs/user-manual.md`, one screenshot, and this spec directory. **Anything else in the diff is a defect**: no migration, no `requirements.txt`, no JavaScript, no `app/database.py`, no `_form_fields.html`
+- [X] T024 [P] Update the bookmarklet paragraph in `docs/user-manual.md` (around line 905 — "for an Amazon page that means the price, the brand, the description, every *Product information* row, and every image...") to name the manufacturer part number, and say it is a default the operator can change or clear
+- [X] T025 Run the E2E suite: `nohup env PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s e2e > /tmp/e2e-019.log 2>&1 &` then poll. **It outlasts a 10-minute command cap — run it detached.** Constitution IV requires a 15-minute allowance
+- [X] T026 Regenerate screenshots: `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s screenshots_headless`, then `venv/bin/nox -s screenshots_verify`. `docs/images/screenshots/user-manual/order_capture.png` is the capture page's screenshot (written by `tests/e2e/test_screenshot_generation.py::test_screenshot_order_capture`) and 018 regenerated exactly that file when it last edited this template. Screenshots churn on every run — inspect what actually differs and commit `order_capture.png` plus anything whose content genuinely moved, **not** the whole directory
+- [X] T027 Confirm the working tree is clean after a plain `nox -s tests` and `nox -s e2e` run (Constitution IV: a test session must leave the tree clean) with `git status --short`
+- [X] T028 Walk [quickstart.md](./quickstart.md) sections 1–3 and 5 end to end, and section 6 by hand against `B0CZ72JRHP` and `B0FX4PDW6M` if a TLS-served instance is available. SC-001 is the acceptance: the field arrives filled with zero keystrokes
+- [X] T029 Review the full diff against the file list in [plan.md](./plan.md): `app/models.py`, `app/catalog_service.py`, `app/product/routes.py`, `app/templates/product/capture.html`, `tests/unit/test_capture.py`, `tests/e2e/test_product_page_capture.py`, `tests/e2e/fixtures/amazon_listing.html`, `docs/user-manual.md`, one screenshot, and this spec directory. **Anything else in the diff is a defect**: no migration, no `requirements.txt`, no JavaScript, no `app/database.py`, no `_form_fields.html`
 - [ ] T030 Open the pull request against `main` referencing issue #90, and note in the body the FR-006 scope call — this field's cleared value survives a re-render, `manufacturer` and unit price still do not, and aligning them is deliberately a separate change
 
 ---
@@ -228,3 +228,44 @@ add classes to `tests/unit/test_capture.py` (T010, T011, T012, T018) and one ext
   number, and a wrong one corroborates a later repeat buy against the wrong product
 - E2E waiting rules are not style: `CLAUDE.md` and Constitution IV. Both pages here are
   server-rendered, so `expect(locator).to_have_value(...)` is the whole wait
+
+---
+
+## What changed during implementation
+
+Recorded here rather than silently, because three of these change what the tasks said.
+
+- **The recycled-identifier question stops being asked on a re-capture.** Not anticipated anywhere in
+  the planning documents, and found by two E2E tests failing. `_corroborates` requires the
+  manufacturer **and** the part number to agree before a capture may attach to a product whose
+  identifier it landed on; the capture has always supplied the first and never the second, so the
+  pair never corroborated and every re-capture raised the question. Filling the part number supplies
+  the missing half. `test_a_hand_edited_value_survives_a_re_capture` and
+  `test_a_repeat_buy_merges_and_stores_no_second_copy` both used that question to reach their
+  subject; both now clear the field on their first capture, with a comment saying why.
+  `test_a_repeat_buy_no_longer_has_to_answer_the_identifier_question` pins the new behaviour, and
+  the spec gained an edge case and SC-006a. This is the outcome US1 is named for — it is the payoff,
+  not a regression.
+- **T022/T023 changed shape.** The plan called for an *empty* higher-priority row in the E2E
+  fixture. The capture agent drops a row with no value before the payload is built
+  (`specificationsFrom`, `capture-agent.js:295`), so an empty cell never reaches Python and a test
+  built on one proves nothing. The fixture row is *over-long* instead, at 101 characters against a
+  ceiling of 100, which does survive the agent and does exercise FR-003. The empty and
+  whitespace-only cases are covered in the unit tests, where they can be reached.
+- **T012 was narrowed and T018 widened.** T012 was written to cover the write-path fallback, whose
+  implementation is T016 in the next phase. The render assertions stayed in T012; the
+  absent-versus-empty write assertions moved into `TestAClearedPartNumberStaysCleared` alongside the
+  code that makes them pass.
+- **T026 commits no screenshot.** `order_capture.png` came back byte-identical: the template edit
+  adds a Jinja comment and an expression that yields the same empty string in a scenario with no
+  listing. Nine unrelated images churned by a few hundred bytes each and were reverted. Details in
+  [quickstart.md](./quickstart.md) §5.
+- **The quickstart's test selectors were wrong** and are corrected. `-k part_number` matches test
+  function names only and picks up eight of the forty-eight; the class names are what select the
+  feature.
+- **T015/T020's "sub-second" is inherited from the constitution and is stale.** The unit suite runs
+  in about 23 seconds, 44 with nox's overhead. Not this feature's to fix.
+
+**Verification at the end**: `nox -s tests` 1432 passed; `nox -s e2e` 558 passed, 0 failed;
+`nox -s screenshots_verify` 18 verified. A mutation check confirmed the FR-006 guard bites — rewriting
+the template expression with `or` fails `test_a_cleared_field_comes_back_cleared` and nothing else.

--- a/tests/e2e/fixtures/amazon_listing.html
+++ b/tests/e2e/fixtures/amazon_listing.html
@@ -120,6 +120,28 @@ if (typeof P !== 'undefined') { P.when('A').register("ImageBlockATF", function(A
             <th class="prodDetSectionEntry">UPC</th>
             <td class="prodDetAttrValue">012345678905</td>
         </tr>
+        <!-- 019 / issue #90: the listings that prompted the issue published the
+             part number in a row exactly like this one, and the confirmation
+             form still came up with the field blank. This is what fills it. -->
+        <!-- 019 FR-003: higher priority than the row below, and deliberately
+             longer than the manufacturer_part_number column holds. It must be
+             passed over rather than end the search, so the pair of rows -- not
+             either one alone -- is what makes the browser path exercise the
+             rule.
+
+             **Over-long rather than empty**, which was the first attempt: the
+             agent drops a row with no value (specificationsFrom, capture-agent.js
+             line 295), so an empty cell never reaches Python and a test built on
+             one proves nothing. The empty and whitespace-only cases are covered
+             where they can be, in the unit tests. -->
+        <tr>
+            <th class="prodDetSectionEntry">Manufacturer Part Number</th>
+            <td class="prodDetAttrValue">NOT-A-PART-NUMBER-BUT-A-WHOLE-SENTENCE-ABOUT-COMPATIBILITY-WITH-EVERY-MODEL-THIS-VENDOR-HAS-EVER-SOLD</td>
+        </tr>
+        <tr>
+            <th class="prodDetSectionEntry">Mfr Part Number</th>
+            <td class="prodDetAttrValue">ACME-7700-B</td>
+        </tr>
     </table>
 </div>
 

--- a/tests/e2e/test_product_page_capture.py
+++ b/tests/e2e/test_product_page_capture.py
@@ -427,7 +427,14 @@ def test_a_captured_specification_filter_finds_the_product(page, live_server, im
 def test_a_hand_edited_value_survives_a_re_capture(page, live_server, image_host):
     """US3's independent test, and FR-010 and FR-011 together"""
     landed = capture_from_listing(page, live_server, image_host)
-    confirm(landed, description="12V 3A PSU")
+    # The part number is cleared so this capture leaves the product without one.
+    # 019 fills that field from the listing, and a product carrying both the
+    # manufacturer and the part number *corroborates* a later capture of the
+    # same listing -- which suppresses the recycled-identifier question this
+    # test needs in order to reach its subject. That suppression is the intended
+    # payoff and is covered by
+    # test_a_repeat_buy_no_longer_has_to_answer_the_identifier_question.
+    confirm(landed, description="12V 3A PSU", manufacturer_part_number="")
 
     landed.goto(f"{live_server.url}/products")
     landed.click("#product-table tbody tr td a")
@@ -830,7 +837,14 @@ def test_a_repeat_buy_merges_and_stores_no_second_copy(page, live_server, image_
     without duplicating them, and store **no second copy of any image**.
     """
     landed = capture_from_listing(page, live_server, image_host)
-    confirm(landed, description="12V 3A PSU")
+    # The part number is cleared so this capture leaves the product without one.
+    # 019 fills that field from the listing, and a product carrying both the
+    # manufacturer and the part number *corroborates* a later capture of the
+    # same listing -- which suppresses the recycled-identifier question this
+    # test needs in order to reach its subject. That suppression is the intended
+    # payoff and is covered by
+    # test_a_repeat_buy_no_longer_has_to_answer_the_identifier_question.
+    confirm(landed, description="12V 3A PSU", manufacturer_part_number="")
 
     landed.goto(f"{live_server.url}/products")
     landed.click("#product-table tbody tr td a")
@@ -1000,3 +1014,127 @@ def test_a_barcode_another_product_holds_is_left_alone(page, live_server, image_
     expect(identifiers).to_contain_text("VENDOR")
     expect(identifiers).not_to_contain_text("GTIN")
     expect(landed.locator("#product-specifications")).to_contain_text(FIXTURE_UPC)
+
+
+# ---------------------------------------------------------------------------
+# 019: the listing fills in the manufacturer part number (issue #90)
+# ---------------------------------------------------------------------------
+
+FIXTURE_MPN = "ACME-7700-B"   # the Mfr Part Number row in the fixture's tech-spec table
+
+
+@pytest.mark.e2e
+def test_the_listing_fills_in_the_manufacturer_part_number(
+    page, live_server, image_host
+):
+    """019 US1, end to end: the row was on the page, so the field is filled.
+
+    Issue #90's whole complaint: the capture displayed a `Mfr Part Number` row
+    and left the field next to it blank.
+    """
+    landed = capture_from_listing(page, live_server, image_host)
+
+    # Nothing has been typed into it. The form is server-rendered, so the value
+    # being there is the completion signal -- no further wait is possible or
+    # needed (CLAUDE.md, render-implies-completion).
+    expect(landed.locator("#manufacturer_part_number")).to_have_value(FIXTURE_MPN)
+
+    confirm(landed, description="12V 3A PSU")
+
+    landed.goto(f"{live_server.url}/products")
+    landed.click("#product-table tbody tr td a")
+
+    expect(landed.locator("#product-mpn")).to_have_text(FIXTURE_MPN)
+    # FR-008: the row it came from is still an ordinary specification.
+    expect(landed.locator("#product-specifications")).to_contain_text(FIXTURE_MPN)
+
+
+@pytest.mark.e2e
+def test_a_cleared_part_number_is_not_put_back(page, live_server, image_host):
+    """019 US2 scenario 2: it is a default, and clearing it is a decision"""
+    landed = capture_from_listing(page, live_server, image_host)
+    expect(landed.locator("#manufacturer_part_number")).to_have_value(FIXTURE_MPN)
+
+    confirm(landed, description="12V 3A PSU", manufacturer_part_number="")
+
+    landed.goto(f"{live_server.url}/products")
+    landed.click("#product-table tbody tr td a")
+
+    # The region first, then the absence -- #product-mpn is rendered only when
+    # the product has one, so "no such element" would also be true of a page
+    # that has not loaded.
+    expect(landed.locator("#product-description")).to_have_text("12V 3A PSU")
+    expect(landed.locator("#product-mpn")).to_have_count(0)
+    # ...and the row is still there regardless, unfiltered.
+    expect(landed.locator("#product-specifications")).to_contain_text(FIXTURE_MPN)
+
+
+@pytest.mark.e2e
+def test_an_unusable_higher_priority_row_is_passed_over(page, live_server, image_host):
+    """019 US3 scenario 2, in a browser.
+
+    The fixture carries a `Manufacturer Part Number` row longer than the column
+    holds, above its usable `Mfr Part Number`. Ending the search on the unusable
+    one would leave the field blank -- the bug this feature exists to fix,
+    reintroduced through the front door. Offering it instead would fail the
+    write at the end of the capture.
+
+    The empty and whitespace-only cases cannot be reached from here: the agent
+    drops a row with no value before the payload is built. They are covered in
+    ``TestThePartNumberTheListingNames``.
+    """
+    landed = capture_from_listing(page, live_server, image_host)
+
+    expect(landed.locator("#manufacturer_part_number")).to_have_value(FIXTURE_MPN)
+
+    confirm(landed, description="12V 3A PSU")
+
+    landed.goto(f"{live_server.url}/products")
+    landed.click("#product-table tbody tr td a")
+
+    expect(landed.locator("#product-mpn")).to_have_text(FIXTURE_MPN)
+    # FR-008: passed over as a default, still kept as a specification row.
+    expect(landed.locator("#product-specifications")).to_contain_text(
+        "NOT-A-PART-NUMBER"
+    )
+
+
+@pytest.mark.e2e
+def test_a_repeat_buy_no_longer_has_to_answer_the_identifier_question(
+    page, live_server, image_host
+):
+    """019's payoff beyond the field itself, and a behaviour change worth pinning.
+
+    The manufacturer and the part number together are the evidence that decides
+    whether a capture landing on an existing product's identifier is the same
+    product or a recycled id (006 FR-019, `_corroborates`). The bookmarklet has
+    always supplied the manufacturer; until 019 nothing supplied the part number,
+    so the pair never corroborated and every re-capture raised the question.
+
+    Now the listing supplies both halves, so a repeat buy of the same listing
+    attaches to the product without being asked -- which is the reason the spec
+    calls the empty field a cost paid at every later purchase, not a cosmetic
+    gap.
+
+    The duplicate-purchase question is unaffected and is still raised: that one
+    is about two orders on one day, and no part number can answer it.
+    """
+    landed = capture_from_listing(page, live_server, image_host)
+    expect(landed.locator("#manufacturer_part_number")).to_have_value(FIXTURE_MPN)
+    confirm(landed, description="12V 3A PSU")
+
+    again = capture_from_listing(page, live_server, image_host)
+    again.click("#capture-btn")
+
+    # The duplicate question still stands, and its arrival is what tells us the
+    # submit was processed -- so the absence below is a real absence, not a page
+    # that has not rendered yet.
+    expect(again.locator("#duplicate-warning")).to_be_visible()
+    expect(again.locator("#identifier-warning")).to_have_count(0)
+
+    again.check("#acknowledged_duplicate_of")
+    again.click("#capture-btn")
+
+    again.goto(f"{live_server.url}/products")
+    # One product, not two: it attached rather than branching.
+    expect(again.locator("#product-table tbody tr")).to_have_count(1)

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -29,7 +29,12 @@ from app.catalog_service import (
     _is_barcode_row_name,
 )
 from app.exceptions import CaptureDecisionRequired, ValidationError
-from app.models import ListingCapture
+from app.models import (
+    MANUFACTURER_PART_NUMBER_MAX_LENGTH,
+    PART_NUMBER_ROW_NAMES,
+    ListingCapture,
+    normalized_row_name,
+)
 
 AMAZON_URL = 'https://www.amazon.com/dp/B0ABCDEFGH/ref=sr_1_3'
 MCMASTER_URL = 'https://www.mcmaster.com/91290A115/'
@@ -1061,6 +1066,117 @@ class TestTheListingPayload:
         assert service.list_products() == []
 
 
+class TestThePartNumberTheListingNames:
+    """019 US1/US3: which row fills the field, and which are passed over.
+
+    Straight against ``ListingCapture`` -- no app, no client, no database. The
+    whole of FR-002 through FR-004 is a property of one pure method, and this is
+    what putting the rule in the domain layer bought.
+    """
+
+    def listing(self, *rows):
+        return ListingCapture(
+            source_url=AMAZON_URL,
+            specifications=[{'name': n, 'value': v} for n, v in rows],
+        )
+
+    def test_priority_beats_the_order_on_the_page(self):
+        """FR-002 / US1 scenario 3: second on the page, first in the list"""
+        listing = self.listing(
+            ('Model Number', 'MKT-7700'), ('Mfr Part Number', '7700-B'),
+        )
+
+        assert listing.manufacturer_part_number() == '7700-B'
+
+    def test_the_full_priority_order_holds(self):
+        """Every name loses to the one above it.
+
+        Rows are listed highest-priority first and dropped off the front, so
+        each pass leaves a different name as the best available one.
+        """
+        rows = [
+            ('Manufacturer Part Number', 'a'), ('Mfr Part Number', 'b'),
+            ('Part Number', 'c'), ('Model Number', 'd'), ('Item model number', 'e'),
+        ]
+        for cut, expected in enumerate('abcde'):
+            assert self.listing(*rows[cut:]).manufacturer_part_number() == expected
+
+    def test_two_rows_of_one_name_take_the_first_captured(self):
+        listing = self.listing(
+            ('Part Number', 'first'), ('Part Number', 'second'),
+        )
+
+        assert listing.manufacturer_part_number() == 'first'
+
+    def test_the_value_is_trimmed_and_otherwise_unaltered(self):
+        """FR-004 / US3 scenario 3. Internal punctuation and spacing survive."""
+        listing = self.listing(('Part Number', '  91290A115 / rev B  '))
+
+        assert listing.manufacturer_part_number() == '91290A115 / rev B'
+
+    def test_a_listing_with_no_rows_names_nothing(self):
+        assert ListingCapture(source_url=AMAZON_URL).manufacturer_part_number() is None
+
+    def test_a_listing_with_no_recognized_name_names_nothing(self):
+        listing = self.listing(('Voltage', '12 Volts'), ('UPC', '012345678905'))
+
+        assert listing.manufacturer_part_number() is None
+
+    # -- 019 US3: a candidate that cannot be a part number is passed over ----
+
+    def test_an_empty_value_does_not_end_the_search(self):
+        """US3 scenario 1. The highest-priority row is the one vendors leave blank."""
+        listing = self.listing(
+            ('Manufacturer Part Number', ''), ('Model Number', 'MKT-7700'),
+        )
+
+        assert listing.manufacturer_part_number() == 'MKT-7700'
+
+    def test_a_whitespace_only_value_does_not_end_the_search(self):
+        listing = self.listing(
+            ('Mfr Part Number', '   \t  '), ('Part Number', '7700-B'),
+        )
+
+        assert listing.manufacturer_part_number() == '7700-B'
+
+    def test_an_over_long_value_does_not_end_the_search(self):
+        """US3 scenario 2 / FR-003.
+
+        Not a cosmetic refusal. Nothing between the form and the column checks
+        length, so an over-long default would submit, the capture would run, the
+        gallery would be retrieved, and the write would fail at the end of it --
+        over a value nobody typed.
+        """
+        listing = self.listing(
+            ('Part Number', 'X' * (MANUFACTURER_PART_NUMBER_MAX_LENGTH + 1)),
+            ('Model Number', 'MKT-7700'),
+        )
+
+        assert listing.manufacturer_part_number() == 'MKT-7700'
+
+    def test_a_value_at_exactly_the_limit_is_accepted(self):
+        """The ceiling is what the column holds, not one less than it"""
+        value = 'X' * MANUFACTURER_PART_NUMBER_MAX_LENGTH
+        listing = self.listing(('Part Number', value))
+
+        assert listing.manufacturer_part_number() == value
+
+    def test_length_is_measured_after_trimming(self):
+        """A value that only exceeds the limit with its padding still fits"""
+        value = 'X' * MANUFACTURER_PART_NUMBER_MAX_LENGTH
+        listing = self.listing(('Part Number', f'   {value}   '))
+
+        assert listing.manufacturer_part_number() == value
+
+    def test_an_over_long_value_is_never_truncated_to_fit(self):
+        """A truncated part number is a wrong one, and a wrong one corroborates"""
+        listing = self.listing(
+            ('Part Number', 'X' * (MANUFACTURER_PART_NUMBER_MAX_LENGTH + 1)),
+        )
+
+        assert listing.manufacturer_part_number() is None
+
+
 class TestTheListingFillsTheForm:
     """US1: the price and the brand arrive without the operator typing them.
 
@@ -1180,6 +1296,66 @@ class TestTheListingFillsTheForm:
 
         assert re.search(r'<input[^>]*id="unit_price"[^>]*value=""', body)
         assert re.search(r'<input[^>]*id="manufacturer"[^>]*value=""', body)
+
+
+class TestThePartNumberFillsTheForm:
+    """019 US1 scenario 1: the field arrives filled, on every first render.
+
+    ``TestTheListingFillsTheForm`` above is the same story for the price and the
+    brand. This one is separate because its rule is not that one: the field is
+    filled by a **presence** test on form_data rather than a truthiness test, so
+    a cleared value can survive. The clearing half lives in
+    ``TestAClearedPartNumberStaysCleared``.
+    """
+
+    def payload(self, *rows):
+        return json.dumps({
+            'version': 1,
+            'source_url': AMAZON_URL,
+            'specifications': [{'name': n, 'value': v} for n, v in rows],
+        })
+
+    def field_of(self, response):
+        """The rendered value of the manufacturer_part_number input"""
+        html = response.data.decode()
+        match = re.search(
+            r'id="manufacturer_part_number".*?value="([^"]*)"', html, re.S,
+        )
+        assert match, 'the manufacturer part number input is not on the page'
+        return match.group(1)
+
+    def test_the_get_form_arrives_filled_from_the_listing(self, client):
+        response = client.get(
+            '/products/capture',
+            query_string={'url': AMAZON_URL,
+                          'listing': self.payload(('Mfr Part Number', '7700-B'))},
+        )
+
+        assert self.field_of(response) == '7700-B'
+
+    def test_the_bookmarklet_landing_arrives_filled_from_the_listing(self, client):
+        """The other first render: a form POST to /api/capture, which writes nothing"""
+        response = client.post('/api/capture', data={
+            'url': AMAZON_URL,
+            'listing': self.payload(('Item model number', 'MKT-7700')),
+        })
+
+        assert self.field_of(response) == 'MKT-7700'
+
+    def test_a_listing_naming_no_part_number_leaves_the_field_empty(self, client):
+        response = client.get(
+            '/products/capture',
+            query_string={'url': AMAZON_URL,
+                          'listing': self.payload(('Voltage', '12 Volts'))},
+        )
+
+        assert self.field_of(response) == ''
+
+    def test_a_capture_with_no_listing_at_all_leaves_the_field_empty(self, client):
+        """FR-009: the paste-a-URL path behaves exactly as it did before"""
+        response = client.get('/products/capture', query_string={'url': AMAZON_URL})
+
+        assert self.field_of(response) == ''
 
 
 class TestFilingReachesTheProductFromTheForm:
@@ -1759,6 +1935,116 @@ def spec_rows(service, product_id):
     ]
 
 
+class TestAClearedPartNumberStaysCleared:
+    """019 US2 / FR-005 and FR-006: a default the operator can actually refuse.
+
+    The half of this feature that makes the other half safe. A part number
+    guessed from a `Model Number` row will sometimes be wrong, and a wrong one
+    corroborates a later repeat buy against the wrong product -- so the operator
+    emptying the field has to mean something, on the submission and on the
+    re-render after a question.
+
+    The re-render is where this differs from the manufacturer and unit price
+    fields beside it: those use `or` in the template, and `''` is falsy, so a
+    cleared value comes back filled. Aligning them is deliberately out of scope
+    (see the spec's assumptions); this class is what stops the part number from
+    joining them.
+    """
+
+    def payload(self, name='Mfr Part Number', value='7700-B'):
+        return json.dumps({
+            'version': 1,
+            'source_url': AMAZON_URL,
+            'specifications': [{'name': name, 'value': value}],
+        })
+
+    def post(self, client, **form):
+        data = {'url': AMAZON_URL, 'listing_title': '12V PSU'}
+        data.update(form)
+        return client.post('/products/capture', data=data, follow_redirects=False)
+
+    def only_product(self, service):
+        products = service.list_products()
+        assert len(products) == 1
+        return products[0]
+
+    def field_of(self, response):
+        match = re.search(
+            r'id="manufacturer_part_number".*?value="([^"]*)"',
+            response.data.decode(), re.S,
+        )
+        assert match, 'the manufacturer part number input is not on the page'
+        return match.group(1)
+
+    @pytest.fixture
+    def already_named(self, service):
+        """A product the item id already names -- posting raises the question"""
+        return service.create_product(
+            description='Something already cataloged',
+            identifiers=[{'id_type': 'VENDOR', 'value': 'B0ABCDEFGH', 'vendor': 'Amazon'}],
+        )
+
+    # -- the write ---------------------------------------------------------
+
+    def test_a_field_that_never_arrived_falls_back_to_the_listing(self, client, service):
+        """FR-005: absent is not a decision, so the listing fills it"""
+        self.post(client, listing=self.payload())
+
+        assert self.only_product(service).manufacturer_part_number == '7700-B'
+
+    def test_an_empty_field_is_a_decision_and_stores_nothing(self, client, service):
+        """FR-005 / US2 scenario 2: the derived value is not put back"""
+        self.post(client, listing=self.payload(), manufacturer_part_number='')
+
+        assert self.only_product(service).manufacturer_part_number is None
+
+    def test_a_typed_field_wins_over_the_listing(self, client, service):
+        """US2 scenario 1"""
+        self.post(
+            client, listing=self.payload(), manufacturer_part_number='What I know it is',
+        )
+
+        assert self.only_product(service).manufacturer_part_number == 'What I know it is'
+
+    def test_a_capture_with_no_listing_is_unaffected(self, client, service):
+        """FR-009: the path with no payload behaves exactly as it did before"""
+        self.post(client, manufacturer_part_number='Typed by hand')
+
+        assert self.only_product(service).manufacturer_part_number == 'Typed by hand'
+
+    # -- the re-render -----------------------------------------------------
+
+    def test_a_cleared_field_comes_back_cleared(self, client, already_named):
+        """FR-006 / US2 scenario 3.
+
+        Written with `or` in the template this fails: '' is falsy, the listing
+        fills the blank a second time, and the operator's decision is undone by
+        a question they were only asked because of something else.
+        """
+        response = self.post(
+            client, listing=self.payload(), manufacturer_part_number='',
+        )
+
+        assert response.status_code == 200
+        assert self.field_of(response) == ''
+
+    def test_a_typed_field_comes_back_as_typed(self, client, already_named):
+        response = self.post(
+            client, listing=self.payload(), manufacturer_part_number='Mine',
+        )
+
+        assert response.status_code == 200
+        assert self.field_of(response) == 'Mine'
+
+    def test_the_question_does_not_write_the_part_number_either(
+        self, client, service, already_named
+    ):
+        """Nothing is written by a capture that stopped to ask"""
+        self.post(client, listing=self.payload())
+
+        assert service.get_product(already_named.id).manufacturer_part_number is None
+
+
 class TestWhichRowNamesMeanABarcode:
     """FR-001: six names, folded -- and nothing else, however barcode-shaped"""
 
@@ -1782,6 +2068,53 @@ class TestWhichRowNamesMeanABarcode:
     @pytest.mark.parametrize('name', [None, '', '   '])
     def test_a_missing_name_is_not_a_barcode_row(self, name):
         assert not _is_barcode_row_name(name)
+
+
+class TestWhichRowNamesMeanAPartNumber:
+    """019 FR-001: five names, folded -- and nothing else"""
+
+    def named(self, name, value='7700-B'):
+        return ListingCapture(
+            source_url=AMAZON_URL, specifications=[{'name': name, 'value': value}],
+        ).manufacturer_part_number()
+
+    @pytest.mark.parametrize('name', [
+        'Manufacturer Part Number', 'Mfr Part Number', 'Part Number',
+        'Model Number', 'Item model number',
+    ])
+    def test_the_five_names_are_recognized(self, name):
+        assert self.named(name) == '7700-B'
+
+    @pytest.mark.parametrize('name', [
+        'mfr part number', 'MFR PART NUMBER', '  Mfr Part Number  ',
+        'Mfr  Part   Number', '\tItem Model Number\n',
+    ])
+    def test_case_and_whitespace_are_folded(self, name):
+        """Internal runs collapse too, not only the surrounding ones"""
+        assert self.named(name) == '7700-B'
+
+    @pytest.mark.parametrize('name', [
+        'Vendor Part Number', 'Part Numbers', 'Number', 'Serial Number',
+        'Manufacturer', 'Model', 'UPC',
+    ])
+    def test_the_whole_name_must_match_not_a_part_of_it(self, name):
+        """A feature that promised five names should fill from five names"""
+        assert self.named(name) is None
+
+    @pytest.mark.parametrize('name', [None, '', '   '])
+    def test_a_missing_name_is_not_a_part_number_row(self, name):
+        assert self.named(name) is None
+
+    @pytest.mark.parametrize('wanted', PART_NUMBER_ROW_NAMES)
+    def test_every_recognized_name_is_stored_already_normalized(self, wanted):
+        """A typo here would make an entry permanently unmatchable, silently.
+
+        The tuple is compared against ``normalized_row_name(...)`` output, so an
+        entry that is not itself normalized can never equal anything. No test
+        that goes through a listing would notice -- the name would simply never
+        match, which is indistinguishable from a listing that does not carry it.
+        """
+        assert normalized_row_name(wanted) == wanted
 
 
 class TestACapturedBarcodeBecomesAnIdentifier:


### PR DESCRIPTION
Closes #90.

The capture read the vendor's product-information rows, displayed them, and left the Manufacturer Part Number field blank even when one of those rows *was* the part number. On `B0CZ72JRHP` and `B0FX4PDW6M` the rows included `Model Number` and `Mfr Part Number` and the field still had to be typed by hand.

## What it does

`ListingCapture.manufacturer_part_number()` walks five recognized row names in priority order — `Manufacturer Part Number`, `Mfr Part Number`, `Part Number`, `Model Number`, `Item model number` — and returns the first usable value, trimmed. The walk is names-outer, rows-inner, so FR-002's two rules fall out of the loop shape rather than being written: priority is by position in the list and never by position on the vendor's page, and among rows sharing a name the first captured wins.

Name folding goes through `normalized_row_name`, which is `_is_barcode_row_name`'s body lifted out and now shared by both. `TestWhichRowNamesMeanABarcode` passing **untouched** was the gate on that move.

The field's template expression tests whether the key is **present** in `form_data`, not whether its value is truthy. That one change covers every render path: `form_data` has no such key on either first render (the bookmarklet's landing dict, `request.args` on the GET) so the listing fills the field, and always has one on a re-render, so what comes back is what the operator decided — **including their decision to empty it**. Written with `or`, a cleared field refills itself the moment the capture asks a question.

A candidate longer than the column is passed over rather than offered, and never truncated. Nothing between the form and the database checks length, so an over-long default would submit, the capture would run, the gallery would be retrieved, and only then would the write fail — over a value nobody typed.

## The part worth reviewing carefully

**The recycled-identifier question is no longer raised on a re-capture, and this was not anticipated in the spec or the plan.**

`_corroborates` requires the manufacturer **and** the part number to agree before a capture may attach to a product whose identifier it landed on. The capture has always supplied the manufacturer and never the part number, so the pair never corroborated and every re-capture raised the question. Filling the part number supplies the missing half.

It surfaced as two existing E2E tests failing — both used that question to reach their subject. It is the outcome US1 is named for ("the second half of the pair that lets a repeat buy attach without asking"), so rather than bending the behavior back I documented it: a spec edge case, SC-006a, and `test_a_repeat_buy_no_longer_has_to_answer_the_identifier_question` pinning it. The two existing tests now clear the field on their first capture, with a comment saying why. The duplicate-purchase question is untouched — no part number can answer "did you order this twice today?".

## Scope call to confirm

FR-006 gives this field redisplay behavior its neighbours don't have. **`manufacturer` and unit price still re-apply their derived default over a field the operator cleared** when the capture comes back with a question — their write path draws the absent-versus-empty distinction correctly, but their template uses `or` and `''` is falsy. Reading issue #90's "the operator must still be able to clear it" as requiring the stronger behavior leaves one field in the form behaving differently from two others.

Aligning them is deliberately out of scope here and recorded as such in the spec's assumptions, in `contracts/README.md`, and as task T017 ("those two hunks must not appear in this diff"). If you'd rather have three consistent fields, that's a follow-up issue.

## Two plan corrections made during implementation

- **The E2E fixture's unusable row is over-long (101 chars), not empty.** The plan called for an empty higher-priority row; the agent drops a row with no value at `capture-agent.js:295`, so an empty cell never reaches Python and a test built on one proves nothing. Empty and whitespace-only are covered in unit tests, where they are reachable.
- **No screenshot is committed.** `order_capture.png` came back byte-identical — the template edit adds a Jinja comment and an expression that yields the same empty string in a scenario with no listing. Nine unrelated images churned by a few hundred bytes and were reverted.

## Verification

| Suite | Result |
|---|---|
| `nox -s tests` | 1432 passed (baseline 1384) |
| `nox -s e2e` | 558 passed, 0 failed |
| `nox -s screenshots_verify` | 18 verified |

A mutation check confirms the FR-006 guard bites: rewriting the template expression as `form_data.get(...) or ...` fails `test_a_cleared_field_comes_back_cleared` and nothing else in the suite.

**Not run**: the by-hand pass against the real `B0CZ72JRHP` and `B0FX4PDW6M` listings (quickstart §6) needs a TLS-served instance. SC-001 is proven against the E2E fixture instead.

## Not in this diff, on purpose

No migration, no new dependency, no JavaScript, no `LISTING_CAPTURE_VERSION` bump (that would make every cached bookmarklet capture with no payload at all), no change to `app/database.py` or `_form_fields.html`.

Spec, plan, research, data model, contracts, quickstart and tasks are in `specs/019-capture-mpn-default/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gGKf9Di9BohiNC62sMWiH
