### PR TITLE
fix: trust the proxy's forwarded scheme and host (#89)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,7 +30,7 @@ def create_app(config_class=Config, storage_backend=None):
     # the proxy has to actually set the headers, which the deployment guide
     # says.
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
-    
+
     # Store the storage backend in app config for access by routes
     if storage_backend:
         app.config['STORAGE_BACKEND'] = storage_backend

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 from flask import Flask
 from flask_wtf.csrf import CSRFProtect
+from werkzeug.middleware.proxy_fix import ProxyFix
 from config import Config
 from app.logging_config import setup_logging
 from app.error_handlers import create_error_handlers
@@ -17,6 +18,18 @@ def create_app(config_class=Config, storage_backend=None):
     """
     app = Flask(__name__)
     app.config.from_object(config_class)
+
+    # Behind a TLS-terminating reverse proxy the app itself speaks plain HTTP,
+    # so Werkzeug reports `request.scheme == 'http'` for a page the browser
+    # loaded over https. That is not cosmetic: the capture bookmarklet bakes in
+    # `url_for(..., _external=True)` addresses at render time, so it shipped
+    # http:// addresses that a vendor's `upgrade-insecure-requests` then broke
+    # (issue #89). Trusting one hop of X-Forwarded-Proto / -Host fixes the
+    # scheme, the host and therefore those URLs. This is LAN-only with one
+    # trusted user, so there is no header-spoofing concern -- but it does mean
+    # the proxy has to actually set the headers, which the deployment guide
+    # says.
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
     
     # Store the storage backend in app config for access by routes
     if storage_backend:

--- a/app/product/routes.py
+++ b/app/product/routes.py
@@ -589,7 +589,11 @@ def _capture_bookmarklet() -> str:
     per capture, which is not worth a version-stamping mechanism.
 
     Both addresses are absolute and are fixed when *this* page renders, which is
-    why the TLS caveat below is about where you drag it from.
+    why the TLS caveat below is about where you drag it from. Their scheme is
+    whatever ``request.scheme`` says, which behind a TLS-terminating proxy means
+    whatever ``X-Forwarded-Proto`` says -- see the ``ProxyFix`` wrapping in
+    ``create_app``. Without it the page renders over https and hands out http
+    addresses, which is issue #89.
 
     The agent still submits a **form into a new tab** rather than issuing a
     fetch: the vendor page is HTTPS and this app is plain HTTP on the LAN, so a

--- a/app/templates/product/capture.html
+++ b/app/templates/product/capture.html
@@ -334,6 +334,12 @@
                     an SSL error instead of reaching the app. Open this page over
                     <code>https</code> and drag it again. The paste box on the left works either
                     way.
+                    {# If the address bar says https and this box is still here, the TLS
+                       terminator in front of the app is not sending X-Forwarded-Proto:
+                       the app is reading the connection it actually got. Issue #89. #}
+                    If the address bar already says <code>https</code>, the reverse proxy
+                    terminating TLS is not sending <code>X-Forwarded-Proto</code>, and the app
+                    cannot tell.
                 </div>
                 {% endif %}
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -708,6 +708,38 @@ release. If it is higher, the workflow builds and pushes
 creates a `v<version>` GitHub release with generated notes. If the version is
 unchanged, the workflow does nothing, so ordinary merges to `main` are safe.
 
+## Serving Behind a TLS Reverse Proxy
+
+If you terminate TLS in front of the application -- nginx, Caddy, Traefik -- the
+proxy must pass the original scheme and host through:
+
+```nginx
+location / {
+    proxy_pass http://workshop-inventory:5000;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+}
+```
+
+The application trusts exactly one hop of those headers
+(`werkzeug.middleware.proxy_fix.ProxyFix` in `app/__init__.py`). It has to,
+because the connection it actually receives is plain HTTP: without them it
+reports the page as `http` even though the browser loaded it over `https`.
+
+That matters in one place beyond cosmetics. The capture bookmarklet on
+`/products/capture` bakes the server's own address into itself when that page
+renders. If the app thinks it is on `http`, the bookmarklet points at `http`,
+and a vendor page sending `upgrade-insecure-requests` rewrites that to `https`
+and fails against a server that does not answer TLS on that port. The page shows
+a warning box whenever it believes it is being served over `http`, so if you are
+looking at an `https` address bar and still see that box, the proxy is not
+sending `X-Forwarded-Proto`.
+
+Nothing here is a security control. On a LAN-only single-user application there
+is no one to spoof the headers; the trust is there so the URLs come out right.
+
 ## Security Posture for `/api/*` Endpoints
 
 The application exposes a handful of JSON endpoints under `/api/*`

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -394,6 +394,11 @@ sudo systemctl status nginx
 2. **SSL certificate problems**
 3. **Upstream connection failures**
 4. **File permission issues**
+5. **Missing `X-Forwarded-Proto`** -- the app then reads the plain-HTTP hop it
+   received rather than the HTTPS the browser used. The visible symptom is the
+   "Not from this page" warning on `/products/capture` at an `https` address
+   bar, and a bookmarklet that points at `http`. See
+   [Serving Behind a TLS Reverse Proxy](deployment-guide.md#serving-behind-a-tls-reverse-proxy).
 
 #### Nginx Logs
 ```bash

--- a/tests/e2e/test_order_capture.py
+++ b/tests/e2e/test_order_capture.py
@@ -301,6 +301,29 @@ def test_the_bookmarklet_is_offered_and_points_at_this_server(page, live_server)
     assert "fetch(" not in href
 
 
+@pytest.mark.e2e
+def test_the_bookmarklet_follows_the_proxy_s_scheme(page, live_server):
+    """Behind a TLS terminator the page is on https and must say so (issue #89).
+
+    The test server speaks plain http, which is exactly the deployment this is
+    about: nginx terminates TLS and forwards http, so the only thing that tells
+    the app what the browser used is `X-Forwarded-Proto`. Without ProxyFix the
+    page renders the http warning at an https address bar *and* hands out an
+    http bookmarklet -- the very failure the warning exists to prevent.
+    """
+    page.set_extra_http_headers({"X-Forwarded-Proto": "https"})
+    page.goto(f"{live_server.url}/products/capture")
+
+    expect(page.locator("#capture-bookmarklet")).to_be_visible()
+    expect(page.locator("#bookmarklet-http-warning")).to_have_count(0)
+
+    href = page.locator("#capture-bookmarklet").get_attribute("href")
+    https_url = live_server.url.replace("http://", "https://")
+    assert f"{https_url}/static/js/capture-agent.js" in href
+    assert f"{https_url}/api/capture" in href
+    assert "http://" not in href
+
+
 # ---------------------------------------------------------------------------
 # The unit price of one item out of a pack (issue #97)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_proxy_headers.py
+++ b/tests/unit/test_proxy_headers.py
@@ -1,0 +1,74 @@
+"""
+The scheme the browser used, not the one the proxy handed us (issue #89).
+
+nginx terminates TLS and talks plain HTTP to the app, so without
+``ProxyFix`` Werkzeug reports ``request.scheme == 'http'`` for a page the
+operator loaded over ``https``. The capture page is where that stops being
+cosmetic: its bookmarklet bakes in ``url_for(..., _external=True)`` addresses
+when the page renders, so it shipped ``http://`` addresses that a vendor's
+``upgrade-insecure-requests`` rewrote to ``https`` and broke -- while the page
+displayed a warning telling the operator to do the thing they had already done.
+
+The warning itself is still right and still tested: reached over plain http, with
+no proxy in front, nothing has changed.
+"""
+
+import html
+import re
+
+import pytest
+
+
+def bookmarklet_of(response):
+    """The bookmarklet's href, unescaped"""
+    match = re.search(
+        r'id="capture-bookmarklet"\s*\n\s*href="([^"]*)"', response.data.decode(),
+    )
+    assert match, 'the bookmarklet is not on the page'
+    return html.unescape(match.group(1))
+
+
+@pytest.mark.unit
+class TestTheForwardedSchemeIsBelieved:
+    def test_the_warning_is_gone_when_the_proxy_says_https(self, client):
+        response = client.get(
+            '/products/capture', headers={'X-Forwarded-Proto': 'https'},
+        )
+
+        assert response.status_code == 200
+        assert b'id="bookmarklet-http-warning"' not in response.data
+
+    def test_both_baked_in_addresses_are_https(self, client):
+        """The failure the warning box exists to prevent, caused by the app itself"""
+        href = bookmarklet_of(client.get(
+            '/products/capture', headers={'X-Forwarded-Proto': 'https'},
+        ))
+
+        assert "s.src='https://localhost/static/js/capture-agent.js" in href
+        assert "s.dataset.endpoint='https://localhost/api/capture'" in href
+        assert 'http://' not in href
+
+    def test_the_forwarded_host_is_believed_too(self, client):
+        """A container's own hostname is no use to a browser on the LAN"""
+        href = bookmarklet_of(client.get('/products/capture', headers={
+            'X-Forwarded-Proto': 'https', 'X-Forwarded-Host': 'shop.example.com',
+        }))
+
+        assert "s.src='https://shop.example.com/static/js/capture-agent.js" in href
+        assert "s.dataset.endpoint='https://shop.example.com/api/capture'" in href
+
+
+@pytest.mark.unit
+class TestPlainHttpIsUnchanged:
+    """No proxy, no headers: the app reads the connection it actually got"""
+
+    def test_the_warning_is_shown(self, client):
+        response = client.get('/products/capture')
+
+        assert b'id="bookmarklet-http-warning"' in response.data
+
+    def test_both_baked_in_addresses_are_http(self, client):
+        href = bookmarklet_of(client.get('/products/capture'))
+
+        assert "s.src='http://localhost/static/js/capture-agent.js" in href
+        assert "s.dataset.endpoint='http://localhost/api/capture'" in href


### PR DESCRIPTION
Fixes #89.

## The bug

nginx terminates TLS and proxies plain HTTP, and nothing in the app trusted the forwarding headers — so Werkzeug saw `request.scheme == 'http'` for a page the browser had loaded over `https`.

Two consequences on `/products/capture`:

* the "Not from this page" `http` warning rendered at an `https` address bar, telling the operator to do what they had already done;
* `_capture_bookmarklet()` baked `http://` into both `url_for(..., _external=True)` addresses, so a vendor sending `upgrade-insecure-requests` rewrote them to `https` and the bookmarklet died with an SSL error. That is the failure the banner exists to warn about, and the app was causing it.

## The fix

`app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)` in `create_app`. One hop; on a LAN-only single-user app there is nobody to spoof the headers, so the trust is there to get the URLs right, not as a security control. It does mean the proxy has to actually send `X-Forwarded-Proto` — the deployment guide now has a "Serving Behind a TLS Reverse Proxy" section with the nginx snippet, and the troubleshooting guide's nginx list names the visible symptom.

The warning box also now says that an `https` address bar plus a visible box means the proxy is not forwarding the header.

## Tests

* `tests/unit/test_proxy_headers.py` (new, 5 tests) — with `X-Forwarded-Proto: https` the warning is gone and both baked-in addresses are `https`; `X-Forwarded-Host` is honoured; with no headers at all nothing changes.
* `tests/e2e/test_order_capture.py::test_the_bookmarklet_follows_the_proxy_s_scheme` — the same through a real browser against the plain-HTTP test server, which is the deployment shape in question.

All three of the forwarded-header assertions fail with the `ProxyFix` line commented out; verified.

Full suites: `nox -s tests` 1437 passed, `nox -s e2e` 559 passed, working tree clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXCQtT6NH1nexFCroWBoQ6