### PR TITLE
feat(capture): read the "About this item" bullets (#92)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/019-capture-mpn-default"
+  "feature_directory": "specs/020-capture-about-this-item"
 }

--- a/app/static/js/capture-agent.js
+++ b/app/static/js/capture-agent.js
@@ -210,6 +210,23 @@
         '#detailBullets_feature_div'
     ];
 
+    // "About this item": the bullets Amazon writes above the detail tables, and
+    // on some listings the only place a physical fact appears at all. Every
+    // dimension B01N4OSKWE publishes is in its five bullets and in no table on
+    // the page, which is why issue #92 called the capture of it an empty record.
+    //
+    // **Not a member of the list above, and it could not be.** `rowsFrom`'s two
+    // shapes are a two-cell table row and a bullet with a bold name span; an
+    // About-this-item bullet is neither, so adding this selector there would
+    // read the container and find nothing in it. It needs its own reader.
+    //
+    // The container holds more than the bullets -- see `bulletsRow`.
+    const BULLET_CONTAINER = '#feature-bullets';
+
+    // The row name, matching the heading the listing itself puts on the section.
+    // Folded case-insensitively by both merges, like every other captured name.
+    const BULLET_ROW_NAME = 'About this item';
+
     /** Trim the punctuation Amazon puts between a bullet's name and its value. */
     function tidyName(name) {
         // The bidi marks are literally in the markup: "Date First Available ‏ : ‎".
@@ -264,6 +281,64 @@
     }
 
     /**
+     * The listing's "About this item" bullets as one row, or null (issue #92).
+     *
+     * **Read from the `li` elements, never from the container's own text.**
+     * `#feature-bullets` carries an `<h2>About this item</h2>` heading and, after
+     * the list, a `<div>` holding "See more product details" -- both inside the
+     * container and both outside the `<ul>`. A reader taking the container's
+     * `textContent` captures them: on a real listing it begins "About this item
+     * Country of Manufacture: CHINA...". Scoping to `li` excludes both for free,
+     * and excludes nothing a bullet contains.
+     *
+     * **There is deliberately no visibility test here, and there could not be
+     * one.** Issue #92 expected a hidden "See more product details" list item;
+     * on all three listings read on 2026-08-19 it is a visible sibling `div`
+     * instead, and no bullet was hidden by anything. That is just as well,
+     * because `canonicalDocument()` hands this a `DOMParser` document: detached,
+     * unstyled, without layout. `offsetHeight` is 0 for every element in it and
+     * `getComputedStyle` reports the UA default rather than what Amazon's CSS
+     * would produce, so "is the shopper shown this" cannot be asked on this side
+     * of the fetch at all. Excluding the furniture is structural or it does not
+     * happen.
+     *
+     * Bullets are joined with **one** newline rather than two: they are list
+     * items, not paragraphs, and `proseFrom` already emits paragraph breaks for
+     * the block structure *within* a bullet.
+     *
+     * Returns null rather than a row with an empty value. `_payload_specifications`
+     * would drop such a row on arrival and nobody would ever hear about it.
+     */
+    function bulletsRow(doc) {
+        const container = doc.querySelector(BULLET_CONTAINER);
+        if (!container) {
+            return null;
+        }
+
+        const lines = [];
+        const items = container.querySelectorAll('li');
+        for (let i = 0; i < items.length; i++) {
+            // A nested list belongs to the bullet containing it, not to the
+            // page. `querySelectorAll` returns the outer and inner items both,
+            // and taking both would emit the nested text twice -- once inside
+            // its parent's prose and once on a line of its own.
+            const parent = items[i].parentElement;
+            if (parent && parent.closest('li')) {
+                continue;
+            }
+            const line = proseOf(items[i]);
+            if (line) {
+                lines.push(line);
+            }
+        }
+
+        if (!lines.length) {
+            return null;
+        }
+        return { name: BULLET_ROW_NAME, value: lines.join('\n') };
+    }
+
+    /**
      * Every product-information row, merged across the page's containers.
      *
      * FR-008 and FR-009. Names differing only in case or surrounding whitespace
@@ -282,6 +357,18 @@
     function specificationsFrom(doc) {
         const entries = [];
         const seen = {};
+
+        // The bullets lead, as they do on the page -- and they are seeded into
+        // the fold rather than merely pushed onto the list. A listing naming a
+        // detail-table row "About this item" as well would otherwise yield two
+        // rows of one name, which is the one duplicate neither this fold nor
+        // merge_specifications downstream would catch. Seeding also settles the
+        // collision the right way round: what survives is the bullets.
+        const bullets = bulletsRow(doc);
+        if (bullets) {
+            entries.push(bullets);
+            seen[bullets.name.toLowerCase()] = true;
+        }
 
         for (let i = 0; i < SPECIFICATION_CONTAINERS.length; i++) {
             const container = doc.querySelector(SPECIFICATION_CONTAINERS[i]);

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -908,9 +908,17 @@ Two ways in:
 2. **The bookmarklet.** Drag *Capture to Workshop* to your bookmarks bar once. On
    a listing, click it: a new tab opens on this application's confirmation page,
    already filled in. It now reads the listing itself, not just the address --
-   for an Amazon page that means the price, the brand, the description, every
-   *Product information* row, and every image the page's own data names, which is
-   usually more than the thumbnail strip shows.
+   for an Amazon page that means the price, the brand, the description, the
+   *About this item* bullets, every *Product information* row, and every image
+   the page's own data names, which is usually more than the thumbnail strip
+   shows.
+
+   **The *About this item* bullets arrive as one specification row** of that
+   name, one bullet to a line. Read them: on some listings that section is the
+   only place the dimensions appear at all, and before this the capture skipped
+   it entirely. The row is yours like any other -- edit it, delete it -- and
+   capturing the same listing again neither adds a second copy nor writes over
+   what you changed.
 
    **Manufacturer Part Number is filled from those rows too.** A row named
    *Manufacturer Part Number*, *Mfr Part Number*, *Part Number*, *Model Number*

--- a/specs/020-capture-about-this-item/checklists/requirements.md
+++ b/specs/020-capture-about-this-item/checklists/requirements.md
@@ -1,0 +1,47 @@
+# Specification Quality Checklist: Capture Reads the "About this item" Bullets
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- **Validation pass (2026-08-19)**: all items pass on the first iteration. Two judgement calls
+  recorded rather than left silent:
+  - **FR-014** names the end-to-end test fixtures. This is a deliberate carry-through of issue
+    #92's own instruction ("put what it finds back into the hand-written e2e fixture as real
+    markup") and states an observable property of the delivered work, not a technique. It is not a
+    language, framework or API detail.
+  - **SC-001 / SC-002** name two specific vendor listings (`B01N4OSKWE`, `B0FX4PDW6M`). These are
+    the issue's own verification cases and are what makes the criteria checkable; they identify
+    inputs, not implementation.
+- **No [NEEDS CLARIFICATION] markers were raised.** The one genuinely open choice — a specification
+  row versus text appended to the description — is resolved in the Assumptions section in favor of
+  the row, which is the option issue #92 itself favors. It is flagged there as the decision most
+  worth revisiting.

--- a/specs/020-capture-about-this-item/contracts/bullets-reader.md
+++ b/specs/020-capture-about-this-item/contracts/bullets-reader.md
@@ -1,0 +1,34 @@
+# Contract: the bullets reader
+
+**Unit**: a new function in `app/static/js/capture-agent.js`, alongside `specificationsFrom()`.
+Internal to one file — recorded here because it is the whole of the feature's new logic and its
+obligations are easier to test than to infer.
+
+## Signature
+
+```
+bulletsRow(doc) -> { name: 'About this item', value: '<line>\n<line>…' } | null
+```
+
+`doc` is whatever `canonicalDocument()` yielded: **usually a detached `DOMParser` document with no
+layout and no stylesheets**, and on the fallback path the live `document`. The function must behave
+identically against both. See research.md §1, Correction 2 — this is why no visibility test is
+available.
+
+## Obligations
+
+| # | Obligation | Spec |
+|---|------------|------|
+| R-1 | Reads only `li` elements inside the bullet container. The `About this item` heading and the `See more product details` link are outside the `<ul>` and are excluded structurally, not by filtering. | FR-005 |
+| R-2 | Each surviving `li` contributes exactly one line, using the file's existing prose reader so stylesheets and scripts cannot appear as text. | FR-003, FR-007 |
+| R-3 | An `li` whose prose is empty contributes no line and no blank line. | FR-006 |
+| R-4 | Lines are joined with a single `\n`, in document order, and the result is trimmed. | FR-003, FR-004 |
+| R-5 | Returns `null` — never a row with an empty value — when the container is absent or no `li` yields text. | FR-008 |
+| R-6 | **Never throws, for any input.** A missing container, a container with no list, a document that is not a listing at all: each yields `null`. | FR-011 |
+| R-7 | Does not mutate `doc`. The fallback path hands it the page the operator is looking at. | existing FR-003 of feature 007 |
+
+## Call site
+
+`specificationsFrom(doc)` calls it once and, when it returns a row, seeds both the output array and
+the `seen` fold with it **before** the container loop. Seeding the fold is what makes C-5 and FR-009
+true; appending without seeding would let a detail table produce a second row of the same name.

--- a/specs/020-capture-about-this-item/contracts/listing-payload.md
+++ b/specs/020-capture-about-this-item/contracts/listing-payload.md
@@ -1,0 +1,60 @@
+# Contract: the `listing` payload, after this feature
+
+**Boundary**: `app/static/js/capture-agent.js` (producer) → `POST /product/capture`, field `listing`
+→ `ListingCapture.from_json` (consumer, `app/models.py`).
+
+This is the one machine boundary the feature crosses. Both sides are in this repository, but they
+are separated by a *cached* script the operator may not have reloaded, so the compatibility rule
+below is real rather than ceremonial.
+
+## Version
+
+```
+version: 1        (unchanged — LISTING_CAPTURE_VERSION = 1)
+```
+
+**The version does not move.** The payload's shape is identical; only the contents of an existing
+array change. A stale cached agent keeps producing a valid version-1 payload without the bullets
+row, which degrades to today's behavior and is replaced on the next load. Bumping to 2 would make
+`from_json` reject every stale agent for no benefit.
+
+## The delta
+
+`specifications` is unchanged in type — `[{name, value}, …]` — and gains **at most one entry**:
+
+```json
+{
+  "version": 1,
+  "specifications": [
+    { "name": "About this item",
+      "value": "First bullet, as the listing wrote it\nSecond bullet\nThird bullet" },
+    { "name": "Material", "value": "6061 Aluminium" },
+    { "name": "Item Length", "value": "300 Millimeters" }
+  ]
+}
+```
+
+Guarantees the producer makes:
+
+| # | Guarantee |
+|---|-----------|
+| C-1 | The entry's `name` is exactly `About this item`. |
+| C-2 | Its `value` holds one bullet per line, `\n`-separated, in the listing's own order. No trailing newline, no blank line between bullets. |
+| C-3 | The entry is **first** in the array when present, before every container-derived row (FR-010). |
+| C-4 | The entry is **absent entirely** when the listing has no bullet list or none of its bullets yields text (FR-008). An entry with an empty `value` is never produced. |
+| C-5 | At most one such entry exists per payload — `specificationsFrom()`'s existing case-insensitive fold guarantees it even if a detail table also publishes the name. |
+| C-6 | No other field of the payload changes for any listing (FR-012). |
+
+Guarantees the consumer already makes, which this feature relies on rather than re-implements:
+
+| # | Guarantee | Where |
+|---|-----------|-------|
+| C-7 | An entry with an empty name or value is dropped, not an error | `_payload_specifications`, `app/models.py:783` |
+| C-8 | A captured name the product already carries is dropped whole, value included | `CatalogService.merge_specifications` |
+| C-9 | Newlines in a `value` survive storage, display and editing | #91's work; `detail.html:106`, `_form_fields.html:51` |
+
+## What is not in the contract
+
+- Any promise about *which* bullets exist. That is the vendor's, and it changes without notice.
+- Any promise that the row is present for a given ASIN. FR-011 makes reading the bullets optional;
+  a payload with no `About this item` entry is well-formed and always was.

--- a/specs/020-capture-about-this-item/data-model.md
+++ b/specs/020-capture-about-this-item/data-model.md
@@ -1,0 +1,59 @@
+# Phase 1 Data Model: Capture Reads the "About this item" Bullets
+
+**Feature**: `specs/020-capture-about-this-item` | **Date**: 2026-08-19
+
+## There is no schema change
+
+No table, column, index or constraint is added or altered, and **no Alembic revision ships with this
+feature**. The bullets row is an ordinary `product_specifications` row; this feature adds a source
+for one, not a kind of one.
+
+Stated explicitly because Principle V makes migrations the only legitimate way to change the schema,
+and the easiest way to get this feature wrong would be to invent somewhere new to put the bullets.
+
+## The one entity involved
+
+### Bullets row — a `ProductSpecification` (`app/database.py:1182`)
+
+| Field | Value for this row | Constraint it must satisfy |
+|-------|--------------------|----------------------------|
+| `product_id` | the product the capture landed on | FK to `products.id`, `ON DELETE CASCADE` |
+| `name` | `About this item` — 15 characters | `String(100)`, and `MAX_SPECIFICATION_NAME_LENGTH = 100` in `CatalogService`. Comfortable. |
+| `value` | the listing's bullets, one per line, `\n`-separated | `MEDIUMTEXT` (widened in `b1a0c0d10009`). No application-level width check exists; the largest values in this table are already A+ descriptions of 20k+ characters, so a six-bullet list is unremarkable. |
+| `display_order` | assigned by `merge_specifications`, after the highest existing order | Set by the service, never by this feature |
+
+There is deliberately no `UniqueConstraint('product_id', 'name')` on this table — the deployed
+collation folds accents as well as case, which would be stricter than the requirement. Uniqueness of
+the `About this item` name is enforced in Python by `CatalogService._validate_specifications` and by
+`merge_specifications`' drop rule, exactly as it is for every other captured name.
+
+## The in-flight shape
+
+### `ListingCapture.specifications` (`app/models.py:677`)
+
+A `List[Dict[str, str]]` of `{'name', 'value'}`. The bullets row is one more entry in that list, in
+first position. **`LISTING_CAPTURE_VERSION` stays `1`** — the payload's *shape* is unchanged, only
+its contents, so a cached agent from before this feature degrades to today's behavior rather than
+being rejected. Bumping the version here would be wrong and would break every stale bookmarklet for
+no gain.
+
+`_payload_specifications` (`app/models.py:783`) drops any entry with an empty name or value before
+anything else sees it. That is the backstop behind FR-008, not the mechanism: the agent must not
+emit the row in the first place.
+
+## Validation, and where each rule lives
+
+| Rule | Enforced by | Note |
+|------|-------------|------|
+| Entry has both a name and a value | `_payload_specifications` | Drops silently; see research.md §4 |
+| Name ≤ 100 chars | `CatalogService._validate_specifications` | Raises `ValidationError` |
+| Name unique within one submission, case- and whitespace-insensitively | `_validate_specifications` (`key = name.lower()`) | Compared in Python, never in SQL |
+| A captured name the product already carries is dropped whole | `CatalogService.merge_specifications` | This is FR-009's second half — US2 is satisfied by existing code, and the feature's job is not to defeat it |
+| Names differing only in case/whitespace within one *reading* fold to the first | `specificationsFrom()` in `capture-agent.js` | FR-009's first half. Emitting the bullets row first is what decides the collision in its favor |
+
+## State transitions
+
+None. A specification row has no lifecycle: it is created, edited, or deleted. In particular there
+is **no "re-capture updates the row" transition** — FR-009 and US2 scenario 2 require the opposite,
+and `merge_specifications` already implements it by dropping the incoming duplicate rather than
+overwriting.

--- a/specs/020-capture-about-this-item/plan.md
+++ b/specs/020-capture-about-this-item/plan.md
@@ -1,0 +1,168 @@
+# Implementation Plan: Capture Reads the "About this item" Bullets
+
+**Branch**: `issues/92` | **Date**: 2026-08-19 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/020-capture-about-this-item/spec.md`
+
+## Summary
+
+Amazon's **About this item** bullets are the only place some listings publish their physical facts —
+on `B01N4OSKWE` every dimension the product has is in those five bullets and nowhere else — and the
+capture agent has never read them. Add a reader that takes the `li` elements out of
+`#feature-bullets` and emits them as one specification row named `About this item`, one bullet per
+line, placed first in the reading so the existing first-occurrence-wins fold resolves any name
+collision in its favor.
+
+The change is one new function and two edited lines in `app/static/js/capture-agent.js`, plus
+fixture and test work. No Python changes, no schema change, no migration, no new dependency.
+
+Two of issue #92's premises did not survive a live inspection of the markup on 2026-08-19 and the
+design follows what was actually there:
+
+- **"See more product details" is not a hidden `li`.** On all three listings probed it is a visible
+  sibling `div` after the `<ul>`. Reading `li` excludes it — and excludes the `<h2>About this
+  item</h2>` heading that sits inside the same container and that the issue does not mention.
+- **A visibility test is not implementable anyway.** `canonicalDocument()` hands the reader a
+  detached `DOMParser` document with no layout and no stylesheets, so `offsetHeight` is 0 and
+  `getComputedStyle` is meaningless. FR-005 is met structurally or not at all.
+
+See [research.md](research.md) for the observed markup and both corrections.
+
+## Technical Context
+
+**Language/Version**: ES5-compatible browser JavaScript (the capture agent runs in the operator's
+browser on a vendor's page, unbundled and untranspiled — the file uses `const`/`let` and no
+`async`/arrow-in-class syntax beyond what it already contains). Python 3.13 for the test suite.
+
+**Primary Dependencies**: None added. The agent depends on nothing but the DOM; the tests use
+Playwright, already present.
+
+**Storage**: MariaDB, `product_specifications`. **No schema change and no Alembic revision** — see
+[data-model.md](data-model.md).
+
+**Testing**: `nox -s tests` (no new coverage expected) and `nox -s e2e` (where all of this feature's
+coverage lands), against the hand-written fixtures in `tests/e2e/fixtures/`.
+
+**Target Platform**: Chrome on the operator's LAN workstation, reading amazon.com; Flask app on the
+same LAN.
+
+**Project Type**: Server-rendered Flask web application with a single injected client-side script.
+
+**Performance Goals**: None. The reader is one `querySelectorAll` over a container of five or six
+list items, inside an operation already dominated by an 8-to-15-second gallery fetch. Principle I
+forbids optimizing without a measurement, and there is nothing here to measure.
+
+**Constraints**: The reader must behave identically against a detached parsed document and against
+the live `document` (the fallback path), and must not be able to throw — a selector that stops
+matching costs the bullets row and nothing else.
+
+**Scale/Scope**: One function, one call site, two fixtures, roughly six e2e assertions. Single user,
+LAN-only, as ever.
+
+## Constitution Check
+
+*GATE: evaluated before Phase 0 and re-checked after Phase 1 design. Both passes below.*
+
+| Principle | Verdict | Note |
+|-----------|---------|------|
+| **I. Simplicity First** | **PASS** | One function, no abstraction, no configuration. The temptation this feature carries is a general "is this element visible" facility; research.md kills it twice over — it is not implementable on the detached document, and no bullet on any probed listing is hidden. Also declined: a hidden-marking-class filter, as machinery for a case with no observed instance. |
+| **II. Layered Architecture Boundaries** | **PASS** | Nothing crosses a layer. No route, service, storage or model file is touched; the change is entirely on the vendor side of the payload boundary, which the payload contract already defines. |
+| **III. Exact Numerics** | **PASS (N/A)** | No measured quantity is parsed or computed. The bullets are stored as text exactly as the listing wrote them — including `15 x 7 x 7mm/0.59"x0.28"x0.28"`, which is deliberately *not* interpreted into dimensions. |
+| **IV. Test Discipline Through Nox** | **PASS, with obligations** | All coverage runs through `nox -s e2e` with a ≥15-minute timeout. No new pytest marker. Every new wait must be on observable state — the capture flow's existing helpers already establish the landing page, and `#product-specifications` is server-rendered, so no `count()`/`text_content()` read may precede an `expect()` that establishes its region. |
+| **V. MariaDB Is the Source of Truth** | **PASS** | No schema change, so no migration. Stated in data-model.md so that "where does the bullets text live" cannot be answered by inventing a column. |
+| **VI. Item Lifecycle and History Invariants** | **PASS (N/A)** | Inventory items are untouched. This is the product catalog. |
+| **Operating Context** | **PASS** | No sanitization layer is added. The prose reader strips `style`/`script` because a stylesheet is not writing, not because a vendor is an attacker — that distinction is already made in the file. |
+| **Workflow: branch and PR** | **Required** | Non-trivial code change → feature branch `issues/92`, merged via PR. |
+| **Workflow: screenshots** | **Triggered, expected no-op** | `app/static/js/**` is touched. `capture-agent.js` is never loaded by an application template, so no screenshot can depend on it; `nox -s screenshots_verify` is run to establish that rather than assert it. |
+
+**Post-Phase-1 re-check**: unchanged. The design added no entity, no interface, and no dependency.
+The only thing Phase 1 added was the decision to emit the row *first* rather than last, which is one
+statement inside an existing loop and reduces work rather than adding it — it makes FR-009's
+collision case fall out of the existing fold instead of needing its own rule.
+
+**Complexity Tracking**: not applicable. No violations to justify.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/020-capture-about-this-item/
+├── spec.md                      # /speckit-specify output
+├── plan.md                      # This file
+├── research.md                  # Phase 0 — live markup probe, two corrections to the issue
+├── data-model.md                # Phase 1 — no schema change, and why that is the point
+├── quickstart.md                # Phase 1 — how to validate, including the manual real-listing check
+├── contracts/
+│   ├── listing-payload.md       # The payload boundary; version stays 1
+│   └── bullets-reader.md        # The new function's obligations
+├── checklists/
+│   └── requirements.md          # Spec quality checklist (all pass)
+└── tasks.md                     # /speckit-tasks output — NOT created by /speckit-plan
+```
+
+### Source code (repository root)
+
+```text
+app/
+└── static/js/
+    └── capture-agent.js         # THE ONLY PRODUCTION FILE THIS FEATURE CHANGES
+                                 #   + BULLET_CONTAINER / bulletsRow()
+                                 #   ~ specificationsFrom(): seed the output and the fold
+
+tests/e2e/
+├── fixtures/
+│   ├── amazon_listing.html      # + an About this item block in the real observed shape
+│   ├── amazon_listing_aplus.html# + the same, so both description forms are covered
+│   └── amazon_listing_markup_only.html   # left without one: the no-bullets case (US4)
+└── test_product_page_capture.py # + the new scenarios; ~ the exact-order payload assertion
+```
+
+**Structure Decision**: no new module, package or directory. The reader belongs in
+`capture-agent.js` next to `specificationsFrom()` because that is the function that owns "what the
+product-information rows are", and this is one more source of them. Putting it anywhere else would
+split one question across two files.
+
+## Approach
+
+### The reader
+
+A new `bulletsRow(doc)` returning `{name, value}` or `null`, obligations as set out in
+[`contracts/bullets-reader.md`](contracts/bullets-reader.md). It reads `li` elements within the
+bullet container, runs each through the file's existing `proseOf` so the #91 stripping and line
+handling apply unchanged, drops the empty ones, and joins with a single `\n` — one `\n`, not two,
+because these are list items and `proseFrom` already emits paragraph breaks around a `LI`.
+
+### The call site
+
+`specificationsFrom()` seeds both its `entries` array and its `seen` map with the bullets row before
+the container loop. Seeding the fold — not merely prepending to the array — is what makes FR-009 and
+contract C-5 true: without it, a detail table publishing an `About this item` row would produce a
+second one.
+
+### The fixtures
+
+The observed shape goes into two of the three fixtures verbatim: the `hr`, the `h2` heading, the
+`ul.a-unordered-list` of `li.a-spacing-mini > span.a-list-item`, and the trailing
+`div.a-section` holding "See more product details". The heading and the trailing div are not
+decoration in the fixture — they are the two things the reader must exclude, and a fixture without
+them tests nothing. `amazon_listing_markup_only.html` deliberately gains no bullet list, so US4 has a
+case.
+
+### What is not built
+
+- No visibility filtering, and no hidden-class filtering (research.md §1).
+- No parsing of bullet text into fields. `B01N4OSKWE`'s bullets are full of `Name: Value; Name:
+  Value` and it is tempting; the spec rules it out and it is a much harder problem.
+- No de-duplication between the bullets and the description.
+- No display or edit work — #91 already did all of it, confirmed in the tree (research.md §3).
+- No Python change of any kind.
+
+## Risks
+
+| Risk | Bound |
+|------|-------|
+| Amazon renames `#feature-bullets` | FR-011: the step is independent and optional; the capture loses one row. The hand-written fixture cannot detect it — this is stated in research.md rather than mitigated, as it was for the original capture feature. |
+| The `\n` vs `\n\n` choice reads wrong in practice | Visible immediately on the first real capture (quickstart step 4). One-character fix. |
+| The exact-order payload assertion gets loosened instead of updated | Called out in research.md §5 and quickstart §2. It is #91's "nothing else moved" guard and is what makes FR-010 testable. |
+| Screenshot churn confuses the gate | Measure the diff before committing any image; do not regenerate reflexively. |

--- a/specs/020-capture-about-this-item/quickstart.md
+++ b/specs/020-capture-about-this-item/quickstart.md
@@ -1,0 +1,101 @@
+# Quickstart: validating the "About this item" capture
+
+**Feature**: `specs/020-capture-about-this-item` | **Date**: 2026-08-19
+
+How to prove this feature works. Automated checks first, then the one thing no local test can
+cover — the real vendor page.
+
+## Prerequisites
+
+- The repository virtualenv at `venv/` (Principle: project commands run against it). Invoke its
+  binaries by path; do not `source venv/bin/activate`.
+- `python3.13` on `PATH` for nox's env creation:
+
+```bash
+export PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"
+```
+
+- Docker running, for the MariaDB container the e2e session brings up.
+
+## 1. Unit suite
+
+```bash
+venv/bin/nox -s tests
+```
+
+Expected: green, in under a second of test time. **This feature adds nothing here.** The change is
+entirely in `app/static/js/capture-agent.js`; there is no Python behavior to unit-test, and adding a
+Python test that asserts something about a JavaScript file would be theatre. If a unit test does
+change, something has gone wrong with the scope.
+
+## 2. End-to-end suite
+
+```bash
+venv/bin/nox -s e2e
+```
+
+**Give this at least a 15-minute timeout** (constitution, Principle IV) — it installs Playwright
+browsers and retries with `--reruns=3`. It runs about 8m15s warm, which exceeds the default 10-minute
+command cap, so run it detached and poll rather than blocking on it.
+
+The session must leave the working tree clean. If `git status` is dirty afterwards, a screenshot
+test leaked into the selection.
+
+New coverage to expect in `tests/e2e/test_product_page_capture.py`:
+
+| Scenario | Proves |
+|----------|--------|
+| The bullets arrive as one `About this item` row, one bullet per line | US1 / FR-001..FR-004 |
+| The row is first in the payload's `specifications` | FR-010, contract C-3 |
+| The heading and the "See more product details" link are absent from the value | FR-005, R-1 |
+| A fixture with no bullet list yields no row and captures otherwise unchanged | US4 / FR-008, FR-012 |
+| Re-capturing the same listing leaves exactly one row, with the first capture's value | US2 / FR-009 |
+| The stored value renders on its own lines and edits without flattening | FR-013 |
+
+The existing exact-order assertion on `payload["specifications"]` (around line 508) will need
+`"About this item"` at the front. That assertion is a "nothing else moved" guard from #91 — update
+it, do not loosen it to a membership check.
+
+## 3. Screenshot gate
+
+```bash
+venv/bin/nox -s screenshots_verify
+```
+
+`capture-agent.js` is under `app/static/js/**`, which the constitution's workflow section says
+requires regenerating documentation screenshots. It is also never loaded by any template in this
+application — the bookmarklet injects it into a *vendor's* page — so no screenshot can depend on it.
+Run the verify session to establish that rather than assert it.
+
+If it reports staleness, check whether the diff has anything to do with this change before
+regenerating; screenshots in this repository churn between runs for unrelated reasons, so measure
+the churn before committing any image.
+
+## 4. The manual check that matters
+
+Nothing local can fail when Amazon changes their markup — the e2e fixture is hand-written and served
+from this application's own origin (see the module docstring of `test_product_page_capture.py` for
+why it has to be). So the feature is not validated until it has run against the real thing.
+
+1. Start the application and load the capture bookmarklet as usual.
+2. Open `https://www.amazon.com/dp/B01N4OSKWE` and fire the bookmarklet.
+3. On the confirmation form, check the specification row count includes the new row, then submit.
+4. On the product page, confirm an `About this item` row exists and that its value contains, each on
+   its own line, the five bullets — in particular the dimensions:
+   `Main Body Size: 15 x 7 x 7mm/0.59"x0.28"x0.28"(L*W*H)`. **This is SC-001**, and it is the
+   difference the issue is about: those dimensions appear nowhere else on that listing.
+5. Repeat for `https://www.amazon.com/dp/B0FX4PDW6M`. Six bullets. **SC-002.**
+6. Capture `B01N4OSKWE` a second time onto the same product and confirm there is still exactly one
+   `About this item` row. **SC-004.**
+7. Capture any listing with no About this item section and confirm no row appears and nothing else
+   changed. **SC-005.**
+
+As of 2026-08-19 both listings carried the markup described in research.md §1. If step 4 comes back
+empty, read the live page before touching the reader — the selector may simply have moved, which is
+the risk FR-011 bounds rather than removes.
+
+## Reference
+
+- Payload shape and its guarantees: [`contracts/listing-payload.md`](contracts/listing-payload.md)
+- The reader's obligations: [`contracts/bullets-reader.md`](contracts/bullets-reader.md)
+- Why no visibility test and no migration: [`research.md`](research.md), [`data-model.md`](data-model.md)

--- a/specs/020-capture-about-this-item/research.md
+++ b/specs/020-capture-about-this-item/research.md
@@ -1,0 +1,229 @@
+# Phase 0 Research: Capture Reads the "About this item" Bullets
+
+**Feature**: `specs/020-capture-about-this-item` | **Date**: 2026-08-19
+
+Issue #92 says in as many words that its selector claims come from earlier probing rather than
+from the listings as they stand, and invites the agent to look at the live pages. That was done:
+three listings were inspected in the owner's Chrome on 2026-08-19 — `B01N4OSKWE` and `B0FX4PDW6M`
+(the issue's two verification cases) and `B0CKXJLP4B` (the ASIN the e2e fixture stands in for).
+Everything in section 1 is what those pages actually contained, not what the issue predicted.
+
+**Two of the issue's premises did not survive the probe.** Both are recorded below with what
+replaced them.
+
+---
+
+## 1. What the real markup is
+
+### Decision
+
+The bullets are read from the `li` elements inside `#feature-bullets`, one bullet per `li`.
+
+### What was observed
+
+All three listings carry `#feature-bullets`, wrapped in `#featurebullets_feature_div`, with an
+identical child sequence:
+
+```
+div#feature-bullets.a-section a-spacing-medium a-spacing-top-small
+├── hr.a-divider-normal            [aria-hidden="true"]
+├── h2.a-size-base-plus a-text-bold   "About this item"
+├── ul.a-unordered-list a-vertical a-spacing-mini
+│   └── li.a-spacing-mini  ×5 / ×6 / ×5
+│       └── span.a-list-item        the bullet's text
+└── div.a-section                   "› See more product details"  (caret span + link)
+```
+
+| Listing | Bullets | Hidden `li` | `.a-text-bold` in a bullet | Bullet `li` children |
+|---------|---------|-------------|----------------------------|----------------------|
+| `B01N4OSKWE` | 5 | 0 | 0 | `span.a-list-item` only |
+| `B0FX4PDW6M` | 6 | 0 | 0 | `span.a-list-item` only |
+| `B0CKXJLP4B` | 5 | 0 | 0 | `span.a-list-item` only |
+
+`B01N4OSKWE`'s five bullets are exactly the content the issue is about — semicolon-separated
+physical facts that appear nowhere else on the page:
+
+```
+Country of Manufacture: CHINA; Material: Plastic,Metal; Net Weight: 9g
+Package Content: 5pcs x Micro Slide Switch; Main Color: Black, Silver Tone; Mount Hole Size: 2mm/0.08"
+Hole Center Distance: 20mm/0.79"; Product Name: Micro Slide Switch; Switch Type: Toggle Switch
+Action Type: Latching; Contact Type: DPDT; Terminal Quantity: 6
+Main Body Size: 15 x 7 x 7mm/0.59"x0.28"x0.28"(L*W*H); Overall Size: 23 x 16 x 7mm/0.91"x0.63"x0.28(L*W*H)
+```
+
+### Correction 1 — "See more product details" is not a hidden `li`
+
+Issue #92 warns that `#feature-bullets li` "includes a hidden 'See more product details' item on
+some listings". On all three listings today it is **a visible sibling `div.a-section` after the
+`<ul>`**, not a list item and not hidden. `li`-scoped reading therefore excludes it structurally,
+with no visibility test involved.
+
+The `h2` heading is the same kind of trap and the issue does not mention it: `#feature-bullets`'s
+own `textContent` begins `"About this item Built-in ESP32-S3 …"`. Anything that reads the
+*container's* text captures the heading as though it were product content. Reading `li` excludes
+that too.
+
+The one element in `#feature-bullets` carrying a hidden marker on any of the three listings is the
+`<hr aria-hidden="true">` divider, which contributes no text.
+
+### Correction 2 — a visibility test is not implementable here anyway
+
+This is the finding that decides the design, and it is not a preference.
+
+`canonicalDocument()` (`app/static/js/capture-agent.js:618`) fetches `/dp/<ASIN>` and parses it with
+`new DOMParser().parseFromString(html, 'text/html')`. That document is **detached**: it has no
+layout and no stylesheets applied. `offsetHeight` is `0` for every element in it, and
+`getComputedStyle(...).display` reports the UA default rather than what Amazon's CSS would produce.
+The probe above could only classify visibility because it ran against the *live rendered* page — the
+capture agent never has that document on its primary path.
+
+So spec FR-005 ("a bullet the listing does not display MUST NOT contribute a line") cannot be met by
+asking whether an element is visible. It can only be met structurally.
+
+### Rationale
+
+`li`-scoped reading answers both corrections at once and costs one `querySelectorAll`. Every
+non-bullet element observed in the container — the divider, the heading, the "See more" link — is
+outside the `<ul>`, so it is already excluded.
+
+### Alternatives considered
+
+- **Add `#feature-bullets` to `SPECIFICATION_CONTAINERS`.** Rejected, as the issue anticipates:
+  `rowsFrom()`'s bullet shape requires a `.a-text-bold` name span, and the probe found zero across
+  all three listings, so this yields nothing at all.
+- **Read the container's whole text as prose.** Rejected: it captures the `About this item`
+  heading and the `See more product details` link as product content, and it loses the
+  one-bullet-per-line structure the row is supposed to have.
+- **Filter by computed visibility.** Rejected as not implementable — see Correction 2.
+- **Filter by hidden-marking classes (`aok-hidden`, `a-hidden`, `[hidden]`, `[aria-hidden]`).**
+  Rejected as speculative generality (Principle I). No bullet on any probed listing carries one.
+  Should the shape appear later, the guard is a one-line predicate in a function that already
+  exists; adding it now would be machinery for a case with no observed instance.
+
+---
+
+## 2. Where the bullets go
+
+### Decision
+
+One specification row, name `About this item`, value the bullets joined with `\n`, emitted **first**
+in `specificationsFrom()`'s output — before the rows read out of the detail containers.
+
+### Rationale
+
+- **A row, not description text**: settled by the spec's Assumptions, following the issue's own
+  preference. A named row is findable, editable and deletable on its own; text appended to an A+
+  description is none of those.
+- **First**, because it matches the page's own order (About this item sits above the detail tables)
+  and because it decides FR-009's collision case correctly. `specificationsFrom()` folds with
+  first-occurrence-wins, so emitting the bullets first means a detail-table row that happened to be
+  named `About this item` loses to the bullets — which is the outcome this feature wants.
+- **`\n` between bullets, not `\n\n`.** These are list items, not paragraphs. `proseFrom()` already
+  emits `\n\n` around a `LI`, so joining already-trimmed bullet strings with a single `\n` is what
+  gives one line per bullet.
+
+### Alternatives considered
+
+- **Appended last.** Works, and loses the collision case: a stray detail-table `About this item`
+  row would win over the actual bullets.
+- **One row per bullet** (`About this item 1`, `2`, …). Rejected: five to six near-duplicate row
+  names is clutter, they sort meaninglessly, and the issue asks for one row.
+
+---
+
+## 3. Line structure is already solved
+
+### Decision
+
+Nothing new is built for FR-013. It is a verification item, not an implementation item.
+
+### Rationale
+
+Issue #91 landed all three halves of it, and each was confirmed in the tree:
+
+| Concern | Where it already works |
+|---------|------------------------|
+| Reading text with line structure kept | `proseFrom()` / `proseOf()`, `capture-agent.js:95` |
+| Displaying a multi-line value | `app/templates/product/detail.html:106`, `white-space: pre-wrap` |
+| **Editing** a multi-line value | `app/templates/product/_form_fields.html:51-67` — a value containing `\n` renders as a `<textarea>` rather than an `<input>`, precisely because the HTML value sanitization algorithm strips CR/LF and an unrelated save would otherwise flatten the row |
+
+The spec flagged the edit path as "worth confirming rather than assuming". It is confirmed: the
+`{% if '\n' in value %}` branch exists and carries a comment explaining why. No work is needed.
+
+---
+
+## 4. What an empty bullets row would actually do
+
+### Decision
+
+Emit no row when there is no readable bullet (FR-008), and correct the spec's stated consequence.
+
+### Rationale
+
+The spec says an empty-valued row "would cost the whole capture" because
+`_validate_specifications` refuses a name with no value. That is not what happens.
+`ListingCapture.from_json` runs first, and `_payload_specifications`
+(`app/models.py:783`) **silently drops** any entry whose name or value is empty. Such a row would
+never reach validation.
+
+The requirement is unchanged — do not emit it — but the failure mode it guards against is a
+silently-absent row, not a failed capture. Written down here so nobody later "hardens" a path that
+was never exposed.
+
+---
+
+## 5. What this change costs the existing tests
+
+### Decision
+
+Three existing e2e assertions in `tests/e2e/test_product_page_capture.py` move, and they move
+because the feature works. None of them is a regression.
+
+| Line | Assertion | Why it moves |
+|------|-----------|--------------|
+| ~508 | `[row["name"] for row in payload["specifications"]] == ["Material", "Item Length", "Customer Reviews", "Finish", "Country of Origin"]` | An exact, ordered list. Gains `"About this item"` at the front once the A+ fixture carries bullets. |
+| ~456 | `before = …count()` then `to_have_count(before)` after re-capture | Self-relative; unaffected in principle, and it is exactly the assertion that proves US2. |
+| ~391 | `#summary-specifications` contains "row" | The count is +1; the assertion is on the word, so it holds. |
+
+The line-508 assertion is the one worth keeping rather than loosening: it was written for #91 as a
+"nothing else moved" guard, and an ordered list is what makes FR-010's stable position testable.
+
+### Rationale
+
+The fixtures are hand-written, so whether these move at all is a choice about which fixture gains a
+bullet list. Both should: `amazon_listing.html` (plain description) and `amazon_listing_aplus.html`
+(rich description) are the two paths, and the bullets are independent of which description form a
+listing uses.
+
+---
+
+## 6. The screenshot gate
+
+### Decision
+
+`nox -s screenshots_verify` is run and the result reported. Screenshots are regenerated only if it
+finds them stale.
+
+### Rationale
+
+The constitution's workflow section requires regenerating documentation screenshots for changes to
+`app/static/js/**`, and `capture-agent.js` is under that path. But `capture-agent.js` is never
+loaded by any of this application's own templates — it is injected into a *vendor's* page by the
+bookmarklet — so no screenshot of this application can depend on it. Running the verify session is
+the honest way to establish that rather than assert it.
+
+If a diff appears it will be screenshot churn unrelated to this change; that is measured before
+anything is committed, not assumed either way.
+
+---
+
+## The risk that is not mitigated
+
+Unchanged from the capture feature's original research, and worth restating because this feature
+adds a fourth selector to the set: Amazon's markup is not a contract. `#feature-bullets` can be
+renamed tomorrow and the e2e fixture — hand-written, served locally — cannot notice. What bounds
+the damage is FR-011: the reader is one independent, optional step, and a selector that stops
+matching costs the bullets row and nothing else.
+
+The probe above narrows this only in the sense that the fixture now reproduces markup that was real
+on 2026-08-19. It does not make the fixture a canary.

--- a/specs/020-capture-about-this-item/spec.md
+++ b/specs/020-capture-about-this-item/spec.md
@@ -1,0 +1,263 @@
+# Feature Specification: Capture Reads the "About this item" Bullets
+
+**Feature Branch**: `issues/92`
+
+**Created**: 2026-08-19
+
+**Status**: Draft
+
+**Input**: GitHub issue #92 — "Capture never reads the \"About this item\" bullets": *From the #80 verification pass, comment items 7 and 10. On `B01N4OSKWE`, all of the relevant information — dimensions and specifications — lives in the listing's About this item section, and none of it was captured. Same on `B0FX4PDW6M`: "important information in About this item was not captured". For a listing like `B01N4OSKWE` this is the difference between a useful catalog record and an empty one. The bullets are prose, not name/value pairs, so the existing row reader's two shapes do not fit. Capture them as one specification row named `About this item` whose value is the bullets, one per line; it must fold under the existing first-occurrence-wins merge rather than duplicating on re-capture. Watch the shape: the bullet list includes a hidden "See more product details" item on some listings.*
+
+## Terminology
+
+- **Capture** — recording a purchase from a vendor listing by way of the bookmarklet, which reads
+  the listing's page and hands the reading to this application. The reading arrives at the
+  confirmation form and the write happens when the operator submits it.
+- **Bullet list** — the listing's own **About this item** section: a short list of prose bullets the
+  vendor writes about the product, displayed near the top of the page, above the product-details
+  tables. It is what the shopper actually reads.
+- **Bullet** — one item of that list, as shown to the shopper. Prose, not a name/value pair.
+- **Specification row** — one `name` / `value` pair stored on the product and shown in the product's
+  specification list. Product information read out of the listing's detail tables is stored this
+  way; this feature adds one more row of the same kind.
+- **The bullets row** — the single specification row this feature produces, named `About this item`,
+  whose value is the listing's bullets one per line.
+- **First-occurrence-wins merge** — the existing rule that decides what a capture adds. It runs in
+  two independent places and both apply here: the reading folds the listing's own containers against
+  each other, and the write folds the captured names against the rows the product already carries,
+  dropping a captured name the product already has. Together they are what makes re-capture
+  idempotent.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The listing's own description of the product survives the capture (Priority: P1)
+
+The operator captures a listing whose real content — dimensions, capacities, materials, what fits
+what — is written in the About this item bullets rather than in a product-details table. The saved
+product carries that content, readable, as part of its specifications.
+
+**Why this priority**: This is the whole feature, and on some listings it is the difference between
+a catalog record and an empty shell. `B01N4OSKWE` publishes *all* of its dimensions and
+specifications in the bullets and nothing in a detail table; today's capture reads the tables, finds
+them empty, and stores a product that says nothing about the thing that was bought. The bullets are
+also the one part of a listing written in plain language, so they are what makes a record legible a
+year later when the listing is gone.
+
+**Independent Test**: Capture a listing whose About this item section carries content that appears
+nowhere in its product-details tables. Confirm the saved product has a specification row named
+`About this item` whose value holds every bullet the shopper sees, and that the previously-captured
+fields are unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a listing with a non-empty About this item section, **When** the operator completes a
+   capture, **Then** the saved product carries a specification row named `About this item`.
+2. **Given** that row, **When** the operator looks at it, **Then** its value contains the text of
+   every bullet the listing shows, in the order the listing shows them.
+3. **Given** that row, **When** the operator looks at it, **Then** each bullet occupies its own line
+   — no two bullets run together into one line, and no single bullet is split across lines it did
+   not have.
+4. **Given** a listing whose dimensions appear only in the bullets, **When** the capture completes,
+   **Then** those dimensions are present in the product's specification list.
+5. **Given** the same capture, **When** it completes, **Then** the product's description, price,
+   brand, gallery images and product-information rows are exactly what they would have been before
+   this feature — the bullets row is added to the reading, not substituted for any of it.
+
+---
+
+### User Story 2 - Re-capturing does not accumulate copies (Priority: P1)
+
+The operator captures the same listing a second time — a repeat purchase, or a first attempt that
+was interrupted. The product ends up with one `About this item` row, not two.
+
+**Why this priority**: Inseparable from US1. The bullets row is large, and a duplicate of it is the
+most visible kind of clutter a product's specification list can acquire. The rule already exists for
+every other captured row; this one has to fold under it rather than around it, and the only way to
+know it does is to state it and test it.
+
+**Independent Test**: Capture a listing, then capture the same listing again onto the same product.
+Confirm exactly one `About this item` row exists and that its value is the one from the first
+capture.
+
+**Acceptance Scenarios**:
+
+1. **Given** a product that already carries an `About this item` row, **When** a capture of the same
+   listing completes, **Then** the product still carries exactly one such row.
+2. **Given** that second capture, **When** it completes, **Then** the existing row's value is
+   unchanged — including a value the operator had edited by hand, which is not overwritten.
+3. **Given** a listing that publishes a product-details row of its own named `About this item` as
+   well as a bullet list, **When** the capture completes, **Then** the product carries exactly one
+   row of that name.
+4. **Given** a product whose `About this item` row the operator deleted, **When** a later capture of
+   the same listing completes, **Then** the row is added back — deletion is not remembered, exactly
+   as it is not for any other captured row.
+
+---
+
+### User Story 3 - What the shopper cannot see is not captured (Priority: P2)
+
+Some listings hang extra items off the bullet list that the page never displays — a "See more
+product details" link, fitment placeholders, decorative fragments. None of them reach the catalog.
+
+**Why this priority**: Lower than the first two because its failure is visible rather than silent —
+a stray line in the row is obvious and one edit removes it. It is still a requirement: the value of
+the bullets row is that it reads like the listing, and a navigational fragment quoted as though it
+were a product fact undermines exactly that. It also guards a real trap in the source markup, which
+is why it is called out rather than assumed.
+
+**Independent Test**: Capture a listing whose bullet list carries a hidden item alongside the
+displayed ones. Confirm the row's value holds the displayed bullets and not the hidden one.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bullet list containing an item the listing hides from the shopper, **When** the
+   capture completes, **Then** that item's text does not appear in the bullets row.
+2. **Given** a bullet whose visible text is empty — decoration, an image with no caption,
+   whitespace only — **When** the capture completes, **Then** it contributes no line, and no blank
+   line, to the row's value.
+3. **Given** a bullet list in which every item is hidden or empty, **When** the capture completes,
+   **Then** no `About this item` row is created at all.
+
+---
+
+### User Story 4 - A listing with no bullets captures exactly as it does today (Priority: P2)
+
+Many listings have no About this item section. Those captures behave the way they always have.
+
+**Why this priority**: The safety half. Capture reads a page that is not a contract, and the
+governing rule for every reading step is that a step which stops working costs its own field and
+nothing else. A new reader that could fail the whole capture would be a worse trade than the
+information it recovers.
+
+**Independent Test**: Capture a listing with no About this item section. Confirm no `About this
+item` row is created, no empty row is created, and every other captured field is what it was before
+this feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** a listing with no About this item section, **When** the capture completes, **Then** no
+   `About this item` row exists and the capture is otherwise unchanged.
+2. **Given** a listing whose About this item section is present but holds no readable text, **When**
+   the capture completes, **Then** no `About this item` row is created — an empty row is never
+   offered. (It would not fail the capture: `_payload_specifications` drops a nameless or valueless
+   entry before validation ever sees it. It would fail *silently*, which is why the row must not be
+   emitted rather than merely tolerated. See `research.md` §4.)
+3. **Given** a listing whose markup has changed such that the bullet list cannot be found at all,
+   **When** the capture completes, **Then** every other field is captured normally and the capture
+   reports no error.
+
+---
+
+### Edge Cases
+
+- **A hidden trailing item.** The bullet list on some listings ends with an item the page does not
+  display, such as "See more product details". It must not become a line. (US3)
+- **A bullet list that is absent, empty, or entirely hidden.** No row, no empty row, no error. (US4)
+- **Nested structure inside a bullet.** A bullet containing its own sub-list or several block
+  elements is still one bullet; its internal line structure is preserved but it does not become
+  several bullets, and it does not collapse into the bullet after it.
+- **A bullet that reads like a name/value pair** — "Material: Stainless Steel". It is captured as a
+  line of the bullets row exactly as written. This feature does not attempt to split bullets into
+  rows; a bullet is prose that sometimes contains a colon.
+- **Bullets that repeat the description.** Some listings say the same thing twice. Both are captured;
+  no de-duplication is attempted between the description and the bullets row.
+- **A very long bullet list.** Some listings run to a dozen long bullets. The value is stored whole;
+  nothing is truncated. (Specification values already carry A+ descriptions many times this size.)
+- **A single bullet.** One line, one row — not a special case, and not a reason to skip the row.
+- **A product-details table that also publishes an `About this item` row.** One row of that name
+  survives, by the merge rule that already governs every captured name. (US2)
+- **A bullet carrying non-prose content** — a stylesheet, a script — must not be reported as text,
+  the same as everywhere else the capture reads prose.
+- **Editing the row afterwards.** The value has newlines in it; the product's edit form must let the
+  operator change it without silently flattening those lines, and the product page must display them.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The capture MUST read the listing's About this item bullet list and report it as one
+  specification row.
+- **FR-002**: That row's name MUST be `About this item`.
+- **FR-003**: That row's value MUST hold the text of each displayed bullet, one bullet per line, in
+  the order the listing displays them.
+- **FR-004**: A bullet's own internal line structure MUST be preserved within its lines, by the same
+  rules that already govern captured prose; and consecutive bullets MUST NOT run together into a
+  single line.
+- **FR-005**: A bullet the listing does not display to the shopper MUST NOT contribute a line.
+- **FR-006**: A bullet whose readable text is empty MUST NOT contribute a line, and MUST NOT
+  contribute a blank line.
+- **FR-007**: Content that was never prose — stylesheets, scripts and their kin — MUST NOT appear in
+  the row's value, consistent with how the capture reads every other block of text.
+- **FR-008**: If the bullet list is absent, or yields no readable bullet, the capture MUST report no
+  row at all rather than a row with an empty value.
+- **FR-009**: The bullets row MUST fold under the existing first-occurrence-wins merge in both of the
+  places that merge runs, so that: a name collision within one reading keeps the first occurrence,
+  and a capture landing on a product that already carries an `About this item` row adds nothing and
+  changes nothing.
+- **FR-010**: The bullets row MUST occupy a defined, stable position in the reported rows, so two
+  captures of the same listing report the rows in the same order.
+- **FR-011**: Reading the bullets MUST NOT be able to fail the capture. If the bullet list cannot be
+  found or cannot be read, the capture MUST lose that row alone and complete normally, reporting no
+  error.
+- **FR-012**: Adding the bullets row MUST NOT change any other captured field — description, price,
+  brand, title, gallery, identifiers or the product-information rows — for any listing.
+- **FR-013**: Wherever a specification value is displayed, the bullets row MUST render with each
+  bullet on its own line; and wherever it is edited, the operator MUST be able to change it without
+  the line structure being lost.
+- **FR-014**: The end-to-end test fixtures MUST include an About this item section whose markup is
+  taken from a real listing, including the hidden-item shape FR-005 guards against, so the reader is
+  exercised against the thing it has to survive rather than against an idealization of it.
+
+### Key Entities
+
+- **Bullets row**: one specification row on a product. Name `About this item`, value the listing's
+  bullets one per line. Stored, merged, displayed, edited and deleted exactly like every other
+  specification row — this feature adds a source for a row, not a new kind of row.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Re-capturing `B01N4OSKWE` produces a catalog record that states the product's
+  dimensions and specifications, where today's record states none of them.
+- **SC-002**: Re-capturing `B0FX4PDW6M` produces a record whose About this item content is present
+  and readable.
+- **SC-003**: For any listing with an About this item section, 100% of the bullets a shopper sees are
+  present in the saved record, each on its own line, and no line is present that the shopper did not
+  see.
+- **SC-004**: Capturing the same listing twice onto the same product leaves exactly one
+  `About this item` row, with the value from the first capture.
+- **SC-005**: For listings with no About this item section, every captured field is byte-for-byte
+  what it was before this feature, and no new row appears.
+- **SC-006**: A listing whose bullet-list markup has changed beyond recognition still captures every
+  other field and reports no error.
+
+## Assumptions
+
+- **The bullets become a specification row, not an appendix to the description.** Issue #92 offers
+  both and favors this one; it is adopted. A named row stays addressable — findable by name,
+  editable and deletable on its own — where text appended to the description is neither, and the
+  description on an A+ listing is already long enough that burying the bullets in it would hide
+  them. This is the decision most worth revisiting if the row proves awkward in use.
+- **`About this item` is the row name**, matching the heading the listing itself uses. It is short
+  enough to be well within the specification-name limit.
+- **Line-structured specification values already work.** Issue #91 landed the prose reader that
+  preserves line breaks and the display that renders them, so "one bullet per line" is a use of
+  existing behavior rather than a new capability. FR-013 is a statement of what must remain true,
+  not new display work — though the edit form's handling of a multi-line value is worth confirming
+  rather than assuming.
+- **No filtering by content.** As with the product-information rows, nothing is dropped for being
+  marketing copy, boilerplate or a repeat of the description. An unwanted row is one click to
+  delete; a physical fact lost to a filter rule is unrecoverable once the listing is gone.
+- **Bullets are not parsed into fields.** No attempt is made to extract dimensions, part numbers or
+  anything else out of the bullet text into their own rows or form fields. That is a separate
+  question and a much harder one.
+- **The vendor is Amazon.** The capture reads Amazon listings; "About this item" is Amazon's own
+  heading for this section. No other vendor is in scope.
+- **The current markup needs confirming against real listings.** The bullet-list shape and the
+  hidden-item problem come from earlier probing, not from `B01N4OSKWE` and `B0FX4PDW6M` as they
+  stand today. Confirming it against the live listings — driving the owner's browser, as issues #94
+  and #95 are being handled — is expected during implementation, and what is found belongs back in
+  the hand-written fixture as real markup (FR-014).
+- **Verification is a re-capture of the two named listings**, per the issue: `B01N4OSKWE` and
+  `B0FX4PDW6M`, with `B01N4OSKWE`'s dimensions as the specific thing to look for.

--- a/specs/020-capture-about-this-item/tasks.md
+++ b/specs/020-capture-about-this-item/tasks.md
@@ -1,0 +1,340 @@
+---
+
+description: "Task list for 020-capture-about-this-item"
+---
+
+# Tasks: Capture Reads the "About this item" Bullets
+
+**Input**: Design documents from `/specs/020-capture-about-this-item/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md),
+[data-model.md](data-model.md), [contracts/](contracts/), [quickstart.md](quickstart.md)
+
+**Tests**: **Required, not optional.** Constitution Principle IV: "Changes that alter behavior MUST
+land with tests covering that behavior." Every test below is an e2e test, because the thing under
+test is a browser script reading a DOM — there is no Python behavior here to unit-test.
+
+**Organization**: Grouped by user story. Read the two notes below before starting; this feature's
+shape does not match the template's default assumptions.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story the task belongs to (US1–US4)
+- Exact file paths are in every task
+
+## Two notes on this feature's shape
+
+**1. `[P]` is rare here, and that is not an oversight.** The entire production change lives in one
+file (`app/static/js/capture-agent.js`) and every new test lives in one other
+(`tests/e2e/test_product_page_capture.py`). Two tasks touching the same file are not parallel. The
+only genuinely parallel work is the three fixture files. Marking more than that `[P]` would be a
+lie that costs a merge conflict.
+
+**2. US2 has no implementation task, and that is the finding.** Re-capture idempotency is delivered
+by `CatalogService.merge_specifications`, which already drops a captured name the product carries,
+plus the fold seeding done once in Phase 2. US2's phase is therefore all test — the work is proving
+the existing machinery covers the new row, not writing new machinery. Resist the urge to add code
+there; if a test fails, the fix belongs in Phase 2's seeding, not in a new rule.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: A branch, and a known-green starting point to measure against.
+
+- [ ] T001 Create and switch to feature branch `issues/92` from `main` (constitution requires a
+      feature branch and PR for non-trivial code changes)
+- [ ] T002 Establish the baseline: run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"
+      venv/bin/nox -s tests` and confirm green before changing anything
+- [ ] T003 Establish the e2e baseline: run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"
+      venv/bin/nox -s e2e` detached (it runs ~8m15s and exceeds a 10-minute command cap; allow
+      ≥15 minutes per Principle IV) and record which tests pass, so a later failure is attributable
+- [ ] T004 Confirm `git status` is clean after T003 — an e2e run that dirties the working tree means
+      a screenshot test leaked into the selection, which must be fixed before proceeding
+
+**Checkpoint**: Branch exists, suite is green, and any later red is this feature's doing.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The function and its call site exist and are wired, producing *nothing* yet. This is
+what every user story builds on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T005 In `app/static/js/capture-agent.js`, add a `BULLET_CONTAINER` constant (`'#feature-bullets'`)
+      next to `SPECIFICATION_CONTAINERS`, with a comment recording what research.md §1 observed:
+      the container also holds an `h2` heading and a trailing "See more product details" `div`,
+      both outside the `<ul>`, which is why the reader is `li`-scoped
+- [ ] T006 In `app/static/js/capture-agent.js`, add `bulletsRow(doc)` returning `null` for every
+      input — absent container, container with no list, document that is not a listing — and
+      never throwing (contract [`bullets-reader.md`](contracts/bullets-reader.md) R-5, R-6;
+      FR-008, FR-011)
+- [ ] T007 In `app/static/js/capture-agent.js`, call `bulletsRow(doc)` at the top of
+      `specificationsFrom(doc)` and, when it returns a row, seed **both** the `entries` array and
+      the `seen` map with it before the container loop. Seeding the fold — not merely prepending —
+      is what makes FR-009 and contract C-5 true (FR-010)
+- [ ] T008 Re-run `venv/bin/nox -s e2e` (detached, ≥15 min) and confirm it is still green: with
+      `bulletsRow` returning `null` the capture must be byte-for-byte what it was at T003
+
+**Checkpoint**: The seam is in place and the application is unchanged. US4's guarantee (FR-008,
+FR-012) is already true at this point and T029 will prove it.
+
+---
+
+## Phase 3: User Story 1 - The listing's own description of the product survives the capture (Priority: P1) 🎯 MVP
+
+**Goal**: The About this item bullets reach the catalog as one `About this item` specification row,
+one bullet per line, in the listing's order.
+
+**Independent Test**: Capture a listing whose About this item content appears nowhere in its
+product-details tables; confirm the saved product carries an `About this item` row holding every
+bullet, each on its own line, and that no other captured field moved.
+
+### Fixtures for User Story 1
+
+- [ ] T009 [P] [US1] Add an About this item block to `tests/e2e/fixtures/amazon_listing.html` in the
+      shape research.md §1 observed on `B01N4OSKWE`: `div#feature-bullets` containing
+      `hr.a-divider-normal[aria-hidden]`, `h2.a-size-base-plus.a-text-bold` reading "About this
+      item", `ul.a-unordered-list.a-vertical.a-spacing-mini` of
+      `li.a-spacing-mini > span.a-list-item`, and a trailing `div.a-section` holding
+      "› See more product details". The heading and the trailing div are not decoration — they are
+      the two things the reader must exclude, and a fixture without them tests nothing
+- [ ] T010 [P] [US1] Add the same block to `tests/e2e/fixtures/amazon_listing_aplus.html`, so both
+      description forms are covered (the bullets are independent of which form a listing uses).
+      Give this one bullets whose text does **not** duplicate the description, so the two are
+      distinguishable in an assertion
+- [ ] T011 [US1] Update the fixture header comment in both files to say what the new block is
+      for and that its markup was observed live on 2026-08-19, matching the existing comments'
+      practice of recording *why* each structure is present
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] In `app/static/js/capture-agent.js`, implement `bulletsRow`'s reading: take
+      `container.querySelectorAll('li')`, run each through the existing `proseOf` so #91's
+      stripping and line handling apply unchanged, drop the ones yielding empty text, and join the
+      rest with a **single** `\n` — one, not two, because these are list items and `proseFrom`
+      already emits paragraph breaks around a `LI` (FR-003, FR-004, FR-007; R-2, R-4)
+- [ ] T013 [US1] In `app/static/js/capture-agent.js`, return `{name: 'About this item', value: …}`
+      when at least one line survived and `null` otherwise (FR-002, FR-008; R-5)
+- [ ] T014 [US1] Add the function docstring in the file's established voice: what it reads, why it
+      is `li`-scoped rather than visibility-filtered, and the fact that `canonicalDocument()` hands
+      it a detached `DOMParser` document with no layout — so `offsetHeight` and `getComputedStyle`
+      are unavailable, not merely unused (research.md §1, Correction 2)
+
+### Tests for User Story 1
+
+- [ ] T015 [US1] In `tests/e2e/test_product_page_capture.py`, add a test that captures
+      `amazon_listing.html` and asserts `payload_of(landed)["specifications"][0]` is the
+      `About this item` row and that its value splits on `\n` into exactly the fixture's bullets in
+      order (US1 scenarios 1–3; FR-001..FR-004, FR-010)
+- [ ] T016 [US1] In the same file, add a test that confirms the row survives to the product page:
+      after `confirm(...)`, navigate to the product and assert `#product-specifications` contains a
+      row named `About this item` whose value carries a bullet's text. Establish the region with
+      `expect(...)` before any `count()` or `text_content()` read — `#product-specifications` is
+      server-rendered but the rule is not conditional
+- [ ] T017 [US1] Update the exact-order assertion at ~line 508
+      (`[row["name"] for row in payload["specifications"]] == [...]`) to lead with
+      `"About this item"`. **Update it; do not loosen it to a membership check** — it is #91's
+      "nothing else moved" guard and it is what makes FR-010 testable (research.md §5)
+- [ ] T018 [US1] In the same file, extend or add a test asserting the unchanged fields alongside the
+      new row — `listing_title`, `brand`, `price`, `images` — so FR-012 has an assertion and not
+      just an intention
+
+**Checkpoint**: US1 is complete and demonstrable. This is the MVP: the bullets are in the catalog.
+
+---
+
+## Phase 4: User Story 2 - Re-capturing does not accumulate copies (Priority: P1)
+
+**Goal**: One `About this item` row per product, no matter how many times the listing is captured.
+
+**Independent Test**: Capture a listing, capture it again onto the same product, confirm exactly one
+`About this item` row exists holding the first capture's value.
+
+**Note**: no implementation task. See "Two notes" above — this story is delivered by
+`merge_specifications` plus T007's seeding. Every task here is a test.
+
+- [ ] T019 [US2] In `tests/e2e/fixtures/amazon_listing_aplus.html`, add a product-details table row
+      whose name is `about this item` in a *different case* from the heading, so the agent-side fold
+      has a real collision to resolve (US2 scenario 3, FR-009 first half, contract C-5)
+- [ ] T020 [US2] In `tests/e2e/test_product_page_capture.py`, add a test asserting that capturing
+      `amazon_listing_aplus.html` yields exactly one entry whose name folds to `about this item`,
+      and that its value is the bullets rather than the table row's — proving the seeding in T007
+      put the bullets first
+- [ ] T021 [US2] In the same file, add a re-capture test: capture, confirm, then capture the same
+      listing again through the duplicate/identifier questions (follow the existing
+      `test_a_repeat_buy_merges_and_stores_no_second_copy` for the click sequence) and assert the
+      product still has exactly one `About this item` row (US2 scenarios 1–2)
+- [ ] T022 [US2] Extend T021 to edit the row's value by hand between the two captures and assert the
+      edited value survives the second capture untouched (US2 scenario 2 — `merge_specifications`
+      drops the incoming duplicate rather than overwriting, and that must stay true)
+
+**Checkpoint**: US1 and US2 both hold independently.
+
+---
+
+## Phase 5: User Story 3 - What the shopper cannot see is not captured (Priority: P2)
+
+**Goal**: The heading, the "See more product details" link and empty bullets contribute no lines.
+
+**Independent Test**: Capture a fixture whose bullet container carries all three, and confirm the
+row's value holds the bullets and nothing else.
+
+- [ ] T023 [US3] In `tests/e2e/fixtures/amazon_listing.html`, add to the bullet list one `li` whose
+      span holds only whitespace and one holding only an `<img>` with no text, so FR-006 has cases
+- [ ] T024 [US3] In `tests/e2e/test_product_page_capture.py`, add a test asserting the row's value
+      does **not** contain `"About this item"` (the `h2`, which sits inside `#feature-bullets` and
+      would be captured by any container-text reader) nor `"See more product details"` (the
+      trailing `div`) — FR-005, R-1
+- [ ] T025 [US3] In the same file, assert the value contains no empty line and no leading or
+      trailing newline, and that its line count equals the number of *non-empty* fixture bullets —
+      FR-006, R-3, R-4
+- [ ] T026 [US3] In the same file, assert the value carries no stylesheet or script text, following
+      the existing `test_a_specification_value_carries_no_stylesheet_or_script`; add a `<style>` or
+      `<script>` inside one fixture bullet in T023 so the assertion has something to catch
+      (FR-007, R-2)
+
+**Checkpoint**: The row reads like the listing, with none of the page's furniture in it.
+
+---
+
+## Phase 6: User Story 4 - A listing with no bullets captures exactly as it does today (Priority: P2)
+
+**Goal**: No bullet list means no row, no empty row, no error, and no other change.
+
+**Independent Test**: Capture a fixture with no About this item section; confirm no such row exists
+and every other field is what it was before this feature.
+
+- [ ] T027 [US4] Confirm `tests/e2e/fixtures/amazon_listing_markup_only.html` still has **no**
+      `#feature-bullets` block — it is deliberately the no-bullets case and must not acquire one
+      from T009/T010's edits
+- [ ] T028 [US4] In `tests/e2e/test_product_page_capture.py`, add a test capturing
+      `amazon_listing_markup_only.html` and asserting no entry in `payload["specifications"]` is
+      named `About this item`, and that no entry anywhere in the payload has an empty `value`
+      (US4 scenarios 1–2; FR-008)
+- [ ] T029 [US4] In the same file, assert the rest of that capture is unchanged — the existing
+      assertions for that fixture at ~line 631 should still pass untouched; if any of them needed
+      editing, FR-012 has been violated and the reader is doing more than it should
+- [ ] T030 [US4] Add a test that a document whose bullet container exists but holds no `<ul>` at all
+      yields no row and no error, either by a fourth small fixture or by an extra container in an
+      existing one (FR-011, R-6 — the case that proves a moved selector costs one row and nothing
+      else)
+
+**Checkpoint**: All four stories hold independently.
+
+---
+
+## Phase 7: Polish, Gates & Verification
+
+**Purpose**: The gates the constitution requires, and the one check no local test can perform.
+
+- [ ] T031 Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — expected
+      green and **unchanged**. If a unit test moved, the change has escaped its scope
+- [ ] T032 Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s e2e` detached with a
+      ≥15-minute allowance; all new and existing tests green
+- [ ] T033 Confirm `git status` is clean after T032 (Principle IV: a test run must leave the working
+      tree clean)
+- [ ] T034 Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s screenshots_verify`.
+      `app/static/js/**` is touched so the workflow rule fires, but `capture-agent.js` is never
+      loaded by an application template — the run establishes that rather than asserting it. If it
+      reports staleness, measure whether the diff has anything to do with this change before
+      regenerating; screenshots in this repository churn for unrelated reasons
+- [ ] T035 Run `venv/bin/nox -s lint` (advisory) on the changed files only; do not reformat
+      surrounding code — mass reformatting destroys review signal
+- [ ] T036 Manual verification, quickstart §4 step 4: capture `https://www.amazon.com/dp/B01N4OSKWE`
+      against a running instance and confirm the `About this item` row holds all five bullets, in
+      particular `Main Body Size: 15 x 7 x 7mm/0.59"x0.28"x0.28"(L*W*H)` — **SC-001**, and the
+      dimensions that appear nowhere else on that listing
+- [ ] T037 Manual verification: capture `https://www.amazon.com/dp/B0FX4PDW6M` and confirm its six
+      bullets are present and readable — **SC-002**
+- [ ] T038 Manual verification: capture `B01N4OSKWE` a second time onto the same product and confirm
+      exactly one `About this item` row remains — **SC-004**
+- [ ] T039 Manual verification: confirm the stored row renders one bullet per line on the product
+      page, and that opening the product's edit form shows it in a `<textarea>` (not an `<input>`)
+      and saving does not flatten it — **FR-013**, which #91 already delivered and this confirms
+- [ ] T040 Open the pull request against `main`, referencing issue #92, and note in the description
+      the two premises of the issue that the live probe corrected (research.md §1) so the record
+      travels with the change
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Phase 1 (Setup)**: no dependencies
+- **Phase 2 (Foundational)**: needs Phase 1 — **blocks every user story**
+- **Phase 3 (US1)**: needs Phase 2
+- **Phase 4 (US2)**: needs Phase 2; its collision test (T020) is only meaningful once T012–T013
+  actually produce a row, so in practice it follows Phase 3
+- **Phase 5 (US3)**: needs Phase 3 — its assertions are about the value US1 produces
+- **Phase 6 (US4)**: needs Phase 2 only. It is genuinely independent of US1 and could be done
+  straight after the foundation
+- **Phase 7 (Polish)**: needs every story phase intended for the release
+
+### Within each story
+
+- Fixtures before the tests that read them
+- Implementation before the tests that assert on it, **except** where a test is being written to
+  fail first — T015 and T024 are both worth writing before T012 to watch them fail
+- T017 must land in the same commit as T012–T013, or the suite is red between them
+
+### Parallel opportunities
+
+Genuinely parallel:
+
+- **T009, T010** — two different fixture files, no shared content. T011 edits both, so it is
+  **not** parallel with either and must follow them
+- **T031, T034, T035** — three independent nox sessions, if the machine can carry them
+
+Everything else is serial by file:
+
+- **T005, T006, T007, T012, T013, T014** all edit `app/static/js/capture-agent.js`
+- **T015–T018, T020–T022, T024–T026, T028–T030** all edit
+  `tests/e2e/test_product_page_capture.py`
+- **T009, T019, T023** all edit fixtures, and T019/T023 both touch files T009/T010 created
+
+---
+
+## Implementation Strategy
+
+### MVP (Phases 1–3)
+
+Setup, the foundation, and US1. That is the whole point of issue #92: `B01N4OSKWE`'s dimensions in
+the catalog. Stop at the Phase 3 checkpoint, run T036, and the feature has already paid for itself.
+
+### Incremental delivery
+
+1. Phases 1–2 → the seam exists, nothing has changed, suite still green
+2. Phase 3 → **MVP**: the bullets are captured (SC-001, SC-002)
+3. Phase 4 → re-capture proven idempotent (SC-004)
+4. Phase 5 → the row reads like the listing rather than like the page (SC-003)
+5. Phase 6 → the no-bullets path proven unchanged (SC-005, SC-006)
+6. Phase 7 → gates, manual verification, PR
+
+### Not a parallel-team feature
+
+One file of production code and one file of tests. Splitting this across people produces conflicts,
+not throughput. The fixture tasks are the only place a second pair of hands helps.
+
+---
+
+## Notes
+
+- `[P]` means different files and no dependency on incomplete work. It is used sparingly here on
+  purpose; see "Two notes" at the top
+- Commit after each logical group; keep T012, T013 and T017 in one commit so the suite is never red
+- **Do not add visibility filtering.** `canonicalDocument()` yields a detached document with no
+  layout — `offsetHeight` is 0 and `getComputedStyle` is meaningless. FR-005 is met structurally,
+  by reading `li` only. This is research.md §1's Correction 2 and it is the single easiest way to
+  get this feature wrong
+- **Do not add hidden-class filtering** (`aok-hidden`, `[hidden]`, `[aria-hidden]`) either. No
+  bullet on any of the three probed listings carries one; Principle I forbids machinery for a case
+  with no observed instance
+- **Do not parse bullet text into fields.** `B01N4OSKWE`'s bullets are full of `Name: Value; Name:
+  Value` and it is tempting. The spec rules it out and it is a much harder problem
+- No Alembic revision, no schema change, no Python change. If a task seems to need one, the scope
+  has slipped

--- a/specs/020-capture-about-this-item/tasks.md
+++ b/specs/020-capture-about-this-item/tasks.md
@@ -270,9 +270,9 @@ and every other field is what it was before this feature.
       **Not in the original task list** -- found while the suite was running. That passage
       enumerates what the capture reads, so a feature that adds to the reading and leaves it
       alone makes the manual quietly wrong
-- [ ] T040 Open the pull request against `main`, referencing issue #92, and note in the description
+- [X] T040 Open the pull request against `main`, referencing issue #92, and note in the description
       the two premises of the issue that the live probe corrected (research.md §1) so the record
-      travels with the change
+      travels with the change -- opened as #111
 
 ---
 

--- a/specs/020-capture-about-this-item/tasks.md
+++ b/specs/020-capture-about-this-item/tasks.md
@@ -43,14 +43,14 @@ there; if a test fails, the fix belongs in Phase 2's seeding, not in a new rule.
 
 **Purpose**: A branch, and a known-green starting point to measure against.
 
-- [ ] T001 Create and switch to feature branch `issues/92` from `main` (constitution requires a
+- [X] T001 Create and switch to feature branch `issues/92` from `main` (constitution requires a
       feature branch and PR for non-trivial code changes)
-- [ ] T002 Establish the baseline: run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"
+- [X] T002 Establish the baseline: run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"
       venv/bin/nox -s tests` and confirm green before changing anything
-- [ ] T003 Establish the e2e baseline: run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"
+- [X] T003 Establish the e2e baseline: run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH"
       venv/bin/nox -s e2e` detached (it runs ~8m15s and exceeds a 10-minute command cap; allow
       ≥15 minutes per Principle IV) and record which tests pass, so a later failure is attributable
-- [ ] T004 Confirm `git status` is clean after T003 — an e2e run that dirties the working tree means
+- [X] T004 Confirm `git status` is clean after T003 — an e2e run that dirties the working tree means
       a screenshot test leaked into the selection, which must be fixed before proceeding
 
 **Checkpoint**: Branch exists, suite is green, and any later red is this feature's doing.
@@ -64,19 +64,19 @@ what every user story builds on.
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T005 In `app/static/js/capture-agent.js`, add a `BULLET_CONTAINER` constant (`'#feature-bullets'`)
+- [X] T005 In `app/static/js/capture-agent.js`, add a `BULLET_CONTAINER` constant (`'#feature-bullets'`)
       next to `SPECIFICATION_CONTAINERS`, with a comment recording what research.md §1 observed:
       the container also holds an `h2` heading and a trailing "See more product details" `div`,
       both outside the `<ul>`, which is why the reader is `li`-scoped
-- [ ] T006 In `app/static/js/capture-agent.js`, add `bulletsRow(doc)` returning `null` for every
+- [X] T006 In `app/static/js/capture-agent.js`, add `bulletsRow(doc)` returning `null` for every
       input — absent container, container with no list, document that is not a listing — and
       never throwing (contract [`bullets-reader.md`](contracts/bullets-reader.md) R-5, R-6;
       FR-008, FR-011)
-- [ ] T007 In `app/static/js/capture-agent.js`, call `bulletsRow(doc)` at the top of
+- [X] T007 In `app/static/js/capture-agent.js`, call `bulletsRow(doc)` at the top of
       `specificationsFrom(doc)` and, when it returns a row, seed **both** the `entries` array and
       the `seen` map with it before the container loop. Seeding the fold — not merely prepending —
       is what makes FR-009 and contract C-5 true (FR-010)
-- [ ] T008 Re-run `venv/bin/nox -s e2e` (detached, ≥15 min) and confirm it is still green: with
+- [X] T008 Re-run `venv/bin/nox -s e2e` (detached, ≥15 min) and confirm it is still green: with
       `bulletsRow` returning `null` the capture must be byte-for-byte what it was at T003
 
 **Checkpoint**: The seam is in place and the application is unchanged. US4's guarantee (FR-008,
@@ -95,51 +95,51 @@ bullet, each on its own line, and that no other captured field moved.
 
 ### Fixtures for User Story 1
 
-- [ ] T009 [P] [US1] Add an About this item block to `tests/e2e/fixtures/amazon_listing.html` in the
+- [X] T009 [P] [US1] Add an About this item block to `tests/e2e/fixtures/amazon_listing.html` in the
       shape research.md §1 observed on `B01N4OSKWE`: `div#feature-bullets` containing
       `hr.a-divider-normal[aria-hidden]`, `h2.a-size-base-plus.a-text-bold` reading "About this
       item", `ul.a-unordered-list.a-vertical.a-spacing-mini` of
       `li.a-spacing-mini > span.a-list-item`, and a trailing `div.a-section` holding
       "› See more product details". The heading and the trailing div are not decoration — they are
       the two things the reader must exclude, and a fixture without them tests nothing
-- [ ] T010 [P] [US1] Add the same block to `tests/e2e/fixtures/amazon_listing_aplus.html`, so both
+- [X] T010 [P] [US1] Add the same block to `tests/e2e/fixtures/amazon_listing_aplus.html`, so both
       description forms are covered (the bullets are independent of which form a listing uses).
       Give this one bullets whose text does **not** duplicate the description, so the two are
       distinguishable in an assertion
-- [ ] T011 [US1] Update the fixture header comment in both files to say what the new block is
+- [X] T011 [US1] Update the fixture header comment in both files to say what the new block is
       for and that its markup was observed live on 2026-08-19, matching the existing comments'
       practice of recording *why* each structure is present
 
 ### Implementation for User Story 1
 
-- [ ] T012 [US1] In `app/static/js/capture-agent.js`, implement `bulletsRow`'s reading: take
+- [X] T012 [US1] In `app/static/js/capture-agent.js`, implement `bulletsRow`'s reading: take
       `container.querySelectorAll('li')`, run each through the existing `proseOf` so #91's
       stripping and line handling apply unchanged, drop the ones yielding empty text, and join the
       rest with a **single** `\n` — one, not two, because these are list items and `proseFrom`
       already emits paragraph breaks around a `LI` (FR-003, FR-004, FR-007; R-2, R-4)
-- [ ] T013 [US1] In `app/static/js/capture-agent.js`, return `{name: 'About this item', value: …}`
+- [X] T013 [US1] In `app/static/js/capture-agent.js`, return `{name: 'About this item', value: …}`
       when at least one line survived and `null` otherwise (FR-002, FR-008; R-5)
-- [ ] T014 [US1] Add the function docstring in the file's established voice: what it reads, why it
+- [X] T014 [US1] Add the function docstring in the file's established voice: what it reads, why it
       is `li`-scoped rather than visibility-filtered, and the fact that `canonicalDocument()` hands
       it a detached `DOMParser` document with no layout — so `offsetHeight` and `getComputedStyle`
       are unavailable, not merely unused (research.md §1, Correction 2)
 
 ### Tests for User Story 1
 
-- [ ] T015 [US1] In `tests/e2e/test_product_page_capture.py`, add a test that captures
+- [X] T015 [US1] In `tests/e2e/test_product_page_capture.py`, add a test that captures
       `amazon_listing.html` and asserts `payload_of(landed)["specifications"][0]` is the
       `About this item` row and that its value splits on `\n` into exactly the fixture's bullets in
       order (US1 scenarios 1–3; FR-001..FR-004, FR-010)
-- [ ] T016 [US1] In the same file, add a test that confirms the row survives to the product page:
+- [X] T016 [US1] In the same file, add a test that confirms the row survives to the product page:
       after `confirm(...)`, navigate to the product and assert `#product-specifications` contains a
       row named `About this item` whose value carries a bullet's text. Establish the region with
       `expect(...)` before any `count()` or `text_content()` read — `#product-specifications` is
       server-rendered but the rule is not conditional
-- [ ] T017 [US1] Update the exact-order assertion at ~line 508
+- [X] T017 [US1] Update the exact-order assertion at ~line 508
       (`[row["name"] for row in payload["specifications"]] == [...]`) to lead with
       `"About this item"`. **Update it; do not loosen it to a membership check** — it is #91's
       "nothing else moved" guard and it is what makes FR-010 testable (research.md §5)
-- [ ] T018 [US1] In the same file, extend or add a test asserting the unchanged fields alongside the
+- [X] T018 [US1] In the same file, extend or add a test asserting the unchanged fields alongside the
       new row — `listing_title`, `brand`, `price`, `images` — so FR-012 has an assertion and not
       just an intention
 
@@ -157,18 +157,18 @@ bullet, each on its own line, and that no other captured field moved.
 **Note**: no implementation task. See "Two notes" above — this story is delivered by
 `merge_specifications` plus T007's seeding. Every task here is a test.
 
-- [ ] T019 [US2] In `tests/e2e/fixtures/amazon_listing_aplus.html`, add a product-details table row
+- [X] T019 [US2] In `tests/e2e/fixtures/amazon_listing_aplus.html`, add a product-details table row
       whose name is `about this item` in a *different case* from the heading, so the agent-side fold
       has a real collision to resolve (US2 scenario 3, FR-009 first half, contract C-5)
-- [ ] T020 [US2] In `tests/e2e/test_product_page_capture.py`, add a test asserting that capturing
+- [X] T020 [US2] In `tests/e2e/test_product_page_capture.py`, add a test asserting that capturing
       `amazon_listing_aplus.html` yields exactly one entry whose name folds to `about this item`,
       and that its value is the bullets rather than the table row's — proving the seeding in T007
       put the bullets first
-- [ ] T021 [US2] In the same file, add a re-capture test: capture, confirm, then capture the same
+- [X] T021 [US2] In the same file, add a re-capture test: capture, confirm, then capture the same
       listing again through the duplicate/identifier questions (follow the existing
       `test_a_repeat_buy_merges_and_stores_no_second_copy` for the click sequence) and assert the
       product still has exactly one `About this item` row (US2 scenarios 1–2)
-- [ ] T022 [US2] Extend T021 to edit the row's value by hand between the two captures and assert the
+- [X] T022 [US2] Extend T021 to edit the row's value by hand between the two captures and assert the
       edited value survives the second capture untouched (US2 scenario 2 — `merge_specifications`
       drops the incoming duplicate rather than overwriting, and that must stay true)
 
@@ -183,16 +183,16 @@ bullet, each on its own line, and that no other captured field moved.
 **Independent Test**: Capture a fixture whose bullet container carries all three, and confirm the
 row's value holds the bullets and nothing else.
 
-- [ ] T023 [US3] In `tests/e2e/fixtures/amazon_listing.html`, add to the bullet list one `li` whose
+- [X] T023 [US3] In `tests/e2e/fixtures/amazon_listing.html`, add to the bullet list one `li` whose
       span holds only whitespace and one holding only an `<img>` with no text, so FR-006 has cases
-- [ ] T024 [US3] In `tests/e2e/test_product_page_capture.py`, add a test asserting the row's value
+- [X] T024 [US3] In `tests/e2e/test_product_page_capture.py`, add a test asserting the row's value
       does **not** contain `"About this item"` (the `h2`, which sits inside `#feature-bullets` and
       would be captured by any container-text reader) nor `"See more product details"` (the
       trailing `div`) — FR-005, R-1
-- [ ] T025 [US3] In the same file, assert the value contains no empty line and no leading or
+- [X] T025 [US3] In the same file, assert the value contains no empty line and no leading or
       trailing newline, and that its line count equals the number of *non-empty* fixture bullets —
       FR-006, R-3, R-4
-- [ ] T026 [US3] In the same file, assert the value carries no stylesheet or script text, following
+- [X] T026 [US3] In the same file, assert the value carries no stylesheet or script text, following
       the existing `test_a_specification_value_carries_no_stylesheet_or_script`; add a `<style>` or
       `<script>` inside one fixture bullet in T023 so the assertion has something to catch
       (FR-007, R-2)
@@ -208,17 +208,17 @@ row's value holds the bullets and nothing else.
 **Independent Test**: Capture a fixture with no About this item section; confirm no such row exists
 and every other field is what it was before this feature.
 
-- [ ] T027 [US4] Confirm `tests/e2e/fixtures/amazon_listing_markup_only.html` still has **no**
+- [X] T027 [US4] Confirm `tests/e2e/fixtures/amazon_listing_markup_only.html` still has **no**
       `#feature-bullets` block — it is deliberately the no-bullets case and must not acquire one
       from T009/T010's edits
-- [ ] T028 [US4] In `tests/e2e/test_product_page_capture.py`, add a test capturing
+- [X] T028 [US4] In `tests/e2e/test_product_page_capture.py`, add a test capturing
       `amazon_listing_markup_only.html` and asserting no entry in `payload["specifications"]` is
       named `About this item`, and that no entry anywhere in the payload has an empty `value`
       (US4 scenarios 1–2; FR-008)
-- [ ] T029 [US4] In the same file, assert the rest of that capture is unchanged — the existing
+- [X] T029 [US4] In the same file, assert the rest of that capture is unchanged — the existing
       assertions for that fixture at ~line 631 should still pass untouched; if any of them needed
       editing, FR-012 has been violated and the reader is doing more than it should
-- [ ] T030 [US4] Add a test that a document whose bullet container exists but holds no `<ul>` at all
+- [X] T030 [US4] Add a test that a document whose bullet container exists but holds no `<ul>` at all
       yields no row and no error, either by a fourth small fixture or by an extra container in an
       existing one (FR-011, R-6 — the case that proves a moved selector costs one row and nothing
       else)
@@ -231,19 +231,29 @@ and every other field is what it was before this feature.
 
 **Purpose**: The gates the constitution requires, and the one check no local test can perform.
 
-- [ ] T031 Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — expected
+- [X] T031 Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s tests` — expected
       green and **unchanged**. If a unit test moved, the change has escaped its scope
-- [ ] T032 Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s e2e` detached with a
+- [X] T032 Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s e2e` detached with a
       ≥15-minute allowance; all new and existing tests green
-- [ ] T033 Confirm `git status` is clean after T032 (Principle IV: a test run must leave the working
+- [X] T033 Confirm `git status` is clean after T032 (Principle IV: a test run must leave the working
       tree clean)
-- [ ] T034 Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s screenshots_verify`.
+- [X] T034 Run `PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" venv/bin/nox -s screenshots_verify`.
       `app/static/js/**` is touched so the workflow rule fires, but `capture-agent.js` is never
       loaded by an application template — the run establishes that rather than asserting it. If it
       reports staleness, measure whether the diff has anything to do with this change before
       regenerating; screenshots in this repository churn for unrelated reasons
-- [ ] T035 Run `venv/bin/nox -s lint` (advisory) on the changed files only; do not reformat
+- [X] T035 Run `venv/bin/nox -s lint` (advisory) on the changed files only; do not reformat
       surrounding code — mass reformatting destroys review signal
+> **T036-T039 are only half done, and the half that is missing needs a running
+> instance.** The bookmarklet requires the application served over HTTPS against
+> MariaDB, so the capture -> store -> display path could not be driven here. What
+> *was* verified, on 2026-08-19: the reader's own code, verbatim, run against both
+> live listings in the browser. `B01N4OSKWE` yields its five bullets including
+> `Main Body Size: 15 x 7 x 7mm/0.59"x0.28"x0.28"(L*W*H)`; `B0FX4PDW6M` yields its
+> six. Neither leaked the heading or the "See more product details" link, neither
+> produced a blank line, both came back trimmed. That is the half the fixtures
+> cannot prove. The end-to-end half remains for the operator.
+
 - [ ] T036 Manual verification, quickstart §4 step 4: capture `https://www.amazon.com/dp/B01N4OSKWE`
       against a running instance and confirm the `About this item` row holds all five bullets, in
       particular `Main Body Size: 15 x 7 x 7mm/0.59"x0.28"x0.28"(L*W*H)` — **SC-001**, and the
@@ -255,6 +265,11 @@ and every other field is what it was before this feature.
 - [ ] T039 Manual verification: confirm the stored row renders one bullet per line on the product
       page, and that opening the product's edit form shows it in a `<textarea>` (not an `<input>`)
       and saving does not flatten it — **FR-013**, which #91 already delivered and this confirms
+- [X] T041 Update the bookmarklet's list of what it reads in `docs/user-manual.md`, and
+      describe where the bullets land, alongside the paragraph 019 added for the part number.
+      **Not in the original task list** -- found while the suite was running. That passage
+      enumerates what the capture reads, so a feature that adds to the reading and leaves it
+      alone makes the manual quietly wrong
 - [ ] T040 Open the pull request against `main`, referencing issue #92, and note in the description
       the two premises of the issue that the live probe corrected (research.md §1) so the record
       travels with the change

--- a/tests/e2e/fixtures/amazon_listing.html
+++ b/tests/e2e/fixtures/amazon_listing.html
@@ -14,6 +14,9 @@
     amazon_listing_aplus.html -- no listing carries both;
   * four product-information containers in three different markups, because the
     extractor has to merge across all of them (FR-009).
+  * an "About this item" bullet list carrying the two things the reader must
+    exclude -- the section heading and the "See more product details" link --
+    and three bullets it must drop or clean (020).
 
   `__IMAGE_HOST__` is replaced by the test with the address of the local image
   server, so the application performs a genuine HTTP fetch of genuine bytes.
@@ -67,6 +70,50 @@ if (typeof P !== 'undefined') { P.when('A').register("ImageBlockATF", function(A
   return data;
 }); }
 </script>
+
+<!-- "About this item" (020 / issue #92). The shape is what B01N4OSKWE really
+     carried on 2026-08-19, furniture included: an `hr`, an `h2` heading and a
+     trailing "See more product details" `div`, all *inside* #feature-bullets
+     and all *outside* the `<ul>`.
+
+     The furniture is the point. The container's own textContent begins
+     "About this item Country of Manufacture: CHINA..." -- so a reader working
+     from the container's text captures the heading as a product fact, and the
+     "See more" link as another. Only the `li` scoping excludes them, and a
+     fixture without them would not notice a reader that had stopped doing it.
+
+     Issue #92 predicted the "See more" item would be a *hidden li*. It is not,
+     on any listing read for this feature; it is a visible sibling div. Both
+     shapes are excluded by reading `li` inside the list, which is why the
+     reader does not test visibility -- it could not anyway, since the agent
+     parses a detached document with no layout.
+
+     The first two bullets are B01N4OSKWE's own: semicolon-separated physical
+     facts published in no table on that listing, which is the whole reason the
+     issue exists. The three after them are the cases the reader must drop or
+     clean. -->
+<div id="featurebullets_feature_div">
+    <div id="feature-bullets" class="a-section a-spacing-medium a-spacing-top-small">
+        <hr aria-hidden="true" class="a-spacing-base a-divider-normal">
+        <h2 class="a-size-base-plus a-text-bold">About this item</h2>
+        <ul class="a-unordered-list a-vertical a-spacing-mini">
+            <li class="a-spacing-mini"><span class="a-list-item">Country of Manufacture: CHINA; Material: Plastic,Metal; Net Weight: 9g</span></li>
+            <li class="a-spacing-mini"><span class="a-list-item">Main Body Size: 15 x 7 x 7mm/0.59"x0.28"x0.28"(L*W*H); Overall Size: 23 x 16 x 7mm</span></li>
+            <!-- Whitespace only: contributes no line, and no blank one either. -->
+            <li class="a-spacing-mini"><span class="a-list-item">   </span></li>
+            <!-- Decoration with no words. Same rule. -->
+            <li class="a-spacing-mini"><span class="a-list-item"><img src="__IMAGE_HOST__/bullet.png" width="16" height="16" alt=""></span></li>
+            <!-- Issue #91's problem on a third surface: a bullet carrying its
+                 own styling and script. Neither may be reported as writing. -->
+            <li class="a-spacing-mini"><span class="a-list-item">
+                <style type="text/css">.a-list-item { color: #0F1111; }</style>
+                Action Type: Latching; Contact Type: DPDT; Terminal Quantity: 6
+                <script type="text/javascript">var bulletsReady = 1;</script>
+            </span></li>
+        </ul>
+        <div class="a-section"><span class="caretnext">&rsaquo;</span> <a class="a-link-normal" href="#prodDetails">See more product details</a></div>
+    </div>
+</div>
 
 <!-- Product information, container 1 of 4: the two-column overview table. -->
 <div id="productOverview_feature_div">

--- a/tests/e2e/fixtures/amazon_listing_aplus.html
+++ b/tests/e2e/fixtures/amazon_listing_aplus.html
@@ -97,7 +97,36 @@ if (typeof P !== 'undefined') { P.when('A').register("ImageBlockATF", function(A
             <th class="prodDetSectionEntry">Country of<br>Origin</th>
             <td class="prodDetAttrValue">United Kingdom</td>
         </tr>
+        <!-- 020 / issue #92: a detail-table row wearing the bullets' own name,
+             differing only in case. The agent seeds its fold with the bullets
+             row *before* reading any container, so exactly one row of this name
+             survives and it is the bullets -- not this. Without the seeding
+             this would arrive as a second "About this item" row, and neither
+             fold downstream would catch it. -->
+        <tr>
+            <th class="prodDetSectionEntry">about this item</th>
+            <td class="prodDetAttrValue">A table row that must lose to the bullets</td>
+        </tr>
     </table>
+</div>
+
+<!-- "About this item" on the other description form (020 / issue #92). Same
+     furniture as the plain fixture; different bullets, deliberately sharing no
+     wording with the A+ copy below, so an assertion can tell which of the two
+     it is looking at.
+
+     A listing carries bullets or it does not, independently of which
+     description form it uses -- so both fixtures have them. -->
+<div id="featurebullets_feature_div">
+    <div id="feature-bullets" class="a-section a-spacing-medium a-spacing-top-small">
+        <hr aria-hidden="true" class="a-spacing-base a-divider-normal">
+        <h2 class="a-size-base-plus a-text-bold">About this item</h2>
+        <ul class="a-unordered-list a-vertical a-spacing-mini">
+            <li class="a-spacing-mini"><span class="a-list-item">Stocked in 300mm and 600mm lengths; longer bars are cut to order.</span></li>
+            <li class="a-spacing-mini"><span class="a-list-item">End caps, corner brackets and drop-in T-nuts are ordered separately.</span></li>
+        </ul>
+        <div class="a-section"><span class="caretnext">&rsaquo;</span> <a class="a-link-normal" href="#prodDetails">See more product details</a></div>
+    </div>
 </div>
 
 <div id="aplus" class="aplus-v2">

--- a/tests/e2e/fixtures/amazon_listing_bullets_empty.html
+++ b/tests/e2e/fixtures/amazon_listing_bullets_empty.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<!--
+  020 / issue #92, US4 scenario 2: an About this item section that is *present*
+  and holds nothing readable.
+
+  A sibling of amazon_listing_markup_only.html and the same joke as that
+  fixture's `#productDescription`: a block that looks like content and is not.
+  The heading and the "See more product details" link are here, and the list
+  holds one item with nothing in it. All three must yield no line, and the
+  absence of lines must yield **no row at all** -- not a row named
+  "About this item" with an empty value, which `_payload_specifications` would
+  drop on arrival without telling anyone.
+
+  The container-missing-entirely case is amazon_listing_markup_only.html's, and
+  the two are different branches: one never finds the container, this one finds
+  it and reads nothing out of it.
+
+  `__IMAGE_HOST__` is replaced by the test with the local image server.
+-->
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Acme Nylon Spacer M3, 6mm</title>
+</head>
+<body>
+
+<div id="titleSection">
+    <h1 id="title"><span id="productTitle">Acme Nylon Spacer M3</span></h1>
+    <a id="bylineInfo" class="a-link-normal" href="/stores/AcmeComponents">Brand: Acme Components</a>
+</div>
+
+<div id="corePrice_feature_div">
+    <span class="a-price" data-a-color="base">
+        <span class="a-offscreen">$4.20</span>
+    </span>
+</div>
+
+<script type="text/javascript">
+// Guarded, as in the other fixtures: the agent reads this block's text, never
+// its effect.
+if (typeof P !== 'undefined') { P.when('A').register("ImageBlockATF", function(A){
+  var data = {
+    'colorImages': { 'initial': [
+      {"hiRes":"__IMAGE_HOST__/brass_rod_sample._AC_SL1500_.jpg","thumb":"__IMAGE_HOST__/brass_rod_sample._AC_US40_.jpg","large":"__IMAGE_HOST__/brass_rod_sample._AC_SX679_.jpg","variant":"MAIN"}
+    ]}
+  };
+  return data;
+}); }
+</script>
+
+<div id="featurebullets_feature_div">
+    <div id="feature-bullets" class="a-section a-spacing-medium a-spacing-top-small">
+        <hr aria-hidden="true" class="a-spacing-base a-divider-normal">
+        <h2 class="a-size-base-plus a-text-bold">About this item</h2>
+        <ul class="a-unordered-list a-vertical a-spacing-mini">
+            <li class="a-spacing-mini"><span class="a-list-item"> </span></li>
+        </ul>
+        <div class="a-section"><span class="caretnext">&rsaquo;</span> <a class="a-link-normal" href="#prodDetails">See more product details</a></div>
+    </div>
+</div>
+
+<div id="prodDetails">
+    <table id="productDetails_techSpec_section_1" class="prodDetTable">
+        <tr>
+            <th class="prodDetSectionEntry">Material</th>
+            <td class="prodDetAttrValue">Nylon 6/6</td>
+        </tr>
+    </table>
+</div>
+
+<div id="productDescription">
+    <p>Unthreaded nylon spacer, 3mm bore, 6mm long.</p>
+</div>
+
+</body>
+</html>

--- a/tests/e2e/test_product_page_capture.py
+++ b/tests/e2e/test_product_page_capture.py
@@ -506,6 +506,9 @@ def test_the_rich_description_is_kept_and_its_furniture_is_not(
     assert payload["brand"] == "Acme Components"
     assert payload["price"] == "1249.50"
     assert [row["name"] for row in payload["specifications"]] == [
+        # 020: the bullets lead, and the detail table's own "about this item"
+        # row is folded away behind them rather than appearing twice.
+        "About this item",
         "Material", "Item Length", "Customer Reviews", "Finish", "Country of Origin",
     ]
 
@@ -1138,3 +1141,223 @@ def test_a_repeat_buy_no_longer_has_to_answer_the_identifier_question(
     again.goto(f"{live_server.url}/products")
     # One product, not two: it attached rather than branching.
     expect(again.locator("#product-table tbody tr")).to_have_count(1)
+
+
+# ---------------------------------------------------------------
+# Issue #92: the listing's own "About this item" bullets
+# ---------------------------------------------------------------
+
+ABOUT_THIS_ITEM = "About this item"
+
+# What amazon_listing.html's bullet list must yield. Two of B01N4OSKWE's real
+# bullets -- the second is where that listing publishes its dimensions, and it
+# publishes them nowhere else -- and one that had to be cleaned of the styling
+# and script inside it. The whitespace-only item and the image-only item are
+# absent, because a bullet with no words is not a line.
+BULLET_LINES = [
+    "Country of Manufacture: CHINA; Material: Plastic,Metal; Net Weight: 9g",
+    'Main Body Size: 15 x 7 x 7mm/0.59"x0.28"x0.28"(L*W*H); Overall Size: 23 x 16 x 7mm',
+    "Action Type: Latching; Contact Type: DPDT; Terminal Quantity: 6",
+]
+
+
+def about_this_item(payload):
+    """The bullets row out of a payload, or None.
+
+    Folded the way both merges fold a name, so a fixture that changed the
+    heading's capitalisation would still be found rather than silently missed.
+    """
+    for row in payload.get("specifications", []):
+        if row["name"].strip().lower() == ABOUT_THIS_ITEM.lower():
+            return row
+    return None
+
+
+@pytest.mark.e2e
+def test_the_about_this_item_bullets_are_captured(page, live_server, image_host):
+    """US1 scenarios 1-3 / FR-001..FR-004, FR-010.
+
+    The whole feature. On B01N4OSKWE every dimension the product has is in
+    these bullets and in no table on the page, so a capture that skipped them
+    stored a record that said nothing about the thing that was bought.
+    """
+    landed = capture_from_listing(page, live_server, image_host)
+
+    entries = payload_of(landed)["specifications"]
+
+    # FR-010, and not an accident of ordering: `specificationsFrom` seeds both
+    # its list and its fold with this row before it reads a single container.
+    assert entries[0]["name"] == ABOUT_THIS_ITEM
+    # FR-003: one bullet per line, in the order the listing shows them.
+    assert entries[0]["value"].split("\n") == BULLET_LINES
+
+
+@pytest.mark.e2e
+def test_the_bullets_reach_the_product(page, live_server, image_host):
+    """US1 scenario 4: the dimensions are in the catalog, not just the payload"""
+    landed = capture_from_listing(page, live_server, image_host)
+    confirm(landed, description="12V 3A PSU")
+
+    landed.goto(f"{live_server.url}/products")
+    landed.click("#product-table tbody tr td a")
+
+    specifications = landed.locator("#product-specifications")
+    expect(specifications).to_contain_text(ABOUT_THIS_ITEM)
+    # The reason the issue was filed, in one assertion.
+    expect(specifications).to_contain_text("Main Body Size: 15 x 7 x 7mm")
+
+
+@pytest.mark.e2e
+def test_the_bullets_row_changes_nothing_else(page, live_server, image_host):
+    """US1 scenario 5 / FR-012: a row was added to the reading, not swapped in"""
+    landed = capture_from_listing(page, live_server, image_host)
+    payload = payload_of(landed)
+
+    assert payload["listing_title"] == "Acme 12V 3A Power Supply Adapter"
+    assert payload["brand"] == "Acme Components"
+    assert payload["price"] == "24.99"
+    assert len(payload["images"]) == GALLERY_IMAGE_COUNT
+    # Every container is still read and still merged across all four of them.
+    names = [row["name"] for row in payload["specifications"]]
+    for expected in ("Brand", "Connector Type", "Item Length", "Best Sellers Rank"):
+        assert expected in names
+
+
+@pytest.mark.e2e
+def test_the_bullets_row_holds_no_page_furniture(page, live_server, image_host):
+    """US3 / FR-005..FR-007, and the trap issue #92 only half identified.
+
+    ``#feature-bullets`` is not only bullets. It opens with an ``<h2>About this
+    item</h2>`` and closes with a "See more product details" link, both inside
+    the container and both outside the list -- so the container's own
+    ``textContent`` begins "About this item Country of Manufacture: CHINA...".
+    Reading the ``li`` elements is what excludes them.
+
+    Nothing here tests visibility, and nothing could: ``canonicalDocument()``
+    parses a detached document with no layout and no stylesheets, where
+    ``offsetHeight`` is 0 for everything. The exclusion is structural.
+    """
+    landed = capture_from_listing(page, live_server, image_host)
+    value = about_this_item(payload_of(landed))["value"]
+
+    # The heading, which shares its wording with the row's own name.
+    assert ABOUT_THIS_ITEM not in value
+    # The trailing link. Issue #92 expected a hidden <li>; it is a visible
+    # sibling <div>, and `li` scoping excludes it either way.
+    assert "See more product details" not in value
+
+    lines = value.split("\n")
+    # FR-006: the whitespace-only bullet and the image-only bullet contributed
+    # nothing, and neither left a blank line behind them.
+    assert lines == BULLET_LINES
+    assert "" not in lines
+    assert value == value.strip()
+
+    # FR-007: #91's rule, on a third surface. Neither is writing.
+    assert "color: #0F1111" not in value
+    assert "bulletsReady" not in value
+
+
+@pytest.mark.e2e
+def test_a_table_row_of_the_same_name_loses_to_the_bullets(
+    page, live_server, image_host
+):
+    """US2 scenario 3 / FR-009, and the reason the fold is *seeded*.
+
+    The A+ fixture publishes a detail-table row named ``about this item``,
+    differing from the bullets' name only in case. Exactly one row of that name
+    may survive and it must be the bullets -- which holds only because
+    ``specificationsFrom`` seeds its ``seen`` map before reading any container.
+    Pushing the bullets onto the list without seeding would yield both, and
+    neither fold downstream would catch it.
+    """
+    landed = capture_from_listing(
+        page, live_server, image_host, fixture="amazon_listing_aplus.html"
+    )
+    entries = payload_of(landed)["specifications"]
+
+    matching = [
+        row for row in entries
+        if row["name"].strip().lower() == ABOUT_THIS_ITEM.lower()
+    ]
+    assert len(matching) == 1
+    assert matching[0]["value"].startswith("Stocked in 300mm")
+    assert "must lose to the bullets" not in matching[0]["value"]
+
+
+@pytest.mark.e2e
+def test_re_capturing_leaves_one_bullets_row(page, live_server, image_host):
+    """US2 scenarios 1-2 / FR-009. Delivered by machinery that already existed.
+
+    ``merge_specifications`` drops a captured name the product already carries,
+    value included. Nothing was written for this story; what is asserted here is
+    that the new row is not somehow exempt from the rule.
+    """
+    landed = capture_from_listing(page, live_server, image_host)
+    confirm(landed, description="12V 3A PSU")
+
+    landed.goto(f"{live_server.url}/products")
+    landed.click("#product-table tbody tr td a")
+    # Establishes the region before the count below is read: the negative half
+    # of this test is a count, and a count against a page that has not rendered
+    # is zero for the wrong reason.
+    expect(landed.locator("#product-specifications")).to_contain_text(ABOUT_THIS_ITEM)
+    product_url = landed.url
+    before = landed.locator("#product-specifications .specification-name").count()
+
+    again = capture_from_listing(page, live_server, image_host)
+    again.click("#capture-btn")
+    # Raised in response to the submit rather than on the landing page, so its
+    # arrival is what tells us the submit was processed. The identifier question
+    # is not raised: 019 fills the part number, which corroborates.
+    expect(again.locator("#duplicate-warning")).to_be_visible()
+    again.check("#acknowledged_duplicate_of")
+    again.click("#capture-btn")
+
+    again.goto(product_url)
+    names = again.locator("#product-specifications .specification-name")
+    expect(names).to_have_count(before)
+    expect(names.filter(has_text=re.compile(r"^About this item$"))).to_have_count(1)
+
+
+@pytest.mark.e2e
+def test_a_listing_with_no_bullet_list_captures_as_before(
+    page, live_server, image_host
+):
+    """US4 scenario 1 / FR-008, FR-012: no section, no row, nothing else moved"""
+    landed = capture_from_listing(
+        page, live_server, image_host, fixture="amazon_listing_markup_only.html"
+    )
+    payload = payload_of(landed)
+
+    assert about_this_item(payload) is None
+    # FR-008: and not an empty-valued row either. One would be dropped by
+    # `_payload_specifications` on arrival without anyone hearing about it,
+    # which is why the agent must not emit it rather than merely tolerate it.
+    assert all(row["value"] for row in payload["specifications"])
+    # FR-012, on the fixture that has no bullets to distract from it.
+    assert payload["description_text"] == (
+        "Knurled brass standoff, M3 thread, 10mm between faces."
+    )
+    assert payload["price"] == "8.75"
+    assert [row["name"] for row in payload["specifications"]] == ["Material"]
+
+
+@pytest.mark.e2e
+def test_a_bullet_list_with_nothing_readable_yields_no_row(
+    page, live_server, image_host
+):
+    """US4 scenario 2 / FR-008, FR-011: found the container, read nothing from it.
+
+    A different branch from the test above, which never finds the container at
+    all. This one finds it, finds the heading, the "See more" link and one empty
+    item, and must still produce no row.
+    """
+    landed = capture_from_listing(
+        page, live_server, image_host, fixture="amazon_listing_bullets_empty.html"
+    )
+    payload = payload_of(landed)
+
+    assert about_this_item(payload) is None
+    assert all(row["value"] for row in payload["specifications"])
+    assert payload["price"] == "4.20"


### PR DESCRIPTION
Closes #92.

Amazon writes an **About this item** section above the detail tables, and on some listings it is the only place a physical fact appears at all. Every dimension `B01N4OSKWE` publishes is in its five bullets and in no table on the page — so a capture that skipped them stored a record saying nothing about the thing that was bought. They now arrive as one specification row named `About this item`, one bullet to a line.

## Two of the issue's premises did not survive a look at the real page

The issue invites the agent to check the live markup rather than trust prior probing, so three listings were read in Chrome on 2026-08-19: `B01N4OSKWE` and `B0FX4PDW6M` (the verification cases) and `B0CKXJLP4B` (the ASIN the fixture stands in for).

1. **"See more product details" is not a hidden `<li>`.** On all three it is a *visible sibling `<div>`* after the `<ul>`. The issue also does not mention the `<h2>About this item</h2>` that sits inside `#feature-bullets` — the same trap and closer to hand, since the container's own `textContent` begins `"About this item Country of Manufacture: CHINA…"`. Reading `li` elements excludes both, structurally.

2. **A visibility test is not implementable here in any case.** `canonicalDocument()` parses with `DOMParser`: the document is detached and unstyled, `offsetHeight` is 0 for everything in it, and `getComputedStyle` reports the UA default rather than what Amazon's CSS would produce. "Is the shopper shown this" cannot be asked on this side of the fetch. FR-005 is met structurally or not at all — which is also what keeps this from growing a visibility-filtering facility.

## The change

- `bulletsRow(doc)` in `app/static/js/capture-agent.js` — reads `li` elements, runs each through the existing `proseOf` so #91's stripping and line handling apply unchanged, drops the empty ones, joins with **one** newline (list items, not paragraphs; `proseFrom` already emits paragraph breaks *within* a bullet). Skips a nested list rather than taking its text twice. Returns `null` rather than an empty-valued row — one would be dropped by `_payload_specifications` on arrival without anyone hearing about it.
- `specificationsFrom()` **seeds its `seen` fold** with the row rather than merely pushing it, so a listing publishing a detail-table row of the same name yields one row and it is the bullets. The A+ fixture carries exactly that collision, spelt in a different case.
- Fixtures carry the markup as observed, furniture and all — the furniture is what the reader must exclude, and a fixture without it would not notice a reader that had stopped excluding it.
- `docs/user-manual.md` — that section enumerates what the bookmarklet reads, so leaving it alone would have made it quietly wrong.

No Python change, no schema change, no migration. Display and editing of a multi-line value needed nothing: #91 landed both, `textarea` branch included.

## Verification

| Gate | Result |
|---|---|
| `nox -s tests` | 1437 passed — identical to baseline, unit suite untouched |
| `nox -s e2e` | **567 passed** (559 baseline + 8 new), no failures |
| Working tree after e2e | Clean |
| `nox -s screenshots_verify` | 18 screenshots valid, no staleness |

`capture-agent.js` is under `app/static/js/**` so the screenshot rule fires, but the file is never loaded by an application template — the bookmarklet injects it into a *vendor's* page. The verify session establishes that rather than asserting it.

The reader's own code was also run verbatim against both live listings: `B01N4OSKWE` yields its five bullets including `Main Body Size: 15 x 7 x 7mm/0.59"x0.28"x0.28"(L*W*H)`, `B0FX4PDW6M` its six. Neither leaked the heading or the link, neither produced a blank line, both came back trimmed.

**Still outstanding — needs a running instance.** The end-to-end manual capture (bookmarklet against a real listing over HTTPS, then confirm the row stores, renders one-per-line, and re-capture leaves one copy) could not be driven from here. `specs/020-capture-about-this-item/tasks.md` records T036–T039 as open for that reason.

## Not built, deliberately

No visibility filtering, no hidden-class filtering (no bullet on any probed listing carries one), no parsing bullet text into fields — `B01N4OSKWE`'s bullets are full of `Name: Value; Name: Value` and it is tempting, but the spec rules it out and it is a much harder problem.

Spec, plan and research: `specs/020-capture-about-this-item/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPKkTEaAniXC5253BK64b4